### PR TITLE
Revert "Build the docker image for linux/arm/v6"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,6 @@ jobs:
           platforms: |
             linux/amd64
             linux/386
-            linux/arm/v6
             linux/arm/v7
             linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Reverts AlexxIT/go2rtc#1362

The easiest way is to revert it, as I solve the issue directly in HA by using the released binaries.
If a Docker image is available, I always tend to use that one, as Docker automatically selects the right platform.

I use now the following `RUN` command:
```dockerfile

# Get go2rtc binary
RUN \
    case "${BUILD_ARCH}" in \
        "aarch64") go2rtc_suffix='arm64' ;; \
        "armhf") go2rtc_suffix='armv6' ;; \
        "armv7") go2rtc_suffix='arm' ;; \
        *) go2rtc_suffix=${BUILD_ARCH} ;; \
    esac \
    && curl -L https://github.com/AlexxIT/go2rtc/releases/download/v1.9.4/go2rtc_linux_${go2rtc_suffix} --output /bin/go2rtc \
    && chmod +x /bin/go2rtc \
    # Verify go2rtc can be executed
    && go2rtc --version
```