### PR TITLE
Fix hanging webrtc streams

### DIFF
--- a/pkg/webrtc/producer.go
+++ b/pkg/webrtc/producer.go
@@ -47,3 +47,13 @@ func (c *Conn) Start() error {
 	c.closed.Wait()
 	return nil
 }
+
+func (c *Conn) Stop() error {
+	for _, receiver := range c.Receivers {
+		receiver.Close()
+	}
+	for _, sender := range c.Senders {
+		sender.Close()
+	}
+	return c.pc.Close()
+}


### PR DESCRIPTION
Since v1.9.4 it is no longer possible to stop webrtc streams (`webrtc:ws://`). Go2RTC attempts to stop them and logs it, but on the client side the Peer Connection never disconnects, making it impossible to stop the stream.

This Pull Request reimplements the stop function for the webrtc producer, which terminates the Peer Connection.