### PR TITLE
Refactor LocalIP method to correctly handle non-TCP connections

### DIFF
--- a/pkg/hap/client.go
+++ b/pkg/hap/client.go
@@ -317,8 +317,15 @@ func (c *Client) GetImage(width, height int) ([]byte, error) {
 }
 
 func (c *Client) LocalIP() string {
-	addr := c.Conn.LocalAddr().(*net.TCPAddr)
-	return addr.IP.To4().String()
+	conn, ok := c.Conn.(*net.TCPConn)
+	if !ok {
+		return ""
+	}
+	addr, ok := conn.LocalAddr().(*net.TCPAddr)
+	if !ok {
+		return ""
+	}
+	return addr.IP.String()
 }
 
 func DecodeKey(s string) []byte {


### PR DESCRIPTION
```
07:16:54.064 DBG [streams] stop producer url=homekit://192.168.88.39:35053?client_id=.......
panic: runtime error: invalid memory address or nil pointer dereference0 drop=0 speed=1.03x    
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xa102da]

goroutine 315 [running]:
github.com/AlexxIT/go2rtc/pkg/hap.(*Client).LocalIP(0xb74fc0?)
	github.com/AlexxIT/go2rtc/pkg/hap/client.go:320 +0x1a
github.com/AlexxIT/go2rtc/pkg/homekit.(*Client).srtpEndpoint(0xc0007de410)
	github.com/AlexxIT/go2rtc/pkg/homekit/client.go:218 +0x25
github.com/AlexxIT/go2rtc/pkg/homekit.(*Client).Start(0xc0007de410)
	github.com/AlexxIT/go2rtc/pkg/homekit/client.go:132 +0x54b
github.com/AlexxIT/go2rtc/internal/streams.(*Producer).worker(0xc0001b43f0, {0xcad2a8?, 0xc0007de410?}, 0x7)
	github.com/AlexxIT/go2rtc/internal/streams/producer.go:162 +0x2f
created by github.com/AlexxIT/go2rtc/internal/streams.(*Producer).reconnect in goroutine 296
	github.com/AlexxIT/go2rtc/internal/streams/producer.go:239 +0x4fd

```