### PR TITLE
Update hardware.Dockerfile for multi-platform support

### DIFF
--- a/hardware.Dockerfile
+++ b/hardware.Dockerfile
@@ -12,7 +12,13 @@ FROM ngrok/ngrok:${NGROK_VERSION} AS ngrok
 
 
 # 1. Build go2rtc binary
-FROM go AS build
+FROM --platform=$BUILDPLATFORM go AS build
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
 
 WORKDIR /build
 


### PR DESCRIPTION
...because we can build from hardware.Dockerfile on non-amd64 host, such as Apple M1