### PR TITLE
feat(logging): enhance log visualisation with level-specific colours

### DIFF
--- a/www/log.html
+++ b/www/log.html
@@ -89,7 +89,7 @@
             const msg = Object.keys(line).reduce((msg, key) => {
                 return KEYS.indexOf(key) < 0 ? `${msg} ${key}=${line[key]}` : msg;
             }, line['message']);
-            return `<tr><td>${ts.toLocaleString()}</td><td>${line['level']}</td><td>${escapeHTML(msg)}</td></tr>`;
+            return `<tr class="${line['level']}"><td>${ts.toLocaleString()}</td><td>${escapeHTML(line['level'])}</td><td>${escapeHTML(msg)}</td></tr>`;
         }).join('');
     }
 

--- a/www/log.html
+++ b/www/log.html
@@ -19,17 +19,30 @@
             height: 100%;
         }
 
-        
-
-        
-
         table tbody td {
             font-size: 13px;
             vertical-align: top;
         }
 
-        
+        .info {
+            color: #0174DF;
+        }
 
+        .debug {
+            color: #808080;
+        }
+
+        .error {
+            color: #DF0101;
+        }
+
+        .trace {
+            color: #585858;
+        }
+
+        .warn {
+            color: #FF9966;
+        }
     </style>
 </head>
 <body>

--- a/www/main.js
+++ b/www/main.js
@@ -131,13 +131,6 @@ body.dark-mode textarea::placeholder {
 body.dark-mode hr {
     border-top: 1px solid #444;
 }
-
-.info { color: #0174DF; }
-.debug { color: #808080; }
-.error { color: #DF0101; }
-.trace { color: #585858; }
-.warn { color: #FF9966; }
-
 </style>
 <nav>
     <ul>

--- a/www/main.js
+++ b/www/main.js
@@ -131,6 +131,13 @@ body.dark-mode textarea::placeholder {
 body.dark-mode hr {
     border-top: 1px solid #444;
 }
+
+.info { color: #0174DF; }
+.debug { color: #808080; }
+.error { color: #DF0101; }
+.trace { color: #585858; }
+.warn { color: #FF9966; }
+
 </style>
 <nav>
     <ul>


### PR DESCRIPTION
- Add CSS classes for log levels (info, debug, error, trace, warn) in main.js to color-code log messages based on their severity.
- Modify log.html to include the log level as a class in each log entry's table row for applying the corresponding color styles.
<img width="782" alt="image" src="https://github.com/AlexxIT/go2rtc/assets/15078499/798dd91c-fc81-4a22-b1b6-36bafab9aa5d">
