### PR TITLE
Fix RTSP url in webui

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -2,25 +2,33 @@ package api
 
 import (
 	"encoding/json"
+	"net"
+	"net/http"
+
 	"github.com/AlexxIT/go2rtc/cmd/app"
 	"github.com/AlexxIT/go2rtc/cmd/streams"
 	"github.com/rs/zerolog"
-	"net"
-	"net/http"
 )
 
+type apiCfg struct {
+	Mod struct {
+		Listen    string `yaml:"listen"`
+		BasePath  string `yaml:"base_path"`
+		StaticDir string `yaml:"static_dir"`
+		Origin    string `yaml:"origin"`
+	} `yaml:"api"`
+	RTSP struct {
+		Listen string `yaml:"listen"`
+	} `yaml:"rtsp"`
+}
+
 func Init() {
-	var cfg struct {
-		Mod struct {
-			Listen    string `yaml:"listen"`
-			BasePath  string `yaml:"base_path"`
-			StaticDir string `yaml:"static_dir"`
-			Origin    string `yaml:"origin"`
-		} `yaml:"api"`
-	}
+
+	var cfg apiCfg
 
 	// default config
 	cfg.Mod.Listen = ":1984"
+	cfg.RTSP.Listen = ":8554"
 
 	// load config from YAML
 	app.LoadConfig(&cfg)
@@ -32,7 +40,7 @@ func Init() {
 	basePath = cfg.Mod.BasePath
 	log = app.GetLogger("api")
 
-	initStatic(cfg.Mod.StaticDir)
+	initStatic(cfg)
 	initWS(cfg.Mod.Origin)
 
 	HandleFunc("api/streams", streamsHandler)

--- a/cmd/api/static.go
+++ b/cmd/api/static.go
@@ -1,12 +1,22 @@
 package api
 
 import (
-	"github.com/AlexxIT/go2rtc/www"
+	"html/template"
+	"io"
 	"net/http"
+	"strings"
+
+	"github.com/AlexxIT/go2rtc/www"
 )
 
-func initStatic(staticDir string) {
+type TemplateData struct {
+	Host     string
+	RTSPPort string
+}
+
+func initStatic(cfg apiCfg) {
 	var root http.FileSystem
+	var staticDir = cfg.Mod.StaticDir
 	if staticDir != "" {
 		log.Info().Str("dir", staticDir).Msg("[api] serve static")
 		root = http.Dir(staticDir)
@@ -15,12 +25,50 @@ func initStatic(staticDir string) {
 	}
 
 	base := len(basePath)
-	fileServer := http.FileServer(root)
 
-	HandleFunc("", func(w http.ResponseWriter, r *http.Request) {
+	HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if base > 0 {
 			r.URL.Path = r.URL.Path[base:]
 		}
-		fileServer.ServeHTTP(w, r)
+
+		if r.URL.Path == "/" {
+			r.URL.Path = r.URL.Path + "index.html"
+		}
+
+		host := strings.Split(r.Host, ":")[0]
+
+		// Open the file using the root FileSystem
+		f, err := root.Open(r.URL.Path)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer f.Close()
+
+		// Read the file contents
+		b, err := io.ReadAll(f)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Parse the template
+		t, err := template.New("template").Parse(string(b))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		data := TemplateData{
+			Host:     host,
+			RTSPPort: cfg.RTSP.Listen[1:],
+		}
+
+		// Execute the template with the Host header value
+		err = t.Execute(w, data)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 }

--- a/www/index.html
+++ b/www/index.html
@@ -89,7 +89,7 @@
         '<a href="webrtc.html?src={name}">2-way-aud</a>',
         '<a href="api/stream.mp4?src={name}">mp4</a>',
         '<a href="api/stream.mjpeg?src={name}">mjpeg</a>',
-        `<a href="rtsp://${location.hostname}:8554/{name}">rtsp</a>`,
+        `<a href="rtsp://{{.Host}}:{{.RTSPPort}}/{name}">rtsp</a>`,
         '<a href="api/streams?src={name}">info</a>',
         '<a href="#" data-name="{name}">delete</a>',
     ];


### PR DESCRIPTION
In case placing go2rtc behind reverse proxy, rtsp url in web-ui was wrong.
Now it fixed by using incoming Host header instead of location.hostname