### PR TITLE
fix ivideon source

### DIFF
--- a/pkg/ivideon/client.go
+++ b/pkg/ivideon/client.go
@@ -132,6 +132,9 @@ func (c *Client) Handle() error {
 		case "stream-init":
 			continue
 
+		case "metadata":
+			continue
+
 		case "fragment":
 			_, data, err = c.conn.ReadMessage()
 			if err != nil {
@@ -183,6 +186,9 @@ func (c *Client) getTracks() error {
 		}
 
 		switch msg.Type {
+		case "metadata":
+			continue
+
 		case "stream-init":
 			s := msg.CodecString
 			i := strings.IndexByte(s, '.')


### PR DESCRIPTION
This config shows error
```yaml
streams:
  ustusa: ivideon:100-ovO8jrLNOcP2mQQjains3o/0
```
```
11:23:17.730 WRN internal/streams/producer.go:171 > error="wrong message type: {\"type\": \"metadata\", \"metadataOffset\": 3998.0, \"metadataPosition\": 1712910198585.0, \"absolute_time\": 1712910198585.0, \"keyframeIndex\": 2.0}" url=ivideon:100-ovO8jrLNOcP2mQQjains3o/0
11:24:31.692 ERR internal/mjpeg/init.go:166 > error="streams: wrong message type: {\"type\": \"metadata\", \"duration\": 3600.0, \"width\": 1920.0, \"height\": 1080.0, \"videodatarate\": 0.0, \"framerate\": 1000.0, \"videocodecid\": 7.0, \"audiodatarate\": 0.0, \"audiosamplerate\": 0.0, \"audiosamplesize\": 0.0, \"stereo\": false, \"audiocodecid\": -16.0, \"audiochannels\": 0.0, \"metadataOffset\": 0.0, \"metadataPosition\": 1712910270562.0, \"speed\": 1.0, \"fragmentPosition\": 1712910270562.0, \"fragmentDuration\": 3600000.0}"
```
skipping messages with type=metadata fixes stream