### PR TITLE
The biggest PR ever: ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ go2rtc.yaml
 go2rtc.json
 
 0_test.go
+
+.DS_Store


### PR DESCRIPTION
In the macOS operating system, [.DS_Store](https://en.wikipedia.org/wiki/.DS_Store) is an auto-generated file that stores custom attributes of its containing folder, such as folder view options, icon positions, and other visual information.