### PR TITLE
Fix crash with tapo cameras not returning 401

### DIFF
--- a/pkg/tapo/client.go
+++ b/pkg/tapo/client.go
@@ -281,7 +281,7 @@ func dial(req *http.Request) (net.Conn, *http.Response, error) {
 	auth := res.Header.Get("WWW-Authenticate")
 
 	if res.StatusCode != http.StatusUnauthorized || !strings.HasPrefix(auth, "Digest") {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("Expected StatusCode to be %d, received %d", http.StatusUnauthorized, res.StatusCode)
 	}
 
 	if password == "" {


### PR DESCRIPTION
err is nil and causes nil pointer dereference panic on line [86](https://github.com/janza/go2rtc/blob/14a9763c73dcbe0e46d602d8437aa46baaf94e88/pkg/tapo/client.go#L86)