### PR TITLE
Fix ISAPI 2 Way Audio

### DIFF
--- a/cmd/streams/stream.go
+++ b/cmd/streams/stream.go
@@ -185,6 +185,11 @@ producers:
 				continue producers
 			}
 		}
+		for _, track := range producer.senders {
+			if len(track.Senders()) > 0 {
+				continue producers
+			}
+		}
 		producer.stop()
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
While testing my HikVision doorbell for 2 way audio I noticed that it wasn't working as the isapi stream would never get opened, this patch fixes it by not letting go2rtc close the producer if senders are present as well.

I don't know if this fix is correct but I tested it on my setup and it opens and closes the isapi "session" correctly.