### PR TITLE
Bugfix&Feature: Add support for pixel format specification in ffmpeg device input params

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Format: `ffmpeg:device?{input-params}#{param1}#{param2}#{param3}`
 streams:
   linux_usbcam:   ffmpeg:device?video=0&video_size=1280x720#video=h264
   windows_webcam: ffmpeg:device?video=0#video=h264
-  macos_facetime: ffmpeg:device?video=0&audio=1&video_size=1280x720&framerate=30#video=h264#audio=pcma
+  macos_facetime: ffmpeg:device?video=0&audio=1&video_size=1280x720&framerate=30&pix_fmt=uyvy422#video=h264#audio=pcma
 ```
 
 #### Source: Exec

--- a/internal/ffmpeg/device/devices.go
+++ b/internal/ffmpeg/device/devices.go
@@ -35,6 +35,8 @@ func GetInput(src string) (string, error) {
 				audio = value[0]
 			case "resolution":
 				input += " -video_size " + value[0]
+			case "pix_fmt":
+				input += " -pix_fmt:v " + value[0]
 			default: // "input_format", "framerate", "video_size"
 				input += " -" + key + " " + value[0]
 			}
@@ -42,12 +44,12 @@ func GetInput(src string) (string, error) {
 	}
 
 	if video != "" {
-		if i, err := strconv.Atoi(video); err == nil && i < len(videos) {
+		if i, err := strconv.Atoi(video); err != nil && i < len(videos) {
 			video = videos[i]
 		}
 	}
 	if audio != "" {
-		if i, err := strconv.Atoi(audio); err == nil && i < len(audios) {
+		if i, err := strconv.Atoi(audio); err != nil && i < len(audios) {
 			audio = audios[i]
 		}
 	}


### PR DESCRIPTION
This pull request introduces support for specifying the pixel format in the ffmpeg device input parameters. This change affects the internal/ffmpeg/device/devices.go file and the README.md file. The pixel format can now be defined using the pix_fmt parameter. This update is particularly useful for macOS devices, as demonstrated in the updated example for macos_facetime in the README.