### PR TITLE
Fix double url-encoding in streams DELETE request

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -125,7 +125,8 @@
         ev.preventDefault();
 
         const url = new URL("api/streams", location.href);
-        url.searchParams.set("src", ev.target.dataset.name);
+        const src = decodeURIComponent(ev.target.dataset.name);
+        url.searchParams.set("src", src);
         fetch(url, {method: "DELETE"}).then(reload);
     });
 


### PR DESCRIPTION
Due to double encoding, the removal of streams whose names contained special characters didn't works

Example 
Before: /api/streams?src=http%253A%252F%252F192.168.88.158%252Fsecretkey%252Flive%252Ffiles%252Fhigh%252Findex.m3u8
After: /api/streams?src=http%3A%2F%2F192.168.88.158%2Fsecretkey%2Flive%2Ffiles%2Fhigh%2Findex.m3u8