### PR TITLE
data race for streams map

### DIFF
--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -61,6 +61,9 @@ func New(name string, source string) *Stream {
 		return nil
 	}
 
+	streamsMu.Lock()
+	defer streamsMu.Unlock()
+
 	stream := NewStream(source)
 	streams[name] = stream
 	return stream

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -64,9 +64,8 @@ func New(name string, source string) *Stream {
 	stream := NewStream(source)
 
 	streamsMu.Lock()
-	defer streamsMu.Unlock()
-
 	streams[name] = stream
+	streamsMu.Unlock()
 	return stream
 }
 

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -61,10 +61,11 @@ func New(name string, source string) *Stream {
 		return nil
 	}
 
+	stream := NewStream(source)
+
 	streamsMu.Lock()
 	defer streamsMu.Unlock()
 
-	stream := NewStream(source)
 	streams[name] = stream
 	return stream
 }


### PR DESCRIPTION
If concurrently calling create stream from api we can have error in write into streams map.
See https://go.dev/doc/articles/race_detector