### PR TITLE
Improve RTSP server authentication handling and auditing

### DIFF
--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -1,6 +1,7 @@
 package rtsp
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -237,7 +238,10 @@ func tcpHandler(conn *rtsp.Conn) {
 	})
 
 	if err := conn.Accept(); err != nil {
-		if err != io.EOF {
+		if err == rtsp.FailedAuth {
+			rAddr := conn.Connection.RemoteAddr
+			log.Warn().Msg(fmt.Sprintf("[rtsp] failed authentication from %s", rAddr))
+		} else if err != io.EOF {
 			log.WithLevel(level).Err(err).Caller().Send()
 		}
 		if closer != nil {

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -1,6 +1,7 @@
 package rtsp
 
 import (
+	"errors"
 	"io"
 	"net"
 	"net/url"
@@ -237,7 +238,7 @@ func tcpHandler(conn *rtsp.Conn) {
 	})
 
 	if err := conn.Accept(); err != nil {
-		if err == rtsp.FailedAuth {
+		if errors.Is(err, rtsp.FailedAuth) {
 			log.Warn().Str("remote_addr", conn.Connection.RemoteAddr).Msg("[rtsp] failed authentication")
 		} else if err != io.EOF {
 			log.WithLevel(level).Err(err).Caller().Send()

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -1,7 +1,6 @@
 package rtsp
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -239,8 +238,7 @@ func tcpHandler(conn *rtsp.Conn) {
 
 	if err := conn.Accept(); err != nil {
 		if err == rtsp.FailedAuth {
-			rAddr := conn.Connection.RemoteAddr
-			log.Warn().Msg(fmt.Sprintf("[rtsp] failed authentication from %s", rAddr))
+			log.Warn().Str("remote_addr", conn.Connection.RemoteAddr).Msg("[rtsp] failed authentication")
 		} else if err != io.EOF {
 			log.WithLevel(level).Err(err).Caller().Send()
 		}

--- a/pkg/rtsp/server.go
+++ b/pkg/rtsp/server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/AlexxIT/go2rtc/pkg/tcp"
 )
 
+var FailedAuth = errors.New("failed authentication")
+
 func NewServer(conn net.Conn) *Conn {
 	return &Conn{
 		Connection: core.Connection{
@@ -54,7 +56,13 @@ func (c *Conn) Accept() error {
 			if err = c.WriteResponse(res); err != nil {
 				return err
 			}
-			continue
+			if req.Header.Get("Authorization") != "" {
+				// eliminate false positive: ffmpeg sends first request without
+				// authorization header even if the user provides credentials
+				return FailedAuth
+			} else {
+				continue
+			}
 		}
 
 		// Receiver: OPTIONS > DESCRIBE > SETUP... > PLAY > TEARDOWN

--- a/pkg/tcp/auth.go
+++ b/pkg/tcp/auth.go
@@ -85,14 +85,14 @@ func (a *Auth) Write(req *Request) {
 	}
 }
 
-func (a *Auth) Validate(req *Request) bool {
+func (a *Auth) Validate(req *Request) (valid, empty bool) {
 	if a == nil {
-		return true
+		return true, true
 	}
 
 	header := req.Header.Get("Authorization")
 	if header == "" {
-		return false
+		return false, true
 	}
 
 	if a.Method == AuthUnknown {
@@ -100,7 +100,7 @@ func (a *Auth) Validate(req *Request) bool {
 		a.header = "Basic " + B64(a.user, a.pass)
 	}
 
-	return header == a.header
+	return header == a.header, false
 }
 
 func (a *Auth) ReadNone(res *Response) bool {


### PR DESCRIPTION
In the latest version (v1.9.7), when using the RTSP module/server, a client fails authentication silently, which makes it very vulnerable to [RTSP brute force attack](https://github.com/anpa1200/RTSP-brute-force-tool):
- There is no log of failed RTSP authentication
- An attacker can test multiple RTSP requests with different credentials in a single TCP connection

This RP adds "failed auth" logging for rtsp server. In addition, the PR prevents an attacker packs many brute force authentication attempts into one TCP connection. After one authentication failed, the TCP connection will terminate, forcing the attacker to start a new TCP connection for the next brute force attempt, which makes it possible to be identified and blocked by a firewall like [pf](https://home.nuug.no/~peter/pf/en/bruteforce.html).

Note `ffmpeg` and `ffmpeg`-based players, e.g., `mpv`, have a special authentication behavior---even if username/password is provided in the URL, the first request does not include it, resulting in a failed authentication, while all subsequent requests (in the same TCP connection) add the authentication field in the header, resulting in successful authentications.