### PR TITLE
fix(streams): handle interface conversion panic in NewStream() at internal/streams

### DIFF
--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -22,8 +22,13 @@ func NewStream(source any) *Stream {
 		}
 	case []any:
 		s := new(Stream)
-		for _, source := range source {
-			s.producers = append(s.producers, NewProducer(source.(string)))
+		for _, src := range source {
+			str, ok := src.(string)
+			if !ok {
+				log.Error().Msgf("[stream] NewStream: Expected string, got %v", src)
+				continue
+			}
+			s.producers = append(s.producers, NewProducer(str))
 		}
 		return s
 	case map[string]any:


### PR DESCRIPTION
```
panic: interface conversion: interface {} is map[string]interface {}, not string

goroutine 1 [running]:
github.com/AlexxIT/go2rtc/internal/streams.NewStream({0x1010ef3e0?, 0x140001305b8?})
        /Users/svk/Documents/GitHub/go2rtc/internal/streams/stream.go:26 +0x3b0
github.com/AlexxIT/go2rtc/internal/streams.Init()
        /Users/svk/Documents/GitHub/go2rtc/internal/streams/streams.go:26 +0x134
main.main()
        /Users/svk/Documents/GitHub/go2rtc/main.go:46 +0x28
exit status 2
```

Now the configuration like this causing a crash at startup. this PR fix it
```yaml
streams:
  - exec: "ffmpeg -i 'https://camera.lipetsk.ru/ms-25.camera.lipetsk.ru/live/6a3efc18-3651-43a4-b164-d07543151c3b/playlist.m3u8' -c:v libx264 -pix_fmt yuv420p -b:v 2368512 -f rtsp {output}"
```

