### PR TITLE
refactor(homekit): replace slices.Max with custom maxByteSlice function

### DIFF
--- a/pkg/homekit/helpers.go
+++ b/pkg/homekit/helpers.go
@@ -2,7 +2,6 @@ package homekit
 
 import (
 	"encoding/hex"
-	"slices"
 
 	"github.com/AlexxIT/go2rtc/pkg/aac"
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -22,8 +21,8 @@ func videoToMedia(codecs []camera.VideoCodec) *core.Media {
 	for _, codec := range codecs {
 		for _, param := range codec.CodecParams {
 			// get best profile and level
-			profileID := slices.Max(param.ProfileID)
-			level := slices.Max(param.Level)
+			profileID := maxByteSlice(param.ProfileID)
+			level := maxByteSlice(param.Level)
 			profile := videoProfiles[profileID] + videoLevels[level]
 			mediaCodec := &core.Codec{
 				Name:      videoCodecs[codec.CodecType],
@@ -35,6 +34,38 @@ func videoToMedia(codecs []camera.VideoCodec) *core.Media {
 	}
 
 	return media
+}
+
+// maxByteSlice returns the maximum byte value from the provided slice.
+//
+// If the slice is empty, it will return 0. It iterates through each byte in the slice,
+// compares them and retains the highest value found. This function assumes that the
+// slice is not nil and does contain at least one element unless an empty slice is
+// intentionally passed to it.
+//
+// Usage:
+//
+//	maxVal := maxByteSlice([]byte{10, 30, 20})
+//	fmt.Println(maxVal) // Output: 30
+//
+// Params:
+//
+//	slice []byte - A slice of bytes from which the maximum value will be determined.
+//
+// Returns:
+//
+//	byte - The maximum byte value found in the slice. If the slice is empty, returns 0.
+func maxByteSlice(slice []byte) byte {
+	if len(slice) == 0 {
+		return 0
+	}
+	max := slice[0]
+	for _, value := range slice[1:] {
+		if value > max {
+			max = value
+		}
+	}
+	return max
 }
 
 var audioCodecs = [...]string{core.CodecPCMU, core.CodecPCMA, core.CodecELD, core.CodecOpus}

--- a/pkg/homekit/helpers_test.go
+++ b/pkg/homekit/helpers_test.go
@@ -1,0 +1,58 @@
+package homekit
+
+import (
+	"testing"
+)
+
+func TestMaxByteSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		slice   []byte
+		wantMax byte
+	}{
+		{
+			name:    "empty slice",
+			slice:   []byte{},
+			wantMax: 0,
+		},
+		{
+			name:    "single element",
+			slice:   []byte{42},
+			wantMax: 42,
+		},
+		{
+			name:    "multiple elements",
+			slice:   []byte{1, 3, 2},
+			wantMax: 3,
+		},
+		{
+			name:    "all elements same",
+			slice:   []byte{9, 9, 9},
+			wantMax: 9,
+		},
+		{
+			name:    "maximum at start",
+			slice:   []byte{99, 10, 88},
+			wantMax: 99,
+		},
+		{
+			name:    "maximum at end",
+			slice:   []byte{12, 24, 48},
+			wantMax: 48,
+		},
+		// Optionally add another case for multiple occurrences of the maximum value
+		{
+			name:    "maximum occurs multiple times",
+			slice:   []byte{23, 56, 23, 56},
+			wantMax: 56,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotMax := maxByteSlice(tt.slice); gotMax != tt.wantMax {
+				t.Errorf("maxByteSlice(%v) = %v, want %v", tt.slice, gotMax, tt.wantMax)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Removed dependency on the 'slices' package by implementing a custom function, maxByteSlice, to determine the maximum value in a slice of bytes. Tests for the new function have also been added to ensure correctness.

The change was made to reduce external dependencies and potentially improve the performance or maintainability of the code by using a simple native implementation instead of a package function. The unit tests included verify various scenarios for the new maxByteSlice function, ensuring it behaves as expected.