### PR TITLE
Clarify import from go2rtc to hass generic camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ You have several options on how to add a camera to Home Assistant:
    - Install any [go2rtc](#fast-start)
    - Add your stream to [go2rtc config](#configuration)
    - Hass > Settings > Integrations > Add Integration > [ONVIF](https://my.home-assistant.io/redirect/config_flow_start/?domain=onvif) > Host: `127.0.0.1`, Port: `1984`
-   - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > `rtsp://127.0.0.1:8554/camera1` (change to your stream name)
+   - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > `rtsp://127.0.0.1:8554/camera1` (change to your stream name) > RTSP Protocol: TCP (leave everything else as is)
 
 You have several options on how to watch the stream from the cameras in Home Assistant:
 

--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ You have several options on how to add a camera to Home Assistant:
    - Install any [go2rtc](#fast-start)
    - Add your stream to [go2rtc config](#configuration)
    - Hass > Settings > Integrations > Add Integration > [ONVIF](https://my.home-assistant.io/redirect/config_flow_start/?domain=onvif) > Host: `127.0.0.1`, Port: `1984`
-   - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > `rtsp://127.0.0.1:8554/camera1` (change to your stream name) > RTSP Protocol: `TCP` (leave everything else as is)
+   - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > Stream Source URL: `rtsp://127.0.0.1:8554/camera1` (change to your stream name, leave everything else as is)
 
 You have several options on how to watch the stream from the cameras in Home Assistant:
 

--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ You have several options on how to add a camera to Home Assistant:
    - Install any [go2rtc](#fast-start)
    - Add your stream to [go2rtc config](#configuration)
    - Hass > Settings > Integrations > Add Integration > [ONVIF](https://my.home-assistant.io/redirect/config_flow_start/?domain=onvif) > Host: `127.0.0.1`, Port: `1984`
-   - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > `rtsp://127.0.0.1:8554/camera1` (change to your stream name) > RTSP Protocol: TCP (leave everything else as is)
+   - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > `rtsp://127.0.0.1:8554/camera1` (change to your stream name) > RTSP Protocol: `TCP` (leave everything else as is)
 
 You have several options on how to watch the stream from the cameras in Home Assistant:
 


### PR DESCRIPTION
The protocol is not set by default. According to my tests, only TCP works.