### PR TITLE
fix(network): preserve selected nodes and edges on data reload

### DIFF
--- a/www/network.html
+++ b/www/network.html
@@ -57,8 +57,13 @@
                     const positions = network.getPositions();
                     const viewPosition = network.getViewPosition();
                     const scale = network.getScale();
+                    const selectedNodes = network.getSelectedNodes();
+                    const selectedEdges = network.getSelectedEdges();
 
                     network.setData(data);
+
+                    network.selectNodes(selectedNodes);
+                    network.selectEdges(selectedEdges);
 
                     for (const nodeId in positions) {
                         network.moveNode(nodeId, positions[nodeId].x, positions[nodeId].y);

--- a/www/network.html
+++ b/www/network.html
@@ -58,18 +58,16 @@
                     const viewPosition = network.getViewPosition();
                     const scale = network.getScale();
                     const selectedNodes = network.getSelectedNodes();
-                    const selectedEdges = network.getSelectedEdges();
 
                     network.setData(data);
-
-                    network.selectNodes(selectedNodes);
-                    network.selectEdges(selectedEdges);
 
                     for (const nodeId in positions) {
                         network.moveNode(nodeId, positions[nodeId].x, positions[nodeId].y);
                     }
 
                     network.moveTo({position: viewPosition, scale: scale});
+
+                    network.selectNodes(selectedNodes);
                 }
             } catch (error) {
                 console.error('Error fetching or updating network data:', error);


### PR DESCRIPTION
This commit introduces new features aimed at enhancing the user interaction with network visualizations on a web page. Specifically, the update allows both nodes and edges to be selected within the network visualization tool. The JavaScript code updates involve:

1. Declaring variables to capture the selected nodes and edges using `getSelectedNodes()` and `getSelectedEdges()` methods.
2. Updating the network data with these selected nodes and edges using `selectNodes()` and `selectEdges()` methods.
