### PR TITLE
Add ability for API to set name of stream

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -85,10 +85,15 @@ var wsHandlers = make(map[string]WSHandler)
 
 func streamsHandler(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
+	name := r.URL.Query().Get("name")
+	
+	if name == "" {
+		name = src
+	}
 
 	switch r.Method {
 	case "PUT":
-		streams.New(src, src)
+		streams.New(name, src)
 		return
 	case "DELETE":
 		streams.Delete(src)


### PR DESCRIPTION
We are looking to bundle go2rtc within frigate and use the go2rtc API add the streams. Having the ability to specify the name of the stream will make managing them much simpler.