### PR TITLE
Adds support for Abode IOTA via HomeKit

### DIFF
--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -72,7 +72,7 @@ func discovery() ([]*api.Source, error) {
 		log.Trace().Msgf("[homekit] mdns=%s", entry)
 
 		category := entry.Info[hap.TXTCategory]
-		if entry.Complete() && (category == hap.CategoryCamera || category == hap.CategoryDoorbell) {
+		if entry.Complete() && (category == hap.CategoryBridge || category == hap.CategoryCamera || category == hap.CategoryDoorbell) {
 			source := &api.Source{
 				Name: entry.Name,
 				Info: entry.Info[hap.TXTModel],


### PR DESCRIPTION
This adds the ability to discover the Abode IOTA and pair it over HomeKit.  It also fixes the TLV8 parsing that would make this particular camera fail to playback due to it producing 0xff, 0x00 in between it's TLV's.  I updated the TLV8 parsing to handle scenarios like this generically because in this case 0xff is type 255 with length 0 so you can just handle them like normal 0 length TLV's and move on.