### PR TITLE
Add the option to pass ICE servers with an async WebRTC offer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/asticode/go-astits v1.13.0
 	github.com/expr-lang/expr v1.16.9
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/gorilla/websocket v1.5.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/miekg/dns v1.1.59

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/expr-lang/expr v1.16.5 h1:m2hvtguFeVaVNTHj8L7BoAyt7O0PAIBaSVbjdHgRXMs
 github.com/expr-lang/expr v1.16.5/go.mod h1:uCkhfG+x7fcZ5A5sXHKuQ07jGZRl6J0FCAaf2k4PtVQ=
 github.com/expr-lang/expr v1.16.9 h1:WUAzmR0JNI9JCiF0/ewwHB1gmcGw5wW7nWt8gc6PpCI=
 github.com/expr-lang/expr v1.16.9/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -132,7 +132,7 @@ func asyncHandler(tr *ws.Transport, msg *ws.Message) error {
 	if apiV2 {
 		var result struct {
 			Sdp        string           `mapstructure:"sdp"`
-			ICEServers []pion.ICEServer `mapstructure:",omitempty"`
+			ICEServers []pion.ICEServer `mapstructure:"iceServers,omitempty"`
 		}
 
 		err := mapstructure.Decode(msg.Value, &result)


### PR DESCRIPTION
Add the option to pass ICE servers with an async WebRTC offer, which are merged with the servers defined in the config. I have added the option only for the async WebRTC offer V2, but it can also be added for the sync V2 one if needed.

This is helpful if you are using a TURN server, where the credentials are only valid for a certain time.

Without this PR, the servers can only be set via the config file. Changes in the config file take effect only after restarting the go2rtc binary, which closes running streams.