### PR TITLE
Refactor /stream API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,6 +13,20 @@ servers:
 
 components:
   parameters:
+    stream_name_path:
+      name: name
+      in: path
+      description: Source stream name
+      required: true
+      schema: { type: string }
+      example: camera1
+    stream_src:
+      name: src
+      in: path
+      description: Stream source
+      required: true
+      schema: { type: string }
+      example: "rtsp://user:pass@10.0.0.1/stream1"
     stream_src_path:
       name: src
       in: path
@@ -169,29 +183,44 @@ paths:
       parameters:
         - name: src
           in: query
-          description: Stream source (URI)
+          description: Stream source(s) (URI). Multiple sources can be specified.
           required: true
-          schema: { type: string }
-          example: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0"
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+          example:
+            [
+              "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0",
+              "rtsp://user:pass@10.0.0.1/stream1",
+            ]
         - name: name
           in: query
           description: Stream name
-          required: false
+          required: true
           schema: { type: string }
           example: camera1
-      responses:
-            default:
-              description: Default response
     patch:
       summary: Update stream source
       tags: [ Streams list ]
       parameters:
         - name: src
           in: query
-          description: Stream source (URI)
-          required: true
-          schema: { type: string }
-          example: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0"
+          description: Stream source(s) (URI). Multiple sources can be specified.
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+          example:
+            [
+              "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0",
+              "rtsp://user:pass@10.0.0.1/stream1",
+            ]
         - name: name
           in: query
           description: Stream name
@@ -237,18 +266,40 @@ paths:
 
 
 
-  /api/streams?src={src}:
+  /api/streams?name={name}:
     get:
-      summary: Get stream info in JSON format
+      summary: Get stream info by name in JSON format
       tags: [ Consume stream ]
       parameters:
-        - $ref: "#/components/parameters/stream_src_path"
+        - $ref: "#/components/parameters/stream_name_path"
       responses:
         "200":
           description: ""
           content:
             application/json:
               example: { producers: [ { url: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0" } ], consumers: [ ] }
+
+  /api/streams?src={src}:
+    get:
+      summary: Get all streams info by source in JSON format
+      tags: [ Consume stream ]
+      parameters:
+        - $ref: "#/components/parameters/stream_src"
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              example:
+                [
+                  {
+                    producers: [ { url: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0" } ], consumers: [ ]
+                  },
+                  {
+                    producers: [{ url: "rtsp://user:pass@10.0.0.1/stream1" }],
+                    consumers: [],
+                  },
+                ]
 
   /api/webrtc?src={src}:
     post:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -254,7 +254,7 @@ paths:
 
   /api/streams?src={src}:
     get:
-      summary: Get all streams info by source in JSON format
+      summary: Get stream info in JSON format
       tags: [ Consume stream ]
       parameters:
         - $ref: "#/components/parameters/stream_src_path"
@@ -263,16 +263,7 @@ paths:
           description: ""
           content:
             application/json:
-              example:
-                [
-                  {
-                    producers: [ { url: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0" } ], consumers: [ ]
-                  },
-                  {
-                    producers: [{ url: "rtsp://user:pass@10.0.0.1/stream1" }],
-                    consumers: [],
-                  },
-                ]
+              example: { producers: [ { url: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0" } ], consumers: [ ] }
 
   /api/webrtc?src={src}:
     post:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13,20 +13,6 @@ servers:
 
 components:
   parameters:
-    stream_name_path:
-      name: name
-      in: path
-      description: Source stream name
-      required: true
-      schema: { type: string }
-      example: camera1
-    stream_src:
-      name: src
-      in: path
-      description: Stream source
-      required: true
-      schema: { type: string }
-      example: "rtsp://user:pass@10.0.0.1/stream1"
     stream_src_path:
       name: src
       in: path
@@ -184,7 +170,7 @@ paths:
         - name: src
           in: query
           description: Stream source(s) (URI). Multiple sources can be specified.
-          required: true
+          required: false
           schema:
             type: array
             items:
@@ -234,7 +220,7 @@ paths:
       summary: Delete stream
       tags: [ Streams list ]
       parameters:
-        - name: src
+        - name: name
           in: query
           description: Stream name
           required: true
@@ -266,25 +252,12 @@ paths:
 
 
 
-  /api/streams?name={name}:
-    get:
-      summary: Get stream info by name in JSON format
-      tags: [ Consume stream ]
-      parameters:
-        - $ref: "#/components/parameters/stream_name_path"
-      responses:
-        "200":
-          description: ""
-          content:
-            application/json:
-              example: { producers: [ { url: "rtsp://rtsp:12345678@192.168.1.123/av_stream/ch0" } ], consumers: [ ] }
-
   /api/streams?src={src}:
     get:
       summary: Get all streams info by source in JSON format
       tags: [ Consume stream ]
       parameters:
-        - $ref: "#/components/parameters/stream_src"
+        - $ref: "#/components/parameters/stream_src_path"
       responses:
         "200":
           description: ""

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -58,28 +58,28 @@ func (s *Stream) SetSource(source string) {
 	if len(s.producers) == 0 {
 		s.producers = append(s.producers, NewProducer(source))
 		return
-	}
-
-	for _, prod := range s.producers {
-		prod.SetSource(source)
+	} else {
+		for _, prod := range s.producers {
+			prod.SetSource(source)
+		}
 	}
 }
 
-func (s *Stream) SetSources(sources []string) {
-    for _, source := range sources {
-        found := false
+func (s *Stream) SetSources(source []string) {
+	for _, src := range source {
+		found := false
 
-        for _, prod := range s.producers {
-            if prod.url == source {
-                found = true
-                break
-            }
-        }
+		for _, prod := range s.producers {
+			if prod.url == src {
+				found = true
+				break
+			}
+		}
 
-        if !found {
-            s.producers = append(s.producers, NewProducer(source))
-        }
-    }
+		if !found {
+			s.producers = append(s.producers, NewProducer(src))
+		}
+	}
 }
 
 func (s *Stream) RemoveConsumer(cons core.Consumer) {

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -21,6 +21,12 @@ func NewStream(source any) *Stream {
 		return &Stream{
 			producers: []*Producer{NewProducer(source)},
 		}
+	case []string:
+        s := new(Stream)
+        for _, src := range source {
+            s.producers = append(s.producers, NewProducer(src))
+        }
+        return s
 	case []any:
 		s := new(Stream)
 		for _, src := range source {
@@ -49,9 +55,31 @@ func (s *Stream) Sources() (sources []string) {
 }
 
 func (s *Stream) SetSource(source string) {
+	if len(s.producers) == 0 {
+		s.producers = append(s.producers, NewProducer(source))
+		return
+	}
+
 	for _, prod := range s.producers {
 		prod.SetSource(source)
 	}
+}
+
+func (s *Stream) SetSources(sources []string) {
+    for _, source := range sources {
+        found := false
+
+        for _, prod := range s.producers {
+            if prod.url == source {
+                found = true
+                break
+            }
+        }
+
+        if !found {
+            s.producers = append(s.producers, NewProducer(source))
+        }
+    }
 }
 
 func (s *Stream) RemoveConsumer(cons core.Consumer) {

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -165,10 +165,6 @@ func Patch(name string, sources ...string) *Stream {
     }
 
     // create new stream with this name
-    if len(sources) == 1 {
-        return New(name, sources[0])
-    }
-
     return New(name, sources)
 }
 


### PR DESCRIPTION
This PR enhances the functionality of the `/streams` API, allowing for more flexible management of multiple sources and improving the overall behavior of the API endpoints.

Key Changes:

1. Multiple Source Management:
   - The API now supports handling multiple sources for streams.

2. `apiStreams` Rewrite:
  - <del> `GET` requests now handle "name" and "src" queries separately:.</del>
     * <del> "name" query searches for an exact stream name match..</del>
     * <del> "src" query returns all streams containing the specified source.</del>
   - `PUT` requests:
     * Allow adding multiple sources (e.g., ?name=test&src=rtsp://localhost:1234/test1&src=rtsp://localhost:1234/test2).
     * Return an error if the stream already exist (PATCH should be used for updating streams)
   - `PATCH` requests:
     * If "src" query is not defined, all sources will be removed.
     * Allow adding/removing multiple sources.
     * Return an error if the stream is not found.
   - `DELETE` requests:
     * Use "name" instead of "src" in the query for consistency with other endpoints.
     * Return an error if the stream is not found.

3. Bug Fixes:
   - Fixed an issue where the config was not updated after a PATCH request.

4. Improved Error Handling:
   - Endpoints now return both a status code and a message for invalid requests, providing clearer feedback.

These changes significantly improve the flexibility and usability of the /streams API, allowing for more complex stream management operations and providing better feedback to API consumers.


P.S. I'm pretty new to Go, so I hope I didn't mess anything up!