### PR TITLE
fix(api): potential Slow Loris Attacks in API Server   

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/pkg/shell"
@@ -96,7 +97,10 @@ func listen(network, address string) {
 		Port = ln.Addr().(*net.TCPAddr).Port
 	}
 
-	server := http.Server{Handler: Handler}
+	server := http.Server{
+		Handler:           Handler,
+		ReadHeaderTimeout: 5 * time.Second, // Example: Set to 5 seconds
+	}
 	if err = server.Serve(ln); err != nil {
 		log.Fatal().Err(err).Msg("[api] serve")
 	}
@@ -126,8 +130,9 @@ func tlsListen(network, address, certFile, keyFile string) {
 	log.Info().Str("addr", address).Msg("[api] tls listen")
 
 	server := &http.Server{
-		Handler:   Handler,
-		TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}},
+		Handler:           Handler,
+		TLSConfig:         &tls.Config{Certificates: []tls.Certificate{cert}},
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 	if err = server.ServeTLS(ln, "", ""); err != nil {
 		log.Fatal().Err(err).Msg("[api] tls serve")


### PR DESCRIPTION
This pull request introduces a configuration enhancement to the API server  
  designed to mitigate potential Slow Loris attacks. By setting a             
  'ReadHeaderTimeout' of 5 seconds, we enforce a time limit on how long the   
  server will wait for the header of an incoming request to be completed. This
  avoids server resources being tied up indefinitely by such attacks, which   
  aim to exhaust server resources by sending partial requests slowly.         