### PR TITLE
Fix exec race/hang on exit

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -158,6 +158,8 @@ func handleRTSP(source string, cmd *exec.Cmd, cl io.Closer, path string) (core.P
 		done <- cmd.Wait()
 	}()
 
+	cl.(*closer).done = done
+
 	select {
 	case <-time.After(time.Minute):
 		log.Error().Str("source", source).Msg("[exec] timeout")


### PR DESCRIPTION
In go2rtc 1.9.4 it is easy to have hangs on exec processes, especially if they spawn child processes, due to a race condition caused by the fact that closer calls cmd.Wait() for RTSP sessions even though cmd.Wait() has already been called in handleRTSP.  As far as I can tell, callling Wait() twice is bad practice and the behavior of doing so is undefined.  

This small patch fixes the issue by passing in the existing channel from handleRTSP to the closer so that it can share the same wait() instead of attempting to call it a second time.  For the handlePipe case, there is no initial call to cmd.Wait(), so the code behaves as previous.

I've tested various killsignals and killtimeout and this fixes all persistent hang conditions.  There is still a scenario where, sigkill may kill the parent but the secondary process keeps the producer stream alive.  I somewhat wonder if it should always return after sigkill, perhaps after a short timeout, since that should hard kill the parent and clearly the goal at that point is to stop the stream immediately, but I'm guessing this is a rare occurrence.

https://github.com/AlexxIT/go2rtc/issues/1243