### PR TITLE
Updated Roborock part in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,10 +648,11 @@ This source type support Roborock vacuums with cameras. Known working models:
 
 - Roborock S6 MaxV - only video (the vacuum has no microphone)
 - Roborock S7 MaxV - video and two way audio
+- Roborock Qrevo MaxV - video and two way audio
 
-Source support load Roborock credentials from Home Assistant [custom integration](https://github.com/humbertogontijo/homeassistant-roborock). Otherwise, you need to log in to your Roborock account (MiHome account is not supported). Go to: go2rtc WebUI > Add webpage. Copy `roborock://...` source for your vacuum and paste it to `go2rtc.yaml` config.
+Source support load Roborock credentials from Home Assistant [custom integration](https://github.com/humbertogontijo/homeassistant-roborock) or the [core integration](https://www.home-assistant.io/integrations/roborock). Otherwise, you need to log in to your Roborock account (MiHome account is not supported). Go to: go2rtc WebUI > Add webpage. Copy `roborock://...` source for your vacuum and paste it to `go2rtc.yaml` config.
 
-If you have graphic pin for your vacuum - add it as numeric pin (lines: 123, 456, 678) to the end of the roborock-link.
+If you have graphic pin for your vacuum - add it as numeric pin (lines: 123, 456, 789) to the end of the roborock-link.
 
 #### Source: WebRTC
 


### PR DESCRIPTION
Wanted to try to add my vacuum camera as a stream, I integrated it into the Homeassistant with the core integration for Roborock. It was listed directly in the list with the `roborock://...` link.
Also noticed a spelling mistake for the pin, which confused me the first time I tried.
I got the Roborock Qrevo MaxV, I can confirm that the addon works with it.