### PR TITLE
feat(version): Enhancements to Version Display Functionality

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/shell"
 	"github.com/AlexxIT/go2rtc/pkg/yaml"
@@ -36,7 +38,25 @@ func Init() {
 	flag.Parse()
 
 	if version {
-		fmt.Printf("go2rtc version %s %s/%s\n", Version, runtime.GOOS, runtime.GOARCH)
+		vcsRevision := ""
+		vcsTime := time.Now().Local()
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" {
+					if len(setting.Value) > 7 {
+						vcsRevision = setting.Value[:7]
+					} else {
+						vcsRevision = setting.Value
+					}
+					vcsRevision = "(" + vcsRevision + ")"
+				}
+				if setting.Key == "vcs.time" {
+					vcsTime, _ = time.Parse(time.RFC3339, setting.Value)
+					vcsTime = vcsTime.Local()
+				}
+			}
+		}
+		fmt.Printf("go2rtc version %s%s: %s %s/%s\n", Version, vcsRevision, vcsTime.Local().String(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,25 +38,27 @@ func Init() {
 	flag.Parse()
 
 	if version {
-		vcsRevision := ""
-		vcsTime := time.Now().Local()
+		var vcsRevision string
+		vcsTime := time.Now()
+
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, setting := range info.Settings {
-				if setting.Key == "vcs.revision" {
-					if len(setting.Value) > 7 {
-						vcsRevision = setting.Value[:7]
-					} else {
-						vcsRevision = setting.Value
+				switch setting.Key {
+				case "vcs.revision":
+					vcsRevision = setting.Value
+					if len(vcsRevision) > 7 {
+						vcsRevision = vcsRevision[:7]
 					}
 					vcsRevision = "(" + vcsRevision + ")"
-				}
-				if setting.Key == "vcs.time" {
-					vcsTime, _ = time.Parse(time.RFC3339, setting.Value)
-					vcsTime = vcsTime.Local()
+				case "vcs.time":
+					if parsedTime, err := time.Parse(time.RFC3339, setting.Value); err == nil {
+						vcsTime = parsedTime.Local()
+					}
 				}
 			}
 		}
-		fmt.Printf("go2rtc version %s%s: %s %s/%s\n", Version, vcsRevision, vcsTime.Local().String(), runtime.GOOS, runtime.GOARCH)
+
+		fmt.Printf("go2rtc version %s%s: %s %s/%s\n", Version, vcsRevision, vcsTime.String(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
### Enhancements to Version Display Functionality

```bash
% ./go2rtc -version
go2rtc version 1.9.1.2(9004308): 2024-05-12 06:35:02 +0300 MSK darwin/arm64
                  ^version  ^commit               ^commit date       ^ binary arch
```

#### Overview
This pull request introduces several enhancements to the version display functionality within our `go2rtc` application. The goal of these changes is to provide more detailed build information which aids in better version tracking and debugging during development and deployment processes.

#### Key Changes
1. **Enhanced Version Output**: The output format of the version command in the `Init()` function has been expanded to include the VCS revision hash and the build time. This additional information is fetched from build metadata, formatted, and displayed alongside the existing version details.

#### Implementation Details
- The `debug.ReadBuildInfo()` function is used to access the current build's metadata.
- Revision hash and build timestamp are extracted from the build info settings. If available, the revision hash is truncated to the first 7 characters for better readability.
- Both the revision hash and the timestamp are then appended to the version string output, enhancing traceability of the build.

#### Benefits
- **Improved Traceability**: Including the VCS revision and timestamp in the version output allows development teams to quickly identify and correlate specific builds with source control, enhancing overall traceability.
- **Ease of Use**: Displaying more detailed version information directly within the application streamlines the process of version verification during troubleshooting and system checks.

This enhancement aligns with ongoing efforts to improve robustness and operational transparency across our development cycles. By integrating build-specific metadata directly into the version output, developers and system administrators can achieve greater insights into the deployment landscape without requiring additional tools or commands.