### PR TITLE
Modify ISAPI to reliably open connections

### DIFF
--- a/pkg/isapi/client.go
+++ b/pkg/isapi/client.go
@@ -84,30 +84,23 @@ func (c *Client) Dial() (err error) {
 }
 
 func (c *Client) Open() (err error) {
-	link := c.url + "/ISAPI/System/TwoWayAudio/channels/" + c.channel
-
    // Hikvision ISAPI may not accept a new open request if the previous one was not closed (e.g.
    // using the test button on-camera or via curl command) but a close request can be sent even if
    // the audio is already closed. So, we send a close request first and then open it again. Seems
    // janky but it works.
-	req, err := http.NewRequest("PUT", link+"/close", nil)
+
+   err = c.Close()
+   if err != nil {
+      return err
+   }
+
+	link := c.url + "/ISAPI/System/TwoWayAudio/channels/" + c.channel
+	req, err := http.NewRequest("PUT", link+"/open", nil)
 	if err != nil {
 		return err
 	}
 
 	res, err := tcp.Do(req)
-	if err != nil {
-		return err
-	}
-
-	tcp.Close(res)
-
-	req, err = http.NewRequest("PUT", link+"/open", nil)
-	if err != nil {
-		return err
-	}
-
-	res, err = tcp.Do(req)
 	if err != nil {
 		return
 	}

--- a/pkg/tcp/request.go
+++ b/pkg/tcp/request.go
@@ -115,7 +115,9 @@ func Do(req *http.Request) (*http.Response, error) {
 			)
 		case "auth":
 			nc := "00000001"
-			cnonce := "00000001" // TODO: random...
+			// TODO: Random cnonce
+         // Here is temp static cnonce of required 32 bytes
+			cnonce := "ZDlmODczZTk2NjQyZTQ4OGQ5ZGEzOTI3YTc5Y2Q0ZGM="
 			response := HexMD5(ha1, nonce, nc, cnonce, qop, ha2)
 			header = fmt.Sprintf(
 				`Digest username="%s", realm="%s", nonce="%s", uri="%s", qop=%s, nc=%s, cnonce="%s", response="%s"`,


### PR DESCRIPTION
Hikvision ISAPI may not accept a new open request if the previous one was not closed (e.g. using the test button on-camera or via curl command) but a close request can be sent even if the audio is already closed. 

Using go2rtc to load microphone, regardless if using dashboard, WebRTC card, or Frigate card, resulted in ISAPI connections that were constantly failing with 401 errors. Testing revealed that manually sending a close request just before opening microphone url allowed it to proceed. 

Modifying func Open in pkg/isapi/client.go to send a 'close' before 'open' seems to be working reliably with Frigate HASS card.

Modified func Close in pkg/isapi/client.go to call `/ISAPI/System/TwoWayAudio/channels/<channel id>/close` instead of `/ISAPI/System/TwoWayAudio/channels/<channel id/close/open`

Made minor mod to pkg/tcp/request.go, changing cnonce to 32 bytes. Still temporary/static and needs randomized.
