### PR TITLE
fix(docker): optimize docker hardware image size by cleaning up apt cache

### DIFF
--- a/hardware.Dockerfile
+++ b/hardware.Dockerfile
@@ -53,7 +53,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
         python3 curl jq \
         intel-media-va-driver-non-free \
         mesa-va-drivers \
-        libasound2-plugins
+        libasound2-plugins && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --link --from=rootfs / /
 


### PR DESCRIPTION
This PR optimizes the -hardware Docker image size by including commands to clean up the APT cache after package installation. This change reduces the overall image size by removing unnecessary files and directories that are not needed in the final image, leading to faster download and deployment times.