### PR TITLE
feat(app): support daemon mode on non-Windows platforms

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -25,13 +26,27 @@ var Info = map[string]any{
 func Init() {
 	var confs Config
 	var version bool
+	var daemon bool
 
 	flag.Var(&confs, "config", "go2rtc config (path to file or raw text), support multiple")
+	if runtime.GOOS != "windows" {
+		flag.BoolVar(&daemon, "daemon", false, "Run program in background")
+	} else {
+		daemon = false
+	}
 	flag.BoolVar(&version, "version", false, "Print the version of the application and exit")
 	flag.Parse()
 
 	if version {
 		fmt.Println("Current version: ", Version)
+		os.Exit(0)
+	}
+
+	if daemon {
+		// Re-run the program in background and exit
+		cmd := exec.Command(os.Args[0], os.Args[2:]...)
+		cmd.Start()
+		fmt.Println("Running in daemon mode with PID:", cmd.Process.Pid)
 		os.Exit(0)
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -43,8 +43,13 @@ func Init() {
 	}
 
 	if daemon {
+		for i, arg := range os.Args[1:] {
+			if arg == "-daemon" {
+				os.Args[i+1] = ""
+			}
+		}
 		// Re-run the program in background and exit
-		cmd := exec.Command(os.Args[0], os.Args[2:]...)
+		cmd := exec.Command(os.Args[0], os.Args[1:]...)
 		cmd.Start()
 		fmt.Println("Running in daemon mode with PID:", cmd.Process.Pid)
 		os.Exit(0)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,32 +25,33 @@ var Info = map[string]any{
 
 func Init() {
 	var confs Config
-	var version bool
 	var daemon bool
+	var version bool
 
 	flag.Var(&confs, "config", "go2rtc config (path to file or raw text), support multiple")
 	if runtime.GOOS != "windows" {
 		flag.BoolVar(&daemon, "daemon", false, "Run program in background")
-	} else {
-		daemon = false
 	}
 	flag.BoolVar(&version, "version", false, "Print the version of the application and exit")
 	flag.Parse()
 
 	if version {
-		fmt.Println("Current version: ", Version)
+		fmt.Println("Current version:", Version)
 		os.Exit(0)
 	}
 
 	if daemon {
-		for i, arg := range os.Args[1:] {
+		for i, arg := range os.Args {
 			if arg == "-daemon" {
 				os.Args[i+1] = ""
+				break
 			}
 		}
 		// Re-run the program in background and exit
 		cmd := exec.Command(os.Args[0], os.Args[1:]...)
-		cmd.Start()
+		if err := cmd.Start(); err != nil {
+			log.Fatal().Err(err).Send()
+		}
 		fmt.Println("Running in daemon mode with PID:", cmd.Process.Pid)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Added a new command-line flag `-daemon` to run the application in the background as a daemon. This option is only available for non-Windows operating systems due to platform-specific process handling. When enabled, the application restarts itself with the same arguments except for the `-daemon` flag, prints the PID of the background process, and then exits the current process.

Simplified replacement for #440