### PR TITLE
Homekit qrcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,7 +970,7 @@ HomeKit module can work in two modes:
 streams:
   dahua1: rtsp://admin:password@192.168.1.123/cam/realmonitor?channel=1&subtype=0
 homekit:
-  dahua1:  # same stream ID from streams list, default PIN - 19550224
+  dahua1:  # same stream ID from streams list, default PIN - 19550224, default setup_id - HMXS
 ```
 
 **Full config**
@@ -985,6 +985,7 @@ streams:
 homekit:
   dahua1:                   # same stream ID from streams list
     pin: 12345678           # custom PIN, default: 19550224
+    setup_id: ABCD          # custom setup ID, default: HMXS
     name: Dahua camera      # custom camera name, default: generated from stream ID
     device_id: dahua1       # custom ID, default: generated from stream ID
     device_private: dahua1  # custom key, default: generated from stream ID

--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -139,10 +139,10 @@ func findHomeKitURLs() map[string]*url.URL {
 }
 
 type PairingInfo struct {
-	Name         string     `json:"name"`
-	DeviceID     string     `json:"device_id"`
-	Pin          string     `json:"pin"`
-	Status       string     `json:"status"`
+	Name         string     `yaml:"name"`
+	DeviceID     string     `yaml:"device_id"`
+	Pin          string     `yaml:"pin"`
+	Status       string     `yaml:"status"`
 }
 
 func getPairingInfo(host string, s *server) PairingInfo {

--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"strconv"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/app"
@@ -143,9 +144,15 @@ type PairingInfo struct {
 	DeviceID     string     `yaml:"device_id"`
 	Pin          string     `yaml:"pin"`
 	Status       string     `yaml:"status"`
+	SetupURI     string     `yaml:"setup_uri"`
 }
 
 func getPairingInfo(host string, s *server) PairingInfo {
+	// for QR-Code
+	category, _ := strconv.ParseInt(hap.CategoryCamera, 10, 64)
+	pin, _ := strconv.ParseInt(strings.Replace(s.hap.Pin, "-", "", -1), 10, 64)
+	payload := "00000000" + strconv.FormatInt(category << 31 + 1 << 28 + pin, 36)
+	uri := strings.ToUpper("X-HM://" + payload[len(payload)-9:] + s.hap.SetupID[:4])
 	status := "unpaired"
 	if len(s.pairings) > 0 {
 		status = "paired"
@@ -153,6 +160,7 @@ func getPairingInfo(host string, s *server) PairingInfo {
 	return PairingInfo {
 		Name: s.mdns.Name ,
 		DeviceID: s.hap.DeviceID,
+		SetupURI: uri,
 		Pin: s.hap.Pin,
 		Status: status,
 	}

--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -180,5 +180,6 @@ func apiPairingHandler(w http.ResponseWriter, r *http.Request) {
 				break;
 			}
 		}
+		discovery()
 	}
 }

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -36,6 +36,7 @@ func Init() {
 	streams.HandleFunc("homekit", streamHandler)
 
 	api.HandleFunc("api/homekit", apiHandler)
+	api.HandleFunc("api/homekit/pairing", apiPairingHandler)
 
 	if cfg.Mod == nil {
 		return

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -26,6 +26,7 @@ func Init() {
 			Name          string   `yaml:"name"`
 			DeviceID      string   `yaml:"device_id"`
 			DevicePrivate string   `yaml:"device_private"`
+			SetupID       string   `yaml:"setup_id"`
 			Pairings      []string `yaml:"pairings"`
 		} `yaml:"homekit"`
 	}
@@ -63,6 +64,7 @@ func Init() {
 		}
 
 		deviceID := calcDeviceID(conf.DeviceID, id) // random MAC-address
+		setupID := (conf.SetupID + "HMXS")[:4] // default setup ID
 		name := calcName(conf.Name, deviceID)
 
 		srv := &server{
@@ -74,6 +76,7 @@ func Init() {
 		srv.hap = &hap.Server{
 			Pin:           pin,
 			DeviceID:      deviceID,
+			SetupID:       setupID,
 			DevicePrivate: calcDevicePrivate(conf.DevicePrivate, id),
 			GetPair:       srv.GetPair,
 			AddPair:       srv.AddPair,

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -129,6 +129,7 @@ func Init() {
 			log.Error().Err(err).Caller().Send()
 		}
 	}()
+	discovery()
 }
 
 var log zerolog.Logger

--- a/internal/homekit/server.go
+++ b/internal/homekit/server.go
@@ -214,7 +214,11 @@ func (s *server) DelPair(conn net.Conn, id string) {
 			continue
 		}
 
-		s.pairings = append(s.pairings[:i], s.pairings[i+1:]...)
+		if strings.Contains(pairing, "permissions=1") {
+			s.pairings = nil
+		} else {
+			s.pairings = append(s.pairings[:i], s.pairings[i+1:]...)
+		}
 		s.UpdateStatus()
 		s.PatchConfig()
 		break

--- a/internal/homekit/server.go
+++ b/internal/homekit/server.go
@@ -203,6 +203,7 @@ func (s *server) AddPair(conn net.Conn, id string, public []byte, permissions by
 		s.UpdateStatus()
 		s.PatchConfig()
 	}
+	discovery()
 }
 
 func (s *server) DelPair(conn net.Conn, id string) {
@@ -223,6 +224,7 @@ func (s *server) DelPair(conn net.Conn, id string) {
 		s.PatchConfig()
 		break
 	}
+	discovery()
 }
 
 func (s *server) PatchConfig() {

--- a/pkg/hap/server.go
+++ b/pkg/hap/server.go
@@ -23,6 +23,7 @@ type HandlerFunc func(net.Conn) error
 type Server struct {
 	Pin           string
 	DeviceID      string
+	SetupID       string
 	DevicePrivate []byte
 
 	GetPair func(conn net.Conn, id string) []byte
@@ -45,7 +46,7 @@ func (s *Server) ServerPublic() []byte {
 func (s *Server) SetupHash() string {
 	// should be setup_id (random 4 alphanum) + device_id (mac address)
 	// but device_id is random, so OK
-	b := sha512.Sum512([]byte(s.DeviceID))
+	b := sha512.Sum512([]byte(s.SetupID[:4] + s.DeviceID))
 	return base64.StdEncoding.EncodeToString(b[:4])
 }
 

--- a/www/links.html
+++ b/www/links.html
@@ -218,5 +218,40 @@ Telegram: rtmps://xxx-x.rtmp.t.me/s/xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx</pre>
     webrtcLinksUpdate();
 </script>
 
+<div>
+  <h2>HomeKit</h2>
+  <div id="homekit-info"></div>
+  <div id="homekit-qrcode"></div>
+  <div id="homekit-unpair"></div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<script>
+    const homekit = new URL('api/homekit/pairing', location.href);
+    fetch(homekit, {cache: 'no-cache'}).then(r => r.json()).then(data => {
+      try {
+        const homekitInfo = data[src];
+        console.log(homekitInfo);
+        document.getElementById('homekit-info').innerHTML = `
+          Setup Code : ${homekitInfo.Pin}<br>
+          Device ID : ${homekitInfo.DeviceID}<br>
+          Status : ${homekitInfo.Status}<br>
+        `;
+        new QRCode('homekit-qrcode', {
+          text: homekitInfo.SetupURI,
+          width: 128,
+          height: 128,
+        });
+        document.getElementById('homekit-unpair').innerHTML = '<br><button>unpair</button><br>';
+        document.getElementById('homekit-unpair').addEventListener('click', ev => {
+          const unpair = new URL(`api/homekit/pairing?stream=${src}`, location.href);
+          fetch(unpair, { method: 'DELETE' }).then(data => {
+            location.reload();
+          }).catch(e => {
+          });
+        });
+      } catch(e) {
+      }
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
HomeKit QR-Code
This request is an additional proposal to the following puru request.
homekit-server: add pairing API #1128

Current problem:
HomeKit's QR-Code registration requires that the DeviceID and SetupHash information be announced in mDNS.
The SetupHash is a string Hash value that combines the SetupID and DeviceID.
In the current code, the SetupHash is a Hash value of DeviceID only.
For this reason, QR-Code reading does not recognize it as a HomeKit accessory.

Suggested fixes:
1. Add setup_id to homekit's option in the config file and add it when SetupHash is calculated.
2. Add API to get string for QR-Code using these values.
3. Add a HomeKit section to the web's links page.
