### PR TITLE
Refactor video toolbox probe commands to use SVGA resolution in hardw…

### DIFF
--- a/internal/ffmpeg/hardware/hardware_darwin.go
+++ b/internal/ffmpeg/hardware/hardware_darwin.go
@@ -4,8 +4,8 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/api"
 )
 
-const ProbeVideoToolboxH264 = "-f lavfi -i testsrc2 -t 1 -c h264_videotoolbox -f null -"
-const ProbeVideoToolboxH265 = "-f lavfi -i testsrc2 -t 1 -c hevc_videotoolbox -f null -"
+const ProbeVideoToolboxH264 = "-f lavfi -i testsrc2=size=svga -t 1 -c h264_videotoolbox -f null -"
+const ProbeVideoToolboxH265 = "-f lavfi -i testsrc2=size=svga -t 1 -c hevc_videotoolbox -f null -"
 
 func ProbeAll(bin string) []api.Stream {
 	return []api.Stream{


### PR DESCRIPTION
updates the video toolbox probe commands in hardware_darwin.go to utilize SVGA resolution, because of QVGA isn'r supported by videotoolbox h264 encoder on macOS systems and always fails. The changes affect both the H264 and H265 codec probe commands.