### PR TITLE
fix: remove stream url from info logs

### DIFF
--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -119,7 +119,7 @@ func GetOrPatch(query url.Values) *Stream {
 
 	// check if name param provided
 	if name := query.Get("name"); name != "" {
-		log.Info().Msgf("[streams] create new stream url=%s", source)
+		log.Info().Msgf("[streams] create new stream %s", name)
 
 		return Patch(name, source)
 	}
@@ -143,6 +143,8 @@ func Delete(id string) {
 	delete(streams, id)
 }
 
-var log zerolog.Logger
-var streams = map[string]*Stream{}
-var streamsMu sync.Mutex
+var (
+	log       zerolog.Logger
+	streams   = map[string]*Stream{}
+	streamsMu sync.Mutex
+)


### PR DESCRIPTION
This solves the most prominent credential leak. With every new connection the passwords were leaked to the logs visible in the UI as well.

With this change only the stream name gets logged here.

There are other places in the codebase where we still log secret embedded in URLs, but a lot of them lack access to the stream name they could be replaced with. Most of these occurances are debug logs, but some are warning level though. I can try to come up with a fix in a followup PR.

This change is a simpler alternative to
https://github.com/AlexxIT/go2rtc/pull/1219 to address the issue to rid of the password in the log line emitted whenever a stream is created:

    [streams] create new stream url=rtsp://stream:xxxxxxxxxx@192.168.42.42:554/stream1

    [streams] create new stream garage-cam