### PR TITLE
For dvrip video codec, only compare least significant 4 bits

### DIFF
--- a/pkg/dvrip/client.go
+++ b/pkg/dvrip/client.go
@@ -336,8 +336,8 @@ func (c *Client) ResponseJSON() (res Response, err error) {
 
 func (c *Client) AddVideoTrack(mediaCode byte, payload []byte) {
 	var codec *core.Codec
-	switch mediaCode {
-	case 0x02, 0x12:
+	switch mediaCode & 0xf {
+	case 0x2:
 		codec = &core.Codec{
 			Name:        core.CodecH264,
 			ClockRate:   90000,
@@ -345,7 +345,7 @@ func (c *Client) AddVideoTrack(mediaCode byte, payload []byte) {
 			FmtpLine:    h264.GetFmtpLine(payload),
 		}
 
-	case 0x03, 0x13:
+	case 0x3:
 		codec = &core.Codec{
 			Name:        core.CodecH265,
 			ClockRate:   90000,

--- a/pkg/dvrip/client.go
+++ b/pkg/dvrip/client.go
@@ -336,8 +336,8 @@ func (c *Client) ResponseJSON() (res Response, err error) {
 
 func (c *Client) AddVideoTrack(mediaCode byte, payload []byte) {
 	var codec *core.Codec
-	switch mediaCode & 0xf {
-	case 0x2:
+	switch mediaCode {
+	case 0x02, 0x12:
 		codec = &core.Codec{
 			Name:        core.CodecH264,
 			ClockRate:   90000,
@@ -345,7 +345,7 @@ func (c *Client) AddVideoTrack(mediaCode byte, payload []byte) {
 			FmtpLine:    h264.GetFmtpLine(payload),
 		}
 
-	case 0x3:
+	case 0x03, 0x13, 0x43:
 		codec = &core.Codec{
 			Name:        core.CodecH265,
 			ClockRate:   90000,


### PR DESCRIPTION
I have another non-working DVRIP camera, this time h265.
This time the error was `[DVRIP] unsupported video codec: 67`, which is 0x43. At this point it became quite obvious that only the least significant 4 bits determines the video codec.
I confirmed that my other 2 cameras still work fine with this change.

This PR fixes that.