### PR TITLE
Lower codec not matched error for ffmpeg to debug

### DIFF
--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -223,6 +223,8 @@ func parseArgs(s string) *ffmpeg.Args {
 			s += "?video&audio"
 		}
 		s += "&source=ffmpeg:" + url.QueryEscape(source)
+		// change codec not matched error level to debug
+		s += "&" + string(streams.CodecNotMatchedErrorCode) + "=" + zerolog.DebugLevel.String()
 		args.Input = inputTemplate("rtsp", s, query)
 	} else if i = strings.Index(s, "?"); i > 0 {
 		switch s[:i] {

--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -223,8 +223,9 @@ func parseArgs(s string) *ffmpeg.Args {
 			s += "?video&audio"
 		}
 		s += "&source=ffmpeg:" + url.QueryEscape(source)
-		// change codec not matched error level to debug
-		s += "&" + string(streams.CodecNotMatchedErrorCode) + "=" + zerolog.DebugLevel.String()
+		for _, v := range query["query"] {
+			s += "&" + v
+		}
 		args.Input = inputTemplate("rtsp", s, query)
 	} else if i = strings.Index(s, "?"); i > 0 {
 		switch s[:i] {

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -192,7 +192,14 @@ func tcpHandler(conn *rtsp.Conn) {
 			conn.Connection.Source = query.Get("source")
 
 			if err := stream.AddConsumer(conn); err != nil {
-				log.Warn().Err(err).Str("stream", name).Msg("[rtsp]")
+				logEvent := log.Warn()
+
+				if _, ok := err.(*streams.CodecNotMatchedError); ok && strings.HasPrefix(query.Get("source"), "ffmpeg") {
+					// lower codec not matched error for ffmpeg to debug
+					logEvent = log.Debug()
+				}
+
+				logEvent.Err(err).Str("stream", name).Msg("[rtsp]")
 				return
 			}
 

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -147,6 +147,7 @@ func tcpHandler(conn *rtsp.Conn) {
 	var closer func()
 
 	trace := log.Trace().Enabled()
+	level := zerolog.WarnLevel
 
 	conn.Listen(func(msg any) {
 		if trace {
@@ -188,20 +189,18 @@ func tcpHandler(conn *rtsp.Conn) {
 				conn.PacketSize = uint16(core.Atoi(s))
 			}
 
+			// param name like ffmpeg style https://ffmpeg.org/ffmpeg-protocols.html
+			if s := query.Get("log_level"); s != "" {
+				if lvl, err := zerolog.ParseLevel(s); err == nil {
+					level = lvl
+				}
+			}
+
 			// will help to protect looping requests to same source
 			conn.Connection.Source = query.Get("source")
 
 			if err := stream.AddConsumer(conn); err != nil {
-				logEvent := log.Warn()
-
-				if err, ok := err.(*streams.ErrorWithErrorCode); ok {
-					level, parseErr := zerolog.ParseLevel(query.Get(err.Code()))
-					if parseErr == nil {
-						logEvent = log.WithLevel(level)
-					}
-				}
-
-				logEvent.Err(err).Str("stream", name).Msg("[rtsp]")
+				log.WithLevel(level).Err(err).Str("stream", name).Msg("[rtsp]")
 				return
 			}
 
@@ -239,7 +238,7 @@ func tcpHandler(conn *rtsp.Conn) {
 
 	if err := conn.Accept(); err != nil {
 		if err != io.EOF {
-			log.Warn().Err(err).Caller().Send()
+			log.WithLevel(level).Err(err).Caller().Send()
 		}
 		if closer != nil {
 			closer()

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -194,9 +194,11 @@ func tcpHandler(conn *rtsp.Conn) {
 			if err := stream.AddConsumer(conn); err != nil {
 				logEvent := log.Warn()
 
-				if _, ok := err.(*streams.CodecNotMatchedError); ok && strings.HasPrefix(query.Get("source"), "ffmpeg") {
-					// lower codec not matched error for ffmpeg to debug
-					logEvent = log.Debug()
+				if err, ok := err.(*streams.ErrorWithErrorCode); ok {
+					level, parseErr := zerolog.ParseLevel(query.Get(err.Code()))
+					if parseErr == nil {
+						logEvent = log.WithLevel(level)
+					}
 				}
 
 				logEvent.Err(err).Str("stream", name).Msg("[rtsp]")

--- a/internal/streams/add_consumer.go
+++ b/internal/streams/add_consumer.go
@@ -130,25 +130,10 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 
 	// 2. Return "codecs not matched"
 	if prodMedias != nil {
-		var prod, cons string
-
-		for _, media := range prodMedias {
-			if media.Direction == core.DirectionRecvonly {
-				for _, codec := range media.Codecs {
-					prod = appendString(prod, codec.PrintName())
-				}
-			}
+		return &CodecNotMatchedError{
+			producerMedias: prodMedias,
+			consumerMedias: consMedias,
 		}
-
-		for _, media := range consMedias {
-			if media.Direction == core.DirectionSendonly {
-				for _, codec := range media.Codecs {
-					cons = appendString(cons, codec.PrintName())
-				}
-			}
-		}
-
-		return errors.New("streams: codecs not matched: " + prod + " => " + cons)
 	}
 
 	// 3. Return unknown error
@@ -163,4 +148,31 @@ func appendString(s, elem string) string {
 		return elem
 	}
 	return s + ", " + elem
+}
+
+type CodecNotMatchedError struct {
+	producerMedias []*core.Media
+	consumerMedias []*core.Media
+}
+
+func (e *CodecNotMatchedError) Error() string {
+	var prod, cons string
+
+	for _, media := range e.producerMedias {
+		if media.Direction == core.DirectionRecvonly {
+			for _, codec := range media.Codecs {
+				prod = appendString(prod, codec.PrintName())
+			}
+		}
+	}
+
+	for _, media := range e.consumerMedias {
+		if media.Direction == core.DirectionSendonly {
+			for _, codec := range media.Codecs {
+				cons = appendString(cons, codec.PrintName())
+			}
+		}
+	}
+
+	return "streams: codecs not matched: " + prod + " => " + cons
 }

--- a/internal/streams/add_consumer.go
+++ b/internal/streams/add_consumer.go
@@ -1,6 +1,7 @@
 package streams
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -124,7 +125,7 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 	}
 
 	if len(text) != 0 {
-		return &ErrorWithErrorCode{MultipleErrorCode, "streams: " + text}
+		return errors.New("streams: " + text)
 	}
 
 	// 2. Return "codecs not matched"
@@ -147,11 +148,11 @@ func formatError(consMedias, prodMedias []*core.Media, prodErrors []error) error
 			}
 		}
 
-		return &ErrorWithErrorCode{CodecNotMatchedErrorCode, "streams: codecs not matched: " + prod + " => " + cons}
+		return errors.New("streams: codecs not matched: " + prod + " => " + cons)
 	}
 
 	// 3. Return unknown error
-	return &ErrorWithErrorCode{UnknownErrorCode, "streams: unknown error"}
+	return errors.New("streams: unknown error")
 }
 
 func appendString(s, elem string) string {
@@ -162,25 +163,4 @@ func appendString(s, elem string) string {
 		return elem
 	}
 	return s + ", " + elem
-}
-
-type ErrorCode string
-
-const (
-	CodecNotMatchedErrorCode ErrorCode = "codecNotMatched"
-	MultipleErrorCode        ErrorCode = "multiple"
-	UnknownErrorCode         ErrorCode = "unknown"
-)
-
-type ErrorWithErrorCode struct {
-	code    ErrorCode
-	message string
-}
-
-func (e *ErrorWithErrorCode) Error() string {
-	return e.message
-}
-
-func (e *ErrorWithErrorCode) Code() string {
-	return string(e.code)
 }


### PR DESCRIPTION
In Home Assistant, we add for all streams the following additional line `"ffmpeg:{stream_name}#audio=opus"` to have audio on WebRTC as most cameras are only supporting aac.

If you use a no-audio camera with the above ffmpeg config, you will see anytime you start the stream the following log entry: `09:32:51.973 ERR [rtsp] error="streams: codecs not matched: H264 => ANY" stream=camera.x`

This PR downgrade the level to debug only when ffmpeg is the source of the RTSP stream