### PR TITLE
fix known problem of wrong profile declaration capabilities

### DIFF
--- a/internal/ffmpeg/hardware/hardware.go
+++ b/internal/ffmpeg/hardware/hardware.go
@@ -58,7 +58,7 @@ func MakeHardware(args *ffmpeg.Args, engine string, defaults map[string]string) 
 			args.Codecs[i] = defaults[name+"/"+engine]
 
 			if !args.HasFilters("drawtext=") {
-				args.Input = "-hwaccel vaapi -hwaccel_output_format vaapi " + args.Input
+				args.Input = "-hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_flags allow_profile_mismatch " + args.Input
 
 				for i, filter := range args.Filters {
 					if strings.HasPrefix(filter, "scale=") {
@@ -78,7 +78,7 @@ func MakeHardware(args *ffmpeg.Args, engine string, defaults map[string]string) 
 				args.InsertFilter("format=vaapi|nv12,hwupload")
 			} else {
 				// enable software pixel for drawtext, scale and transpose
-				args.Input = "-hwaccel vaapi -hwaccel_output_format nv12 " + args.Input
+				args.Input = "-hwaccel vaapi -hwaccel_output_format nv12 -hwaccel_flags allow_profile_mismatch " + args.Input
 
 				args.AddFilter("hwupload")
 			}


### PR DESCRIPTION
Hi,

i just started to use go2rtc and came across an issue with h264 and the baseline profile. It looks like some streams over-declare their required capabilities

https://github.com/FFmpeg/FFmpeg/blob/0e9956a06e9307e01232bc354665fadf6f7a09df/libavcodec/options_table.h#L402C1-L403C1

```
// Allowing a profile mismatch can be useful because streams may
 // over-declare their required capabilities - in particular, many
// H.264 baseline profile streams (notably some of those in FATE)
// only use the feature set of constrained baseline.
```

Therefore it is a good idea to add this parameter to be more resillient. On top of that "raw" option does not work as the following error will be thrown:

```
Codec AVOption hwaccel_flags () is not an encoding option.
```