### PR TITLE
proxy protocol for http api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pion/srtp/v2 v2.0.18
 	github.com/pion/stun v0.6.1
 	github.com/pion/webrtc/v3 v3.2.40
+	github.com/pires/go-proxyproto v0.7.0
 	github.com/rs/zerolog v1.33.0
 	github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1
 	github.com/sigurn/crc8 v0.0.0-20220107193325-2243fe600f9f

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/pion/webrtc/v3 v3.2.39 h1:Lf2SIMGdE3M9VNm48KpoX5pR8SJ6TsMnktzOkc/oB0o
 github.com/pion/webrtc/v3 v3.2.39/go.mod h1:AQ8p56OLbm3MjhYovYdgPuyX6oc+JcKx/HFoCGFcYzA=
 github.com/pion/webrtc/v3 v3.2.40 h1:Wtfi6AZMQg+624cvCXUuSmrKWepSB7zfgYDOYqsSOVU=
 github.com/pion/webrtc/v3 v3.2.40/go.mod h1:M1RAe3TNTD1tzyvqHrbVODfwdPGSXOUo/OgpoGGJqFY=
+github.com/pires/go-proxyproto v0.7.0 h1:IukmRewDQFWC7kfnb66CSomk2q/seBuilHBYFwyq0Hs=
+github.com/pires/go-proxyproto v0.7.0/go.mod h1:Vz/1JPY/OACxWGQNIRY2BeyDmpoaWmEP40O9LbuiFR4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.4.0/go.mod h1:NWz/XGvpEW1FyYQ7fCx4dqYBLlfTcE+A9FLAkNKqjFE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -79,8 +79,7 @@ func Init() {
 			if err != nil {
 				return nil, err
 			}
-
-			proxyReadTimeout := 200 * time.Millisecond
+			proxyReadTimeout := proxyproto.DefaultReadHeaderTimeout
 			if cfg.Mod.ProxyProtocolReadTimeout > 0 {
 				proxyReadTimeout = cfg.Mod.ProxyProtocolReadTimeout
 			}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -23,18 +23,18 @@ var netListen func(network, address string) (net.Listener, error)
 func Init() {
 	var cfg struct {
 		Mod struct {
-			Listen            string        `yaml:"listen"`
-			ProxyProto        bool          `yaml:"proxy_proto"`
-			ProxyProtoTimeout time.Duration `yaml:"proxy_proto_timeout_millis"`
-			Username          string        `yaml:"username"`
-			Password          string        `yaml:"password"`
-			BasePath          string        `yaml:"base_path"`
-			StaticDir         string        `yaml:"static_dir"`
-			Origin            string        `yaml:"origin"`
-			TLSListen         string        `yaml:"tls_listen"`
-			TLSCert           string        `yaml:"tls_cert"`
-			TLSKey            string        `yaml:"tls_key"`
-			UnixListen        string        `yaml:"unix_listen"`
+			Listen                   string        `yaml:"listen"`
+			ProxyProtocol            bool          `yaml:"proxy_protocol"`
+			ProxyProtocolReadTimeout time.Duration `yaml:"proxy_protocol_read_timeout"`
+			Username                 string        `yaml:"username"`
+			Password                 string        `yaml:"password"`
+			BasePath                 string        `yaml:"base_path"`
+			StaticDir                string        `yaml:"static_dir"`
+			Origin                   string        `yaml:"origin"`
+			TLSListen                string        `yaml:"tls_listen"`
+			TLSCert                  string        `yaml:"tls_cert"`
+			TLSKey                   string        `yaml:"tls_key"`
+			UnixListen               string        `yaml:"unix_listen"`
 		} `yaml:"api"`
 	}
 
@@ -73,7 +73,7 @@ func Init() {
 		Handler = middlewareLog(Handler) // 1st
 	}
 
-	if cfg.Mod.ProxyProto {
+	if cfg.Mod.ProxyProtocol {
 		netListen = func(network, address string) (net.Listener, error) {
 			ln, err := net.Listen(network, address)
 			if err != nil {
@@ -81,8 +81,8 @@ func Init() {
 			}
 
 			proxyReadTimeout := 200 * time.Millisecond
-			if cfg.Mod.ProxyProtoTimeout > 0 {
-				proxyReadTimeout = cfg.Mod.ProxyProtoTimeout
+			if cfg.Mod.ProxyProtocolReadTimeout > 0 {
+				proxyReadTimeout = cfg.Mod.ProxyProtocolReadTimeout
 			}
 			return &proxyproto.Listener{
 				Listener:          ln,


### PR DESCRIPTION
If we put go2rtc behind proxy (like haproxy) we cannot use some additional feature like network panel with real source ip if stream is consumed with fmp4 over websocket.
[Proxyprotocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) is made for transmit source ip/port address from proxy chain. Is transparent of application layer due it work in transport layer (tcp and udp).

With this PR can be enabled (default is disabled) and configured with two new api parameter into go2rtc.yaml file

```
api:
  proxy_protocol: <bool>
  proxy_protocol_read_timeout: <string representation of time.Duration>
```