### PR TITLE
Ensure exit code is within valid range

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -233,7 +233,14 @@ func exitHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s := r.URL.Query().Get("code")
-	code, _ := strconv.Atoi(s)
+	code, err := strconv.Atoi(s)
+
+	// https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_08_02
+	if err != nil || code < 0 || code > 125 {
+		http.Error(w, "Code must be in the range [0, 125]", http.StatusBadRequest)
+		return
+	}
+
 	os.Exit(code)
 }
 


### PR DESCRIPTION
The exitHandler function now properly validates the exit code provided in the query string. It checks for conversion errors and ensures the code is within the valid range of 0 to 125. If the validation fails, it responds with an HTTP 400 Bad Request error. This prevents potential misuse of the exit endpoint by restricting the exit codes to expected values.