### PR TITLE
Nest extend stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,8 +579,7 @@ streams:
 
 Any cameras in WebRTC format are supported. But at the moment Home Assistant only supports some [Nest](https://www.home-assistant.io/integrations/nest/) cameras in this fomat.
 
-The Nest API only allows you to get a link to a stream for 5 minutes, but a call to extend the stream is made before it expires. If for some reason the stream expires anyway, any streaming clients will lose connection.
-Note: Do not use this with frigate. If the stream expires, Frigate will consume all available ram on your machine within seconds.
+**Important.** The Nest API only allows you to get a link to a stream for 5 minutes. Do not use this with Frigate! If the stream expires, Frigate will consume all available ram on your machine within seconds. It's recommended to use [Nest source](#source-nest) - it supports extending the stream.
 
 ```yaml
 streams:
@@ -611,7 +610,7 @@ streams:
 
 *[New in v1.6.0](https://github.com/AlexxIT/go2rtc/releases/tag/v1.6.0)*
 
-Currently only WebRTC cameras are supported. Stream reconnects every 5 minutes.
+Currently only WebRTC cameras are supported.
 
 For simplicity, it is recommended to connect the Nest/WebRTC camera to the [Home Assistant](#source-hass). But if you can somehow get the below parameters - Nest/WebRTC source will work without Hass.
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,8 @@ streams:
 
 Any cameras in WebRTC format are supported. But at the moment Home Assistant only supports some [Nest](https://www.home-assistant.io/integrations/nest/) cameras in this fomat.
 
-The Nest API only allows you to get a link to a stream for 5 minutes. So every 5 minutes the stream will be reconnected.
+The Nest API only allows you to get a link to a stream for 5 minutes, but a call to extend the stream is made before it expires. If for some reason the stream expires anyway, any streaming clients will lose connection.
+Note: Do not use this with frigate. If the stream expires, Frigate will consume all available ram on your machine within seconds.
 
 ```yaml
 streams:

--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -4,21 +4,14 @@ import (
 	"errors"
 	"net/url"
 
-	"time"
-
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/webrtc"
 	pion "github.com/pion/webrtc/v3"
 )
 
 type Client struct {
-	conn            *webrtc.Conn
-	projectId       string
-	deviceId        string
-	mediaSessionId  string
-	streamExpiresAt time.Time
-	nestApi         *API
-	timer           *time.Timer
+	conn *webrtc.Conn
+	api  *API
 }
 
 func NewClient(rawURL string) (*Client, error) {
@@ -72,7 +65,7 @@ func NewClient(rawURL string) (*Client, error) {
 	}
 
 	// 4. Exchange SDP via Hass
-	answer, mediaSessionId, expiresAt, err := nestAPI.ExchangeSDP(projectID, deviceID, offer)
+	answer, err := nestAPI.ExchangeSDP(projectID, deviceID, offer)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +75,7 @@ func NewClient(rawURL string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{conn: conn, deviceId: deviceID, projectId: projectID, mediaSessionId: mediaSessionId, streamExpiresAt: expiresAt, nestApi: nestAPI}, nil
+	return &Client{conn: conn, api: nestAPI}, nil
 }
 
 func (c *Client) GetMedias() []*core.Media {
@@ -98,35 +91,12 @@ func (c *Client) AddTrack(media *core.Media, codec *core.Codec, track *core.Rece
 }
 
 func (c *Client) Start() error {
-	c.StartExtendStreamTimer()
-
+	c.api.StartExtendStreamTimer()
 	return c.conn.Start()
 }
 
-func (c *Client) StartExtendStreamTimer() {
-	ontimer := func() {
-		c.ExtendStream()
-		c.StartExtendStreamTimer()
-	}
-	// Calculate the duration until 30 seconds before the stream expires
-	duration := time.Until(c.streamExpiresAt.Add(-30 * time.Second))
-
-	// Start the timer
-	c.timer = time.AfterFunc(duration, ontimer)
-}
-
-func (c *Client) ExtendStream() error {
-	mediaSessionId, expiresAt, err := c.nestApi.ExtendStream(c.projectId, c.deviceId, c.mediaSessionId)
-	if err != nil {
-		return err
-	}
-	c.mediaSessionId = mediaSessionId
-	c.streamExpiresAt = expiresAt
-	return nil
-}
-
 func (c *Client) Stop() error {
-	c.timer.Stop()
+	c.api.StopExtendStreamTimer()
 	return c.conn.Stop()
 }
 


### PR DESCRIPTION
This solves the issue of the stream expiring after 5 minutes.
However, this does not yet make the nest integration stable. If the stream for some reason should expire, any streaming clients will lose connection. And in the case of Frigate, it will consume all available ram within seconds of reconnecting. I've added this disclaimer to the readme.

Locally, I've fixed this as described here:
https://github.com/AlexxIT/go2rtc/issues/723#issuecomment-1872591484

But I don't feel confident committing this change, as I'm unsure if it will break other WebRTC sources.