### PR TITLE
Fix camera brand typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ streams:
     - rtsp://admin:password@192.168.1.123/cam/realmonitor?channel=1&subtype=1
   amcrest_doorbell:
     - rtsp://username:password@192.168.1.123:554/cam/realmonitor?channel=1&subtype=0#backchannel=0
-  unify_camera: rtspx://192.168.1.123:7441/fD6ouM72bWoFijxK
+  unifi_camera: rtspx://192.168.1.123:7441/fD6ouM72bWoFijxK
   glichy_camera: ffmpeg:rstp://username:password@192.168.1.123/live/ch00_1 
 ```
 
@@ -213,7 +213,7 @@ streams:
 
 - **Amcrest Doorbell** users may want to disable two way audio, because with an active stream you won't have a call button working. You need to add `#backchannel=0` to the end of your RTSP link in YAML config file
 - **Dahua Doorbell** users may want to change backchannel [audio codec](https://github.com/AlexxIT/go2rtc/issues/52)
-- **Unify** users may want to disable HTTPS verification. Use `rtspx://` prefix instead of `rtsps://`. And don't use `?enableSrtp` [suffix](https://github.com/AlexxIT/go2rtc/issues/81)
+- **Ubiquiti UniFi** users may want to disable HTTPS verification. Use `rtspx://` prefix instead of `rtsps://`. And don't use `?enableSrtp` [suffix](https://github.com/AlexxIT/go2rtc/issues/81)
 - **TP-Link Tapo** users may skip login and password, because go2rtc support login [without them](https://drmnsamoliu.github.io/video.html)
 - If your camera has two RTSP links - you can add both of them as sources. This is useful when streams has different codecs, as example AAC audio with main stream and PCMU/PCMA audio with second stream
 - If the stream from your camera is glitchy, try using [ffmpeg source](#source-ffmpeg). It will not add CPU load if you won't use transcoding


### PR DESCRIPTION
Change "Unify" to "Ubiquiti UniFi", so that users using Ctrl+F or the search function to find information they are looking for, actually have a chance to find it.