### PR TITLE
Fix "no response" error when viewing cameras via apple watch

### DIFF
--- a/pkg/hap/camera/accessory.go
+++ b/pkg/hap/camera/accessory.go
@@ -62,6 +62,7 @@ func ServiceCameraRTPStreamManagement() *hap.Service {
 				VideoAttrs: []VideoAttrs{
 					{Width: 1920, Height: 1080, Framerate: 30},
 					{Width: 1280, Height: 720, Framerate: 30}, // important for iPhones
+					{Width: 320, Height: 240, Framerate: 15}, // apple watch
 				},
 			},
 		},


### PR DESCRIPTION
Apple watch requires specific video resolution and frame rate, and without it the error message "no response" will be shown when the camera is clicked and watched via apple watch. Already paired cameras won't take effect until they are re-paired.