### PR TITLE
upd(ci): upgrade GitHub Actions to newer versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,87 +15,87 @@ jobs:
     env: { CGO_ENABLED: 0 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with: { go-version: '1.21' }
 
       - name: Build go2rtc_win64
         env: { GOOS: windows, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_win64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_win64, path: go2rtc.exe }
 
       - name: Build go2rtc_win32
         env: { GOOS: windows, GOARCH: 386 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_win32
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_win32, path: go2rtc.exe }
 
       - name: Build go2rtc_win_arm64
         env: { GOOS: windows, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_win_arm64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_win_arm64, path: go2rtc.exe }
 
       - name: Build go2rtc_linux_amd64
         env: { GOOS: linux, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_amd64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_linux_amd64, path: go2rtc }
 
       - name: Build go2rtc_linux_i386
         env: { GOOS: linux, GOARCH: 386 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_i386
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_linux_i386, path: go2rtc }
 
       - name: Build go2rtc_linux_arm64
         env: { GOOS: linux, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_arm64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_linux_arm64, path: go2rtc }
 
       - name: Build go2rtc_linux_arm
         env: { GOOS: linux, GOARCH: arm, GOARM: 7 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_arm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_linux_arm, path: go2rtc }
 
       - name: Build go2rtc_linux_armv6
         env: { GOOS: linux, GOARCH: arm, GOARM: 6 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_armv6
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_linux_armv6, path: go2rtc }
 
       - name: Build go2rtc_linux_mipsel
         env: { GOOS: linux, GOARCH: mipsle }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_mipsel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_linux_mipsel, path: go2rtc }
 
       - name: Build go2rtc_mac_amd64
         env: { GOOS: darwin, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_mac_amd64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_mac_amd64, path: go2rtc }
 
       - name: Build go2rtc_mac_arm64
         env: { GOOS: darwin, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_mac_arm64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_mac_arm64, path: go2rtc }
 
   docker-master:
@@ -103,11 +103,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ github.repository }}
           tags: |
@@ -116,20 +116,20 @@ jobs:
             type=match,pattern=v(.*),group=1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: |
@@ -148,11 +148,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta-hw
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ github.repository }}
           flavor: |
@@ -164,20 +164,20 @@ jobs:
             type=match,pattern=v(.*),group=1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: hardware.Dockerfile

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,13 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './website'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       GOARCH: ${{ matrix.arch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
 
@@ -70,13 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/${{ matrix.platform }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build and push Hardware
         if: matrix.platform == 'amd64'
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: hardware.Dockerfile


### PR DESCRIPTION
Updated various GitHub Actions used in the CI workflows (build.yml, gh-pages.yml, test.yml) to their latest major versions. This includes actions for checking out code, setting up Go, uploading artifacts, configuring Docker, and deploying to GitHub Pages. The update is part of routine maintenance to ensure compatibility with the latest features and improvements provided by these actions.

_With loves, your's dependabot :)_