### PR TITLE
docs(scripts): Update paths and commands in scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,8 +13,8 @@
 go get -u
 go mod tidy
 go mod why github.com/pion/rtcp
-go list -deps .\cmd\go2rtc_rtsp\
-./goweight
+go list -deps .\examples\go2rtc_rtsp\
+go run github.com/paralin/goweight@latest .
 ```
 
 ## Dependencies


### PR DESCRIPTION
This commit updates the README.md file in the scripts directory. 
It's modifies the command to run goweight from a local script execution (./goweight) to using the latest version available on GitHub (go run github.com/paralin/goweight@latest). These modifications seem aimed at correcting paths and ensuring that the most updated tool version is used for better dependency management and weight analysis of the project.