### PR TITLE
Fix CORS support in WHEP/WHIP API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -211,7 +211,7 @@ func middlewareCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, X-PINGOTHER, Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 
 
 		next.ServeHTTP(w, r)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -212,8 +212,6 @@ func middlewareCORS(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -211,7 +211,9 @@ func middlewareCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, X-PINGOTHER, Content-Type")
+
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/webrtc/server.go
+++ b/internal/webrtc/server.go
@@ -49,6 +49,9 @@ func syncHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "", http.StatusBadRequest)
 		}
 
+	case "OPTIONS":
+		w.WriteHeader(http.StatusNoContent)
+
 	default:
 		http.Error(w, "", http.StatusMethodNotAllowed)
 	}


### PR DESCRIPTION
Browsers don't allow WHIP/WHEP API calls  to the go2rtc server when they are directed to  a different domain, even when all origins are allowed in go2rtc configuration.
```
api:
  origin: "*"  
```

The problem it that when browsers detect a POST to another domain, they usually send first  a _Preflight Request_. This is an OPTIONS request  to verify with the server if that's  allowed. The server needs to reply with a 'No content' status , and some headers with information about what's allowed.  Right now, go2rtc just returns a "Method not allowed" response, which prevents the browser from sending the actual POST.

This change adds an OPTIONS handler and some allowed headers, so that the cors WHEP/WHIP requests can be accepted by the browser.

