### PR TITLE
Build the docker image for linux/arm/v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
           platforms: |
             linux/amd64
             linux/386
+            linux/arm/v6
             linux/arm/v7
             linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Home assistant wants to use this project to improve the camera experience by offering WebRTC for any camera stream instead to high latency HLS stream type.
For this we need to build this project also for linux/arm/v6

HA PR: https://github.com/home-assistant/core/pull/124410