### PR TITLE
Extend streams API to allow multiple sources

### DIFF
--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -101,7 +101,7 @@ func apiPair(id, url string) error {
 		return err
 	}
 
-	streams.New(id, []string{conn.URL()})
+	streams.New(id, conn.URL())
 
 	return app.PatchConfig(id, conn.URL(), "streams")
 }

--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -101,7 +101,7 @@ func apiPair(id, url string) error {
 		return err
 	}
 
-	streams.New(id, conn.URL())
+	streams.New(id, []string{conn.URL()})
 
 	return app.PatchConfig(id, conn.URL(), "streams")
 }

--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -1,7 +1,6 @@
 package streams
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
@@ -9,18 +8,13 @@ import (
 	"github.com/AlexxIT/go2rtc/pkg/probe"
 )
 
-func returnAllStreams(w http.ResponseWriter) {
-	api.ResponseJSON(w, streams)
-}
-
 func apiStreams(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	src := query.Get("src")
 
 	// without source - return all streams list
-	// PUT checks first body for sources
-	if src == "" && r.Method != "POST" && r.Method != "PUT" {
-		returnAllStreams(w)
+	if src == "" && r.Method != "POST" {
+		api.ResponseJSON(w, streams)
 		return
 	}
 
@@ -53,31 +47,13 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		if name == "" {
 			name = src
 		}
-		var sources []string
-		if src != "" {
-			sources = []string{src}
-		} else if r.Header.Get("Content-Type") == "application/json" {
-			var data struct {
-				Sources []string `json:"sources"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-				log.Error().Err(err).Caller().Send()
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			sources = data.Sources
-		} else {
-			// without source(s) - return all streams list
-			returnAllStreams(w)
-			return
-		}
 
-		if New(name, sources) == nil {
+		if New(name, query["src"]...) == nil {
 			http.Error(w, "", http.StatusBadRequest)
 			return
 		}
 
-		if err := app.PatchConfig(name, sources, "streams"); err != nil {
+		if err := app.PatchConfig(name, query["src"], "streams"); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -21,6 +21,12 @@ func NewStream(source any) *Stream {
 		return &Stream{
 			producers: []*Producer{NewProducer(source)},
 		}
+	case []string:
+		s := new(Stream)
+		for _, str := range source {
+			s.producers = append(s.producers, NewProducer(str))
+		}
+		return s
 	case []any:
 		s := new(Stream)
 		for _, src := range source {

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -56,7 +56,7 @@ func Validate(source string) error {
 	return nil
 }
 
-func New(name string, sources []string) *Stream {
+func New(name string, sources ...string) *Stream {
 	for _, source := range sources {
 		if Validate(source) != nil {
 			return nil
@@ -107,7 +107,7 @@ func Patch(name string, source string) *Stream {
 	}
 
 	// create new stream with this name
-	return New(name, []string{source})
+	return New(name, source)
 }
 
 func GetOrPatch(query url.Values) *Stream {

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -56,12 +56,14 @@ func Validate(source string) error {
 	return nil
 }
 
-func New(name string, source string) *Stream {
-	if Validate(source) != nil {
-		return nil
+func New(name string, sources []string) *Stream {
+	for _, source := range sources {
+		if Validate(source) != nil {
+			return nil
+		}
 	}
 
-	stream := NewStream(source)
+	stream := NewStream(sources)
 
 	streamsMu.Lock()
 	streams[name] = stream
@@ -105,7 +107,7 @@ func Patch(name string, source string) *Stream {
 	}
 
 	// create new stream with this name
-	return New(name, source)
+	return New(name, []string{source})
 }
 
 func GetOrPatch(query url.Values) *Stream {


### PR DESCRIPTION
In Home Assistant, we use the API to add streams to go2rtc, but currently, the API supports only one source. 
Currently, only the yaml config supports adding multiple sources to one stream.

This PR adds support for adding multiple sources for one stream via the API.
I choose to pass the sources via the body as source URLs can contain sensitive data like username and password, and we should avoid passing them via URL as many tools log/cache the whole URL.

I tested the PR manually as I'm new to go and didn't find any API tests in go2rtc.
Thanks in advance for the review and any feedback :)