### PR TITLE
fix(onvif): Add RateControl to fix Unifi Protect integration

### DIFF
--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -172,6 +172,7 @@ func appendProfile(e *Envelope, tag, name string) {
 		<tt:Name>VEC</tt:Name>
 		<tt:Encoding>H264</tt:Encoding>
 		<tt:Resolution><tt:Width>1920</tt:Width><tt:Height>1080</tt:Height></tt:Resolution>
+		<trt:RateControl></trt:RateControl>
 	</tt:VideoEncoderConfiguration>
 </trt:`, tag, `>
 `)


### PR DESCRIPTION
Hey @AlexxIT, I'm moving to Docker after my initial tests. Saw on the [other PR](https://github.com/AlexxIT/go2rtc/pull/1520) that we are missing `RateControl` on the current version. 

Here it is a quick fix !