### PR TITLE
Fix invalid tcpType for UDP candidate

### DIFF
--- a/pkg/webrtc/helper.go
+++ b/pkg/webrtc/helper.go
@@ -25,12 +25,17 @@ func NewCandidate(network, address string) (string, error) {
 		return "", err
 	}
 
+	tcpType := ice.TCPTypeUnspecified
+	if network == "tcp" {
+		tcpType = ice.TCPTypePassive
+	}
+
 	cand, err := ice.NewCandidateHost(&ice.CandidateHostConfig{
 		Network:   network,
 		Address:   host,
 		Port:      i,
 		Component: ice.ComponentRTP,
-		TCPType:   ice.TCPTypePassive,
+		TCPType:   tcpType,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Current v0.1-rc.8 code added UDP candidates for WebRTC but is hard coded with `tcpType passive` which is invalid.  Spec says tcpType for UDP should be null and some implementations appear to fail on this invalid candidate.  This PR fixes this behavior.