### PR TITLE
fix display of Version in web ui

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,6 +38,8 @@ func Init() {
 		os.Exit(0)
 	}
 
+	Info["version"] = Version
+
 	if confs == nil {
 		confs = []string{"go2rtc.yaml"}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -22,7 +22,6 @@ var UserAgent = "go2rtc/" + Version
 
 var ConfigPath string
 var Info = map[string]any{
-	"version": Version,
 }
 
 func Init() {


### PR DESCRIPTION
### Description

The web ui displays an empty Version string like `Version: , Config: /volume1/@appdata/go2rtc/go2rtc.yaml` on the default web page.

reported at https://github.com/SynoCommunity/spksrc/pull/5889#issuecomment-1763186306

### Details
- fix display of ${data.version} in www/index.html
- Info["version"] must be initialized when Version is set