### PR TITLE
Add mediaCode 0x12 to CodecH264 identifiers ini DVIRIP stream

### DIFF
--- a/pkg/dvrip/client.go
+++ b/pkg/dvrip/client.go
@@ -337,7 +337,7 @@ func (c *Client) ResponseJSON() (res Response, err error) {
 func (c *Client) AddVideoTrack(mediaCode byte, payload []byte) {
 	var codec *core.Codec
 	switch mediaCode {
-	case 2:
+	case 0x02, 0x12:
 		codec = &core.Codec{
 			Name:        core.CodecH264,
 			ClockRate:   90000,


### PR DESCRIPTION
The DVRIP stream didn't work in one of my cameras.
Go2RTC reported `[DVRIP] unsupported video codec: 18` even though it uses h264.

This PR adds code 0x12 which fixes de issue. I tested it locally and the stream works perfectly now.

Thanks for this awesome project btw