### PR TITLE
nest: add support for RTSP cameras

### DIFF
--- a/internal/nest/init.go
+++ b/internal/nest/init.go
@@ -2,6 +2,7 @@ package nest
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/streams"
@@ -38,11 +39,12 @@ func apiNest(w http.ResponseWriter, r *http.Request) {
 
 	var items []*api.Source
 
-	for name, deviceID := range devices {
-		query.Set("device_id", deviceID)
+	for _, device := range devices {
+		query.Set("device_id", device.DeviceID)
+		query.Set("protocols", strings.Join(device.Protocols, ","))
 
 		items = append(items, &api.Source{
-			Name: name, URL: "nest:?" + query.Encode(),
+			Name: device.Name, URL: "nest:?" + query.Encode(),
 		})
 	}
 

--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -120,18 +120,8 @@ func (a *API) GetDevices(projectID string) ([]DeviceInfo, error) {
 	devices := make([]DeviceInfo, 0, len(resv.Devices))
 
 	for _, device := range resv.Devices {
+		// only RTSP and WEB_RTC available (both supported)
 		if len(device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols) == 0 {
-			continue
-		}
-
-		supported := false
-		for _, protocol := range device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols {
-			if protocol == "WEB_RTC" || protocol == "RTSP" {
-				supported = true
-				break
-			}
-		}
-		if !supported {
 			continue
 		}
 
@@ -146,7 +136,11 @@ func (a *API) GetDevices(projectID string) ([]DeviceInfo, error) {
 			name = device.ParentRelations[0].DisplayName
 		}
 
-		devices = append(devices, DeviceInfo{Name: name, DeviceID: device.Name[i+1:], Protocols: device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols})
+		devices = append(devices, DeviceInfo{
+			Name:      name,
+			DeviceID:  device.Name[i+1:],
+			Protocols: device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols,
+		})
 	}
 
 	return devices, nil

--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -33,6 +33,12 @@ type Auth struct {
 	AccessToken string
 }
 
+type DeviceInfo struct {
+	Name      string
+	DeviceID  string
+	Protocols []string
+}
+
 var cache = map[string]*API{}
 var cacheMu sync.Mutex
 
@@ -84,7 +90,7 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 	return api, nil
 }
 
-func (a *API) GetDevices(projectID string) (map[string]string, error) {
+func (a *API) GetDevices(projectID string) ([]DeviceInfo, error) {
 	uri := "https://smartdevicemanagement.googleapis.com/v1/enterprises/" + projectID + "/devices"
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
@@ -111,7 +117,7 @@ func (a *API) GetDevices(projectID string) (map[string]string, error) {
 		return nil, err
 	}
 
-	devices := map[string]string{}
+	devices := make([]DeviceInfo, 0, len(resv.Devices))
 
 	for _, device := range resv.Devices {
 		if len(device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols) == 0 {
@@ -139,38 +145,11 @@ func (a *API) GetDevices(projectID string) (map[string]string, error) {
 		if name == "" && len(device.ParentRelations) > 0 {
 			name = device.ParentRelations[0].DisplayName
 		}
-		devices[name] = device.Name[i+1:]
+
+		devices = append(devices, DeviceInfo{Name: name, DeviceID: device.Name[i+1:], Protocols: device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols})
 	}
 
 	return devices, nil
-}
-
-func (a *API) GetDevice(projectID, deviceID string) (Device, error) {
-	uri := "https://smartdevicemanagement.googleapis.com/v1/enterprises/" + projectID + "/devices/" + deviceID
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		return Device{}, err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+a.Token)
-
-	client := &http.Client{Timeout: time.Second * 5000}
-	res, err := client.Do(req)
-	if err != nil {
-		return Device{}, err
-	}
-
-	if res.StatusCode != 200 {
-		return Device{}, errors.New("nest: wrong status: " + res.Status)
-	}
-
-	var device Device
-
-	if err = json.NewDecoder(res.Body).Decode(&device); err != nil {
-		return Device{}, err
-	}
-
-	return device, nil
 }
 
 func (a *API) ExchangeSDP(projectID, deviceID, offer string) (string, error) {

--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -23,7 +23,7 @@ type API struct {
 	StreamSessionID string
 
 	// RTSP
-	StreamToken string
+	StreamToken          string
 	StreamExtensionToken string
 
 	extendTimer *time.Timer
@@ -120,7 +120,7 @@ func (a *API) GetDevices(projectID string) (map[string]string, error) {
 
 		supported := false
 		for _, protocol := range device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols {
-			if (protocol == "WEB_RTC" || protocol == "RTSP") {
+			if protocol == "WEB_RTC" || protocol == "RTSP" {
 				supported = true
 				break
 			}
@@ -231,7 +231,7 @@ func (a *API) ExtendStream() error {
 	var reqv struct {
 		Command string `json:"command"`
 		Params  struct {
-			MediaSessionID string `json:"mediaSessionId,omitempty"`
+			MediaSessionID       string `json:"mediaSessionId,omitempty"`
 			StreamExtensionToken string `json:"streamExtensionToken,omitempty"`
 		} `json:"params"`
 	}
@@ -272,10 +272,10 @@ func (a *API) ExtendStream() error {
 
 	var resv struct {
 		Results struct {
-			ExpiresAt      time.Time `json:"expiresAt"`
-			MediaSessionID string    `json:"mediaSessionId"`
-			StreamExtensionToken string `json:"streamExtensionToken"`
-			StreamToken string `json:"streamToken"`
+			ExpiresAt            time.Time `json:"expiresAt"`
+			MediaSessionID       string    `json:"mediaSessionId"`
+			StreamExtensionToken string    `json:"streamExtensionToken"`
+			StreamToken          string    `json:"streamToken"`
 		} `json:"results"`
 	}
 
@@ -293,8 +293,8 @@ func (a *API) ExtendStream() error {
 
 func (a *API) GenerateRtspStream(projectID, deviceID string) (string, error) {
 	var reqv struct {
-		Command string `json:"command"`
-		Params  struct {} `json:"params"`
+		Command string   `json:"command"`
+		Params  struct{} `json:"params"`
 	}
 	reqv.Command = "sdm.devices.commands.CameraLiveStream.GenerateRtspStream"
 
@@ -324,10 +324,10 @@ func (a *API) GenerateRtspStream(projectID, deviceID string) (string, error) {
 
 	var resv struct {
 		Results struct {
-			StreamURLs map[string]string `json:"streamUrls"`
-			StreamExtensionToken string `json:"streamExtensionToken"`
-			StreamToken string `json:"streamToken"`
-			ExpiresAt      time.Time `json:"expiresAt"`
+			StreamURLs           map[string]string `json:"streamUrls"`
+			StreamExtensionToken string            `json:"streamExtensionToken"`
+			StreamToken          string            `json:"streamToken"`
+			ExpiresAt            time.Time         `json:"expiresAt"`
 		} `json:"results"`
 	}
 

--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -33,12 +33,6 @@ func Dial(rawURL string) (core.Producer, error) {
 	refreshToken := query.Get("refresh_token")
 	projectID := query.Get("project_id")
 	deviceID := query.Get("device_id")
-	protocols := strings.Split(query.Get("protocols"), ",")
-
-	// Default to WEB_RTC for backwards compataiility
-	if len(protocols) == 0 {
-		protocols = append(protocols, "WEB_RTC")
-	}
 
 	if cliendID == "" || cliendSecret == "" || refreshToken == "" || projectID == "" || deviceID == "" {
 		return nil, errors.New("nest: wrong query")
@@ -49,16 +43,13 @@ func Dial(rawURL string) (core.Producer, error) {
 		return nil, err
 	}
 
-	// Pick the first supported protocol in order of priority (WEB_RTC, RTSP)
-	for _, proto := range protocols {
-		if proto == "WEB_RTC" {
-			return rtcConn(nestAPI, rawURL, projectID, deviceID)
-		} else if proto == "RTSP" {
-			return rtspConn(nestAPI, rawURL, projectID, deviceID)
-		}
+	protocols := strings.Split(query.Get("protocols"), ",")
+	if len(protocols) > 0 && protocols[0] == "RTSP" {
+		return rtspConn(nestAPI, rawURL, projectID, deviceID)
 	}
 
-	return nil, errors.New("nest: unsupported camera")
+	// Default to WEB_RTC for backwards compataiility
+	return rtcConn(nestAPI, rawURL, projectID, deviceID)
 }
 
 func (c *WebRTCClient) GetMedias() []*core.Media {

--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -3,6 +3,7 @@ package nest
 import (
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/rtsp"
@@ -32,6 +33,12 @@ func Dial(rawURL string) (core.Producer, error) {
 	refreshToken := query.Get("refresh_token")
 	projectID := query.Get("project_id")
 	deviceID := query.Get("device_id")
+	protocols := strings.Split(query.Get("protocols"), ",")
+
+	// Default to WEB_RTC for backwards compataiility
+	if len(protocols) == 0 {
+		protocols = append(protocols, "WEB_RTC")
+	}
 
 	if cliendID == "" || cliendSecret == "" || refreshToken == "" || projectID == "" || deviceID == "" {
 		return nil, errors.New("nest: wrong query")
@@ -42,12 +49,8 @@ func Dial(rawURL string) (core.Producer, error) {
 		return nil, err
 	}
 
-	device, err := nestAPI.GetDevice(projectID, deviceID)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, proto := range device.Traits.SdmDevicesTraitsCameraLiveStream.SupportedProtocols {
+	// Pick the first supported protocol in order of priority (WEB_RTC, RTSP)
+	for _, proto := range protocols {
 		if proto == "WEB_RTC" {
 			return rtcConn(nestAPI, rawURL, projectID, deviceID)
 		} else if proto == "RTSP" {

--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -17,7 +17,7 @@ type WebRTCClient struct {
 
 type RTSPClient struct {
 	conn *rtsp.Conn
-	api *API
+	api  *API
 }
 
 func Dial(rawURL string) (core.Producer, error) {


### PR DESCRIPTION
Add support for RTSP cameras for Nest. The protocol information is carried in the stream URL, to avoid having to make a call to resolve the device when a stream is started. The same logic for extending the stream is used, but StreamExtensionToken is used when it's an RTSP stream.