### PR TITLE
Read from credential files

### DIFF
--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -19,15 +19,15 @@ go2rtc -c log.format=text -c /config/go2rtc.yaml -c rtsp.listen='' -c /usr/local
 
 ## Environment variables
 
-Also go2rtc support templates for using environment variables in any part of config:
+There is support for loading external variables into the config. First, they will be attempted to be loaded from [credential files](https://systemd.io/CREDENTIALS). If `CREDENTIALS_DIRECTORY` is not set, then the key will be loaded from an environment variable. If no environment variable is set, then the string will be left as-is.
 
 ```yaml
 streams:
   camera1: rtsp://rtsp:${CAMERA_PASSWORD}@192.168.1.123/av_stream/ch0
 
 rtsp:
-  username: ${RTSP_USER:admin}   # "admin" if env "RTSP_USER" not set
-  password: ${RTSP_PASS:secret}  # "secret" if env "RTSP_PASS" not set
+  username: ${RTSP_USER:admin}   # "admin" if "RTSP_USER" not set
+  password: ${RTSP_PASS:secret}  # "secret" if "RTSP_PASS" not set
 ```
 
 ## JSON Schema

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -49,6 +50,13 @@ func ReplaceEnvVars(text string) string {
 		if i := strings.IndexByte(key, ':'); i > 0 {
 			key, def = key[:i], key[i+1:]
 			dok = true
+		}
+
+		if dir, vok := os.LookupEnv("CREDENTIALS_DIRECTORY"); vok {
+			value, err := os.ReadFile(filepath.Join(dir, key))
+			if err == nil {
+				return strings.TrimSpace(string(value))
+			}
 		}
 
 		if value, vok := os.LookupEnv(key); vok {


### PR DESCRIPTION
See https://systemd.io/CREDENTIALS/. This will also work for Docker Secrets by setting `CREDENTIALS_DIRECTORY=/run/secrets`.

See also https://github.com/AlexxIT/go2rtc/issues/1293.