### PR TITLE
Fix choppy audio sounds when opus is used with HomeKit as a consumer

### DIFF
--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -63,6 +63,7 @@ var defaults = map[string]string{
 	// https://ffmpeg.org/ffmpeg-resampler.html
 	// `-async 1` or `-min_comp 0` - force frame_size=960, important for WebRTC audio quality
 	"opus":       "-c:a libopus -application:a lowdelay -frame_duration 20 -min_comp 0",
+	"opus/16000": "-c:a libopus -application:a lowdelay -frame_duration 20 -ar:a 16000 -min_comp 0", // for HomeKit and timestamp mangling
 	"pcmu":       "-c:a pcm_mulaw -ar:a 8000 -ac:a 1",
 	"pcmu/8000":  "-c:a pcm_mulaw -ar:a 8000 -ac:a 1",
 	"pcmu/16000": "-c:a pcm_mulaw -ar:a 16000 -ac:a 1",

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -122,7 +122,7 @@ func Init() {
 	api.HandleFunc(hap.PathPairSetup, hapPairSetup)
 	api.HandleFunc(hap.PathPairVerify, hapPairVerify)
 
-	log.Trace().Msgf("[homekit] mnds: %s", entries)
+	log.Trace().Msgf("[homekit] mdns: %s", entries)
 
 	go func() {
 		if err := mdns.Serve(mdns.ServiceHAP, entries); err != nil {

--- a/pkg/homekit/consumer.go
+++ b/pkg/homekit/consumer.go
@@ -158,8 +158,6 @@ func (c *Consumer) AddTrack(media *core.Media, codec *core.Codec, track *core.Re
 		} else {
 			sender.Handler = h264.RepairAVCC(track.Codec, sender.Handler)
 		}
-		// case core.CodecOpus:
-		// 	sender.Handler = h264.RTPPay(400, sender.Handler)
 	}
 
 	sender.HandleRTP(track)

--- a/pkg/srtp/opus.go
+++ b/pkg/srtp/opus.go
@@ -1,0 +1,43 @@
+package srtp
+
+// https://datatracker.ietf.org/doc/html/rfc6716
+// TOC Byte Configuration Parameters (MODE_BANDWIDTH_FRAME-SIZE)
+const (
+	SILK_NB_10    = 0
+	SILK_NB_20    = 1
+	SILK_NB_40    = 2
+	SILK_NB_60    = 3
+	SILK_MB_10    = 4
+	SILK_MB_20    = 5
+	SILK_MB_40    = 6
+	SILK_MB_60    = 7
+	SILK_WB_10    = 8
+	SILK_WB_20    = 9
+	SILK_WB_40    = 10
+	SILK_WB_60    = 11
+	HYBRID_SWB_10 = 12
+	HYBRID_SWB_20 = 13
+	HYBRID_FB_10  = 14
+	HYBRID_FB_20  = 15
+	CELT_NB_2_5   = 16
+	CELT_NB_5     = 17
+	CELT_NB_10    = 18
+	CELT_NB_20    = 19
+	CELT_WB_2_5   = 20
+	CELT_WB_5     = 21
+	CELT_WB_10    = 22
+	CELT_WB_20    = 23
+	CELT_SWB_2_5  = 24
+	CELT_SWB_5    = 25
+	CELT_SWB_10   = 26
+	CELT_SWB_20   = 27
+	CELT_FB_2_5   = 28
+	CELT_FB_5     = 29
+	CELT_FB_10    = 30
+	CELT_FB_20    = 31
+)
+
+const (
+	SAMPLE_RATE        = 16 // 16k sample rate by using opus/16000
+	MAX_PAYLOAD_LENGTH = 1276
+)

--- a/pkg/srtp/session.go
+++ b/pkg/srtp/session.go
@@ -102,7 +102,6 @@ func (s *Session) repacketizeOpus(packet *rtp.Packet) *rtp.Packet {
 		if len(s.frameSize) < 3 {
 			s.frameBuffer = append(s.frameBuffer, packet.Payload[1:]...)
 			s.frameSize = append(s.frameSize, len(packet.Payload[1:]))
-
 		}
 		if len(s.frameSize) == 3 {
 			toc |= 0b00000011                  // code 3: signaled number of frames

--- a/pkg/srtp/session_test.go
+++ b/pkg/srtp/session_test.go
@@ -1,0 +1,186 @@
+package srtp
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+// https://datatracker.ietf.org/doc/html/rfc6716#
+
+// Input:
+
+// For code 0 packets, the TOC byte is immediately followed by N-1 bytes
+// of compressed data for a single frame (where N is the size of the
+// packet)
+//
+// 0                   1                   2                   3
+// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// | config  |s|0|0|                                               |
+// +-+-+-+-+-+-+-+-+                                               |
+// |                    Compressed frame 1 (N-1 bytes)...          :
+// :                                                               |
+// |                                                               |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+
+var CONFIG_10 = []uint8{SILK_NB_10, SILK_MB_10, SILK_WB_10, HYBRID_SWB_10, HYBRID_FB_10, CELT_NB_10, CELT_WB_10, CELT_SWB_10, CELT_FB_10}
+var CONFIG_20 = []uint8{SILK_NB_20, SILK_MB_20, SILK_WB_20, HYBRID_SWB_20, HYBRID_FB_20, CELT_NB_20, CELT_WB_20, CELT_SWB_20, CELT_FB_20}
+
+// ffmpeg sends 20ms Opus frames, and 20ms frame is requested (Wi-Fi connection)
+// only timestamp is mangled
+func TestOpusPacket20(t *testing.T) {
+
+	for _, conf := range CONFIG_20 {
+		audioSession := &Session{
+			AudioFrameDuration: 20,
+		}
+		var timestamp uint32 = 0
+		for i := 0; i <= 15; i++ {
+			packet := newRandomOpusPacket(conf<<3, uint16(i))
+			repacketizedPacket := audioSession.repacketizeOpus(packet.Clone())
+			require.Equal(t, packet.Payload, repacketizedPacket.Payload)
+			require.Equal(t, packet.SequenceNumber, repacketizedPacket.SequenceNumber)
+			// compare timestamp
+			if i == 0 {
+				// first packet, timestamp no change
+				require.Equal(t, packet.Timestamp, repacketizedPacket.Timestamp)
+			} else {
+				require.Equal(t, timestamp+uint32(audioSession.AudioFrameDuration)*SAMPLE_RATE, repacketizedPacket.Timestamp)
+			}
+			timestamp = repacketizedPacket.Timestamp
+		}
+	}
+}
+
+// ffmpeg sends 20ms Opus frames, and 60ms frame is requested (Cellular connection)
+// merge three frames into one packet
+func TestOpusRepacketize20to60(t *testing.T) {
+	audioSession := &Session{
+		AudioFrameDuration: 60,
+	}
+
+	packets := make([]*rtp.Packet, 3)
+	for _, conf := range CONFIG_20 {
+		for i := 1; i <= 15; i++ {
+			packet := newRandomOpusPacket(conf<<3, uint16(i))
+			repacketizedPacket := audioSession.repacketizeOpus(packet.Clone())
+
+			if i%3 != 0 {
+				require.Nil(t, repacketizedPacket)
+				packets[i%3] = packet
+			} else {
+				require.NotNil(t, repacketizedPacket)
+				// compare sequence number
+				if packets[0] != nil {
+					require.Equal(t, packets[0].SequenceNumber+1, repacketizedPacket.SequenceNumber)
+				}
+				// compare timestamp
+				if packets[0] != nil {
+					require.Equal(t, packets[0].Timestamp+uint32(audioSession.AudioFrameDuration)*SAMPLE_RATE, repacketizedPacket.Timestamp)
+				}
+
+				// compare config bytes
+				require.Equal(t, byte(conf<<3+3), repacketizedPacket.Payload[0])
+				// compaer frame count byte (M)
+				//  0 1 2 3 4 5 6 7
+				// +-+-+-+-+-+-+-+-+
+				// |v|p|     M     |
+				// +-+-+-+-+-+-+-+-+
+				require.Equal(t, byte(1<<7+3), repacketizedPacket.Payload[1])
+				// compare M-1 frame lengths
+				firstLength := int(repacketizedPacket.Payload[2])
+				lengthIt := 3
+				if firstLength >= 252 {
+					// second byte is needed
+					firstLength += int(repacketizedPacket.Payload[3]) * 4
+					lengthIt++
+				}
+				secondLength := int(repacketizedPacket.Payload[lengthIt])
+				if secondLength >= 252 {
+					// second byte is needed
+					secondLength += int(repacketizedPacket.Payload[lengthIt+1]) * 4
+					lengthIt++
+				}
+				thirdLength := len(repacketizedPacket.Payload) - 1 - lengthIt - firstLength - secondLength
+				require.Equal(t, len(packets[1].Payload)-1, firstLength)
+				require.Equal(t, len(packets[2].Payload)-1, secondLength)
+				require.Equal(t, len(packet.Payload)-1, thirdLength)
+				// compare payloads
+				require.Equal(t, packets[1].Payload[1:], repacketizedPacket.Payload[lengthIt+1:lengthIt+1+firstLength])
+				require.Equal(t, packets[2].Payload[1:], repacketizedPacket.Payload[lengthIt+1+firstLength:lengthIt+1+firstLength+secondLength])
+				require.Equal(t, packet.Payload[1:], repacketizedPacket.Payload[lengthIt+1+firstLength+secondLength:])
+				packets[0] = repacketizedPacket
+			}
+		}
+	}
+
+}
+
+// ffmpeg sends <20ms Opus frames, and 20ms or 60ms frame is requested
+// not handled. can be implemented similarly by merging multiple frames into one packet
+func TestOpusPacket10(t *testing.T) {
+	frameDurations := []uint8{20, 60}
+	for _, frameDuration := range frameDurations {
+		audioSession := &Session{
+			AudioFrameDuration: frameDuration,
+		}
+		for _, conf := range CONFIG_10 {
+			for i := 0; i <= 15; i++ {
+				packet := newRandomOpusPacket(conf<<3, uint16(i))
+				// return packet as is
+				repacketizedPacket := audioSession.repacketizeOpus(packet.Clone())
+				require.Equal(t, packet, repacketizedPacket)
+			}
+		}
+	}
+}
+
+// ffmpeg sends >20ms Opus frames, and 20ms or 60ms frame is requested
+// only timestamp is mangled
+// e.g, If ffmpeg args contains -frame_duration 60, three 20ms frames will be sent.
+// After timestamp mangling, audio is working in Cellular but not in Wi-Fi connections.
+func TestOpusPacket60(t *testing.T) {
+	frameDurations := []uint8{20, 60}
+	for _, frameDuration := range frameDurations {
+		for _, conf := range CONFIG_20 {
+			audioSession := &Session{
+				AudioFrameDuration: frameDuration,
+			}
+			var timestamp uint32 = 0
+			for i := 0; i <= 15; i++ {
+				packet := newRandomOpusPacket(conf<<3, uint16(i))
+				packet.Payload[0] |= 0b00000011 // code 3
+				repacketizedPacket := audioSession.repacketizeOpus(packet.Clone())
+				require.Equal(t, packet.Payload, repacketizedPacket.Payload)
+				// compare timestamp
+				if i == 0 {
+					// first packet, timestamp no change
+					require.Equal(t, packet.Timestamp, repacketizedPacket.Timestamp)
+				} else {
+					require.Equal(t, timestamp+uint32(audioSession.AudioFrameDuration)*SAMPLE_RATE, repacketizedPacket.Timestamp)
+				}
+				timestamp = repacketizedPacket.Timestamp
+			}
+		}
+	}
+}
+
+// return a rtp packet with random payload
+func newRandomOpusPacket(configByte byte, seqenceNumber uint16) *rtp.Packet {
+	rawPacket := make([]byte, rand.Intn(1276)+1)
+	rawPacket[0] = configByte
+	for i := 1; i < len(rawPacket); i++ {
+		rawPacket[i] = byte(rand.Intn(256))
+	}
+	return &rtp.Packet{
+		Header: rtp.Header{
+			SequenceNumber: seqenceNumber,
+		},
+		Payload: rawPacket,
+	}
+}

--- a/pkg/srtp/session_test.go
+++ b/pkg/srtp/session_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 // https://datatracker.ietf.org/doc/html/rfc6716#
-
+//
 // Input:
-
+//
 // For code 0 packets, the TOC byte is immediately followed by N-1 bytes
 // of compressed data for a single frame (where N is the size of the
 // packet)
@@ -26,15 +26,12 @@ import (
 // |                                                               |
 // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-
-
 var CONFIG_10 = []uint8{SILK_NB_10, SILK_MB_10, SILK_WB_10, HYBRID_SWB_10, HYBRID_FB_10, CELT_NB_10, CELT_WB_10, CELT_SWB_10, CELT_FB_10}
 var CONFIG_20 = []uint8{SILK_NB_20, SILK_MB_20, SILK_WB_20, HYBRID_SWB_20, HYBRID_FB_20, CELT_NB_20, CELT_WB_20, CELT_SWB_20, CELT_FB_20}
 
 // ffmpeg sends 20ms Opus frames, and 20ms frame is requested (Wi-Fi connection)
 // only timestamp is mangled
 func TestOpusPacket20(t *testing.T) {
-
 	for _, conf := range CONFIG_20 {
 		audioSession := &Session{
 			AudioFrameDuration: 20,
@@ -60,12 +57,11 @@ func TestOpusPacket20(t *testing.T) {
 // ffmpeg sends 20ms Opus frames, and 60ms frame is requested (Cellular connection)
 // merge three frames into one packet
 func TestOpusRepacketize20to60(t *testing.T) {
-	audioSession := &Session{
-		AudioFrameDuration: 60,
-	}
-
-	packets := make([]*rtp.Packet, 3)
 	for _, conf := range CONFIG_20 {
+		audioSession := &Session{
+			AudioFrameDuration: 60,
+		}
+		packets := make([]*rtp.Packet, 3)
 		for i := 1; i <= 15; i++ {
 			packet := newRandomOpusPacket(conf<<3, uint16(i))
 			repacketizedPacket := audioSession.repacketizeOpus(packet.Clone())
@@ -83,7 +79,6 @@ func TestOpusRepacketize20to60(t *testing.T) {
 				if packets[0] != nil {
 					require.Equal(t, packets[0].Timestamp+uint32(audioSession.AudioFrameDuration)*SAMPLE_RATE, repacketizedPacket.Timestamp)
 				}
-
 				// compare config bytes
 				require.Equal(t, byte(conf<<3+3), repacketizedPacket.Payload[0])
 				// compaer frame count byte (M)


### PR DESCRIPTION
HomeKit cameras have choppy sounds (https://github.com/AlexxIT/go2rtc/issues/667) in Wi-Fi and no sound in cellular network. This is due to incorrect timestamp increment and mismatched frame sizes.

It looks like iOS devices only request either 20ms (Wi-Fi) or 60ms (Cellular) opus frame sizes, and because I don't know how to dynamically modify ffmpeg args after SelectedStreamConfig is retrieved from iOS devices, merging three 20ms frames into one rtp packet is implemented to deal with mismatched frame sizes. For the timestamp increment, it will be frame size(provided by client) * sampling rate(16k with `opus/16000`). It looks like default `opus` also works.

I put these in `pkg/srtp` and I'm not a golang expert. Please let me know if there's better approaches.