### PR TITLE
Improve codec not matched error by including kind

### DIFF
--- a/internal/streams/add_consumer.go
+++ b/internal/streams/add_consumer.go
@@ -130,12 +130,15 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 
 	// 2. Return "codecs not matched"
 	if prodMedias != nil {
-		var prod, cons string
+		var prod, cons map[string]string = make(map[string]string), make(map[string]string)
 
 		for _, media := range prodMedias {
 			if media.Direction == core.DirectionRecvonly {
 				for _, codec := range media.Codecs {
-					prod = appendString(prod, codec.PrintName())
+					if _, ok := prod[codec.Name]; !ok {
+						prod[media.Kind] = ""
+					}
+					prod[media.Kind] = appendString(prod[media.Kind], codec.PrintName())
 				}
 			}
 		}
@@ -143,16 +146,27 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 		for _, media := range consMedias {
 			if media.Direction == core.DirectionSendonly {
 				for _, codec := range media.Codecs {
-					cons = appendString(cons, codec.PrintName())
+					if _, ok := cons[codec.Name]; !ok {
+						cons[media.Kind] = ""
+					}
+					cons[media.Kind] = appendString(cons[media.Kind], codec.PrintName())
 				}
 			}
 		}
 
-		return errors.New("streams: codecs not matched: " + prod + " => " + cons)
+		return errors.New("streams: codecs not matched: " + mapToString(prod) + " => " + mapToString(cons))
 	}
 
 	// 3. Return unknown error
 	return errors.New("streams: unknown error")
+}
+
+func mapToString(m map[string]string) string {
+	var s string
+	for k, v := range m {
+		s = appendString(s, "("+k+": "+v+")")
+	}
+	return s
 }
 
 func appendString(s, elem string) string {

--- a/internal/streams/add_consumer.go
+++ b/internal/streams/add_consumer.go
@@ -130,15 +130,12 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 
 	// 2. Return "codecs not matched"
 	if prodMedias != nil {
-		var prod, cons map[string]string = make(map[string]string), make(map[string]string)
+		var prod, cons string
 
 		for _, media := range prodMedias {
 			if media.Direction == core.DirectionRecvonly {
 				for _, codec := range media.Codecs {
-					if _, ok := prod[codec.Name]; !ok {
-						prod[media.Kind] = ""
-					}
-					prod[media.Kind] = appendString(prod[media.Kind], codec.PrintName())
+					prod = appendString(prod, media.Kind+":"+codec.PrintName())
 				}
 			}
 		}
@@ -146,27 +143,16 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 		for _, media := range consMedias {
 			if media.Direction == core.DirectionSendonly {
 				for _, codec := range media.Codecs {
-					if _, ok := cons[codec.Name]; !ok {
-						cons[media.Kind] = ""
-					}
-					cons[media.Kind] = appendString(cons[media.Kind], codec.PrintName())
+					cons = appendString(cons, media.Kind+":"+codec.PrintName())
 				}
 			}
 		}
 
-		return errors.New("streams: codecs not matched: " + mapToString(prod) + " => " + mapToString(cons))
+		return errors.New("streams: codecs not matched: " + prod + " => " + cons)
 	}
 
 	// 3. Return unknown error
 	return errors.New("streams: unknown error")
-}
-
-func mapToString(m map[string]string) string {
-	var s string
-	for k, v := range m {
-		s = appendString(s, "("+k+": "+v+")")
-	}
-	return s
 }
 
 func appendString(s, elem string) string {


### PR DESCRIPTION
Currently, a codec not matched error could be misunderstood as the kind is not included: 
`21:10:48.404 WRN [rtsp] error="streams: codecs not matched: H264 => ANY" stream=camera.x`

This PR adds the kind, and the error will be now:
`19:26:01.708 WRN [rtsp] error="streams: codecs not matched: (video: H264) => (audio: ANY)" stream=camera.x`

Now it's clear that the mismatch is correct as audio ANY will not match any video codec