### PR TITLE
homekit-server: add pairing API

### DIFF
--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -36,6 +36,7 @@ func Init() {
 	streams.HandleFunc("homekit", streamHandler)
 
 	api.HandleFunc("api/homekit", apiHandler)
+	api.HandleFunc("api/homekit/pairing", apiPairingHandler)
 
 	if cfg.Mod == nil {
 		return

--- a/internal/homekit/server.go
+++ b/internal/homekit/server.go
@@ -214,7 +214,11 @@ func (s *server) DelPair(conn net.Conn, id string) {
 			continue
 		}
 
-		s.pairings = append(s.pairings[:i], s.pairings[i+1:]...)
+		if strings.Contains(pairing, "permissions=1") {
+			s.pairings = nil
+		} else {
+			s.pairings = append(s.pairings[:i], s.pairings[i+1:]...)
+		}
 		s.UpdateStatus()
 		s.PatchConfig()
 		break


### PR DESCRIPTION
Current issues:
1. when HomeHub (AppleTV, HomePod) is being used with HomeKit and the device is deleted from the iOS Home app, the HomeHub pairing information remains and the next registration is not possible.

2. If a device is deleted from the iOS Home app while go2rtc is not running, the device does not exist in the Home app, but the go2rtc pairing information remains, so the next registration cannot be performed.

Suggested correction:
Regarding the first problem,
The current code deletes only the pairing information that has the same id in DelPair in internal/homekit/server.go.
In HomeKit, one stream cannot be registered to multiple homes.
Therefore, when deleting pairing information with permissions=1, modify to delete all pairing information of stream.
If permissions=0, delete only the pairing information of the HomeHub, since it is the HomeHub's information.

Since the second problem cannot be handled automatically, add an API for deleting pairing information.
GET to get the current pairing information, and DELETE to delete the pairing that has been deleted by Query.

- GET api/homekit/pairing
-   get the pairing information.
- DELETE api/homekit/pairing?[stream='stream' | name='mDNSname' | device_id='deviceID' ]
-   remove the pairing that has been deleted by Query.