### PR TITLE
Allow to set webrtc candidates via env

### DIFF
--- a/cmd/webrtc/webrtc.go
+++ b/cmd/webrtc/webrtc.go
@@ -2,15 +2,18 @@ package webrtc
 
 import (
 	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/AlexxIT/go2rtc/cmd/api"
 	"github.com/AlexxIT/go2rtc/cmd/app"
 	"github.com/AlexxIT/go2rtc/cmd/streams"
 	"github.com/AlexxIT/go2rtc/pkg/webrtc"
 	pion "github.com/pion/webrtc/v3"
 	"github.com/rs/zerolog"
-	"io"
-	"net"
-	"net/http"
 )
 
 func Init() {
@@ -55,6 +58,12 @@ func Init() {
 	}
 
 	candidates = cfg.Mod.Candidates
+
+	// Add candidates from GO2RTC_WEBRTC_CANDIDATES to list
+	if candidates == nil {
+		value := os.Getenv("GO2RTC_WEBRTC_CANDIDATES")
+		candidates = strings.Split(value, ",")
+	}
 
 	api.HandleWS("webrtc/offer", asyncHandler)
 	api.HandleWS("webrtc/candidate", candidateHandler)

--- a/cmd/webrtc/webrtc.go
+++ b/cmd/webrtc/webrtc.go
@@ -57,13 +57,12 @@ func Init() {
 		return pionAPI.NewPeerConnection(pionConf)
 	}
 
-	candidates = cfg.Mod.Candidates
+	// Read candidates from GO2RTC_WEBRTC_CANDIDATES
+	candidatesFromEnv := os.Getenv("GO2RTC_WEBRTC_CANDIDATES")
+	candidates = strings.Split(candidatesFromEnv, ",")
 
-	// Add candidates from GO2RTC_WEBRTC_CANDIDATES to list
-	if candidates == nil {
-		value := os.Getenv("GO2RTC_WEBRTC_CANDIDATES")
-		candidates = strings.Split(value, ",")
-	}
+	// Read candidates from config
+	candidates = append(candidates, cfg.Mod.Candidates...)
 
 	api.HandleWS("webrtc/offer", asyncHandler)
 	api.HandleWS("webrtc/candidate", candidateHandler)


### PR DESCRIPTION
I know go2rtc does not recommend using something other than `--network host`, but this should help running without `--network host`.

With `--network host`, go2rtc can detect (at some extent), the local IP address of the host machine. At some extent, because if you run it within a VM which is within a NAT, it will not be able to detect the proper IP address.

My use for this will be in the Frigate add-on. I plan to do something like this:

```bash

# Get the local IP address of the HA host machine
local_ip=$(curl -s http://supervisor/core/info | jq -r '.local_ip')
webrtc_port=$(curl -s http://supervisor/addons/self/options | jq -r '.webrtc_port')

export GO2RTC_WEBRTC_CANDIDATES="${local_ip}:${webrtc_port}"

exec go2rtc
```

Which should help simplify this setup process by not requiring the user to set its own list of candidates: https://deploy-preview-4055--frigate-docs.netlify.app/configuration/live#webrtc-extra-configuration

/cc @NickM-27