### PR TITLE
Fix H200 + D230 Doorbell stream

### DIFF
--- a/pkg/tapo/client.go
+++ b/pkg/tapo/client.go
@@ -291,7 +291,7 @@ func dial(req *http.Request, brand, username, password string) (net.Conn, *http.
 	if err != nil {
 		return nil, nil, err
 	}
-	_ = res.Body.Close() // ignore response body
+	_, _ = io.Copy(io.Discard, res.Body) // ignore response body
 
 	auth := res.Header.Get("WWW-Authenticate")
 


### PR DESCRIPTION
As stated in my issue #1174 streaming the D230 doorbell was not possible.

Running firmware versions:
H200: 1.3.6 Build 20240829 rel.71119
D230: 1.1.17 Build 20240731 rel.53511

This PR is implementing the fix suggested by @aprilmaccydee (as stated in https://github.com/AlexxIT/go2rtc/issues/1174#issuecomment-2247587646). So all credits to them for figuring that out and sharing.

Using "io.Copy" reads the full body before discarding it, while "Body.Close()" only closes the body. I am not quite sure, why that makes a difference, but it does.