### PR TITLE
Fix: duplicate pairing strings in config

### DIFF
--- a/internal/homekit/server.go
+++ b/internal/homekit/server.go
@@ -198,9 +198,11 @@ func (s *server) AddPair(conn net.Conn, id string, public []byte, permissions by
 		"client_public": []string{hex.EncodeToString(public)},
 		"permissions":   []string{string('0' + permissions)},
 	}
-	s.pairings = append(s.pairings, query.Encode())
-	s.UpdateStatus()
-	s.PatchConfig()
+	if s.GetPair(conn, id) == nil {
+		s.pairings = append(s.pairings, query.Encode())
+		s.UpdateStatus()
+		s.PatchConfig()
+	}
 }
 
 func (s *server) DelPair(conn net.Conn, id string) {


### PR DESCRIPTION
This pull request adds a preventive measure in the HomeKit     
  server's  AddPair  function. A conditional check is performed before adding 
  a new pair to ensure that it doesn't already exist within the pairings. This
  preventative measure avoids redundancy and can potentially improve the      
  efficiency of pairing processes in the HomeKit server. 