### PR TITLE
Add Ring camera integration

### DIFF
--- a/internal/ring/init.go
+++ b/internal/ring/init.go
@@ -1,0 +1,47 @@
+package ring
+
+import (
+	"net/http"
+
+	"github.com/AlexxIT/go2rtc/internal/api"
+	"github.com/AlexxIT/go2rtc/internal/streams"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/ring"
+)
+
+func Init() {
+	streams.HandleFunc("ring", func(source string) (core.Producer, error) {
+		return ring.Dial(source)
+	})
+
+	api.HandleFunc("api/ring", apiRing)
+}
+
+func apiRing(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	refreshToken := query.Get("refresh_token")
+
+	ringAPI, err := ring.NewRingRestClient(ring.RefreshTokenAuth{RefreshToken: refreshToken}, nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	devices, err := ringAPI.FetchRingDevices()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var items []*api.Source
+
+	for _, camera := range devices.AllCameras {
+		query.Set("device_id", camera.DeviceID)
+
+		items = append(items, &api.Source{
+			Name: camera.Description, URL: "ring:?" + query.Encode(),
+		})
+	}
+
+	api.ResponseSources(w, items)
+}

--- a/internal/ring/init.go
+++ b/internal/ring/init.go
@@ -84,9 +84,17 @@ func apiRing(w http.ResponseWriter, r *http.Request) {
     var items []*api.Source
     for _, camera := range devices.AllCameras {
         cleanQuery.Set("device_id", camera.DeviceID)
+
+        // Stream source
         items = append(items, &api.Source{
             Name: camera.Description,
             URL:  "ring:?" + cleanQuery.Encode(),
+        })
+
+        // Snapshot source
+        items = append(items, &api.Source{
+            Name: camera.Description + " Snapshot",
+            URL:  "ring:?" + cleanQuery.Encode() + "&snapshot",
         })
     }
 

--- a/internal/ring/init.go
+++ b/internal/ring/init.go
@@ -1,7 +1,9 @@
 package ring
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/streams"
@@ -18,30 +20,75 @@ func Init() {
 }
 
 func apiRing(w http.ResponseWriter, r *http.Request) {
-	query := r.URL.Query()
-	refreshToken := query.Get("refresh_token")
+    query := r.URL.Query()
+    var ringAPI *ring.RingRestClient
+    var err error
 
-	ringAPI, err := ring.NewRingRestClient(ring.RefreshTokenAuth{RefreshToken: refreshToken}, nil)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+    // Check auth method
+    if email := query.Get("email"); email != "" {
+        // Email/Password Flow
+        password := query.Get("password")
+        code := query.Get("code")
 
-	devices, err := ringAPI.FetchRingDevices()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+        ringAPI, err = ring.NewRingRestClient(ring.EmailAuth{
+            Email:    email,
+            Password: password,
+        }, nil)
 
-	var items []*api.Source
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
 
-	for _, camera := range devices.AllCameras {
-		query.Set("device_id", camera.DeviceID)
+        // Try authentication (this will trigger 2FA if needed)
+        if _, err = ringAPI.GetAuth(code); err != nil {
+            if ringAPI.Using2FA {
+                // Return 2FA prompt
+                json.NewEncoder(w).Encode(map[string]interface{}{
+                    "needs_2fa": true,
+                    "prompt":    ringAPI.PromptFor2FA,
+                })
+                return
+            }
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
+    } else {
+        // Refresh Token Flow
+        refreshToken := query.Get("refresh_token")
+        if refreshToken == "" {
+            http.Error(w, "either email/password or refresh_token is required", http.StatusBadRequest)
+            return
+        }
 
-		items = append(items, &api.Source{
-			Name: camera.Description, URL: "ring:?" + query.Encode(),
-		})
-	}
+        ringAPI, err = ring.NewRingRestClient(ring.RefreshTokenAuth{
+            RefreshToken: refreshToken,
+        }, nil)
+        if err != nil {
+            http.Error(w, err.Error(), http.StatusInternalServerError)
+            return
+        }
+    }
 
-	api.ResponseSources(w, items)
+    // Fetch devices
+    devices, err := ringAPI.FetchRingDevices()
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    // Create clean query with only required parameters
+    cleanQuery := url.Values{}
+	cleanQuery.Set("refresh_token", ringAPI.RefreshToken)
+
+    var items []*api.Source
+    for _, camera := range devices.AllCameras {
+        cleanQuery.Set("device_id", camera.DeviceID)
+        items = append(items, &api.Source{
+            Name: camera.Description,
+            URL:  "ring:?" + cleanQuery.Encode(),
+        })
+    }
+
+    api.ResponseSources(w, items)
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/nest"
 	"github.com/AlexxIT/go2rtc/internal/ngrok"
 	"github.com/AlexxIT/go2rtc/internal/onvif"
+	"github.com/AlexxIT/go2rtc/internal/ring"
 	"github.com/AlexxIT/go2rtc/internal/roborock"
 	"github.com/AlexxIT/go2rtc/internal/rtmp"
 	"github.com/AlexxIT/go2rtc/internal/rtsp"
@@ -80,6 +81,7 @@ func main() {
 	mpegts.Init()   // mpegts passive source
 	roborock.Init() // roborock source
 	homekit.Init()  // homekit source
+	ring.Init()	 	// ring source
 	nest.Init()     // nest source
 	bubble.Init()   // bubble source
 	expr.Init()     // expr source

--- a/pkg/ring/api.go
+++ b/pkg/ring/api.go
@@ -1,0 +1,416 @@
+package ring
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"time"
+)
+
+type RefreshTokenAuth struct {
+	RefreshToken string
+}
+
+// AuthConfig represents the decoded refresh token data
+type AuthConfig struct {
+	RT  string `json:"rt"`  // Refresh Token
+	HID string `json:"hid"` // Hardware ID
+}
+
+// AuthTokenResponse represents the response from the authentication endpoint
+type AuthTokenResponse struct {
+    AccessToken		string `json:"access_token"`
+    ExpiresIn		int    `json:"expires_in"`
+    RefreshToken 	string `json:"refresh_token"`
+    Scope       	string `json:"scope"`     // Always "client"
+    TokenType   	string `json:"token_type"` // Always "Bearer"
+}
+
+// SocketTicketRequest represents the request to get a socket ticket
+type SocketTicketResponse struct {
+	Ticket 				string 	`json:"ticket"`
+	ResponseTimestamp 	int64 	`json:"response_timestamp"`
+}
+
+// RingRestClient handles authentication and requests to Ring API
+type RingRestClient struct {
+	httpClient       *http.Client
+	authConfig       *AuthConfig
+	hardwareID       string
+	authToken        *AuthTokenResponse
+	auth           	 RefreshTokenAuth
+	onTokenRefresh   func(string) // Callback when refresh token is updated
+}
+
+// CameraKind represents the different types of Ring cameras
+type CameraKind string
+
+const (
+	Doorbot             CameraKind = "doorbot"
+	Doorbell            CameraKind = "doorbell"
+	DoorbellV3          CameraKind = "doorbell_v3"
+	DoorbellV4          CameraKind = "doorbell_v4"
+	DoorbellV5          CameraKind = "doorbell_v5"
+	DoorbellOyster      CameraKind = "doorbell_oyster"
+	DoorbellPortal      CameraKind = "doorbell_portal"
+	DoorbellScallop     CameraKind = "doorbell_scallop"
+	DoorbellScallopLite CameraKind = "doorbell_scallop_lite"
+	DoorbellGraham      CameraKind = "doorbell_graham_cracker"
+	LpdV1               CameraKind = "lpd_v1"
+	LpdV2               CameraKind = "lpd_v2"
+	LpdV4               CameraKind = "lpd_v4"
+	JboxV1              CameraKind = "jbox_v1"
+	StickupCam          CameraKind = "stickup_cam"
+	StickupCamV3        CameraKind = "stickup_cam_v3"
+	StickupCamElite     CameraKind = "stickup_cam_elite"
+	StickupCamLongfin   CameraKind = "stickup_cam_longfin"
+	StickupCamLunar     CameraKind = "stickup_cam_lunar"
+	SpotlightV2         CameraKind = "spotlightw_v2"
+	HpCamV1             CameraKind = "hp_cam_v1"
+	HpCamV2             CameraKind = "hp_cam_v2"
+	StickupCamV4        CameraKind = "stickup_cam_v4"
+	FloodlightV1        CameraKind = "floodlight_v1"
+	FloodlightV2        CameraKind = "floodlight_v2"
+	FloodlightPro       CameraKind = "floodlight_pro"
+	CocoaCamera         CameraKind = "cocoa_camera"
+	CocoaDoorbell       CameraKind = "cocoa_doorbell"
+	CocoaFloodlight     CameraKind = "cocoa_floodlight"
+	CocoaSpotlight      CameraKind = "cocoa_spotlight"
+	StickupCamMini      CameraKind = "stickup_cam_mini"
+	OnvifCamera         CameraKind = "onvif_camera"
+)
+
+// RingDeviceType represents different types of Ring devices
+type RingDeviceType string
+
+const (
+	IntercomHandsetAudio RingDeviceType = "intercom_handset_audio"
+	OnvifCameraType      RingDeviceType = "onvif_camera"
+)
+
+// CameraData contains common fields for all camera types
+type CameraData struct {
+	ID          float64	`json:"id"`
+	Description string 	`json:"description"`
+	DeviceID    string 	`json:"device_id"`
+	Kind        string 	`json:"kind"`
+	LocationID  string 	`json:"location_id"`
+}
+
+// RingDevicesResponse represents the response from the Ring API
+type RingDevicesResponse struct {
+	Doorbots           []CameraData              `json:"doorbots"`
+	AuthorizedDoorbots []CameraData              `json:"authorized_doorbots"`
+	StickupCams        []CameraData              `json:"stickup_cams"`
+	AllCameras         []CameraData              `json:"all_cameras"`
+	Chimes             []CameraData              `json:"chimes"`
+	Other              []map[string]interface{}  `json:"other"`
+}
+
+const (
+	clientAPIBaseURL    = "https://api.ring.com/clients_api/"
+	deviceAPIBaseURL    = "https://api.ring.com/devices/v1/"
+	commandsAPIBaseURL  = "https://api.ring.com/commands/v1/"
+	appAPIBaseURL       = "https://prd-api-us.prd.rings.solutions/api/v1/"
+	oauthURL           	= "https://oauth.ring.com/oauth/token"
+	apiVersion         	= 11
+	defaultTimeout     	= 20 * time.Second
+	maxRetries        	= 3
+)
+
+// NewRingRestClient creates a new Ring client instance
+func NewRingRestClient(auth RefreshTokenAuth, onTokenRefresh func(string)) (*RingRestClient, error) {
+	client := &RingRestClient{
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		auth:          	auth,
+		onTokenRefresh: onTokenRefresh,
+		hardwareID:   	generateHardwareID(),
+	}
+
+	// check if refresh token is provided
+	if auth.RefreshToken == "" {
+		return nil, fmt.Errorf("refresh token is required")
+	}
+
+	if config, err := parseAuthConfig(auth.RefreshToken); err == nil {
+		client.authConfig = config
+		client.hardwareID = config.HID
+	}
+
+	return client, nil
+}
+
+// Request makes an authenticated request to the Ring API
+func (c *RingRestClient) Request(method, url string, body interface{}) ([]byte, error) {
+	// Ensure we have a valid auth token
+	if err := c.ensureAuth(); err != nil {
+		return nil, fmt.Errorf("authentication failed: %w", err)
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(jsonBody)
+	}
+
+	// Create request
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Authorization", "Bearer "+c.authToken.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("hardware_id", c.hardwareID)
+	req.Header.Set("User-Agent", "android:com.ringapp")
+
+	// Make request with retries
+	var resp *http.Response
+	var responseBody []byte
+	
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		resp, err = c.httpClient.Do(req)
+		if err != nil {
+			if attempt == maxRetries {
+				return nil, fmt.Errorf("request failed after %d retries: %w", maxRetries, err)
+			}
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		defer resp.Body.Close()
+
+		responseBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		// Handle 401 by refreshing auth and retrying
+		if resp.StatusCode == http.StatusUnauthorized {
+			c.authToken = nil // Force token refresh
+			if attempt == maxRetries {
+				return nil, fmt.Errorf("authentication failed after %d retries", maxRetries)
+			}
+			if err := c.ensureAuth(); err != nil {
+				return nil, fmt.Errorf("failed to refresh authentication: %w", err)
+			}
+			req.Header.Set("Authorization", "Bearer "+c.authToken.AccessToken)
+			continue
+		}
+
+		// Handle other error status codes
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(responseBody))
+		}
+
+		break
+	}
+
+	return responseBody, nil
+}
+
+// ensureAuth ensures we have a valid auth token
+func (c *RingRestClient) ensureAuth() error {
+	if c.authToken != nil {
+		return nil
+	}
+
+	var grantData = map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": c.authConfig.RT,
+	}
+
+	// Add common fields
+	grantData["client_id"] = "ring_official_android"
+	grantData["scope"] = "client"
+
+	// Make auth request
+	body, err := json.Marshal(grantData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal auth request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", oauthURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create auth request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("hardware_id", c.hardwareID)
+	req.Header.Set("User-Agent", "android:com.ringapp")
+	req.Header.Set("2fa-support", "true")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("auth request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusPreconditionFailed {
+		return fmt.Errorf("2FA required. Please see documentation for handling 2FA")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("auth request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var authResp AuthTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+		return fmt.Errorf("failed to decode auth response: %w", err)
+	}
+
+	// Update auth config and refresh token
+	c.authToken = &authResp
+	c.authConfig = &AuthConfig{
+		RT:  authResp.RefreshToken,
+		HID: c.hardwareID,
+	}
+
+	// Encode and notify about new refresh token
+	if c.onTokenRefresh != nil {
+		newRefreshToken := encodeAuthConfig(c.authConfig)
+		c.onTokenRefresh(newRefreshToken)
+	}
+
+	return nil
+}
+
+// Helper functions for auth config encoding/decoding
+func parseAuthConfig(refreshToken string) (*AuthConfig, error) {
+	decoded, err := base64.StdEncoding.DecodeString(refreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var config AuthConfig
+	if err := json.Unmarshal(decoded, &config); err != nil {
+		// Handle legacy format where refresh token is the raw token
+		return &AuthConfig{RT: refreshToken}, nil
+	}
+
+	return &config, nil
+}
+
+func encodeAuthConfig(config *AuthConfig) string {
+	jsonBytes, _ := json.Marshal(config)
+	return base64.StdEncoding.EncodeToString(jsonBytes)
+}
+
+// API URL helpers
+func ClientAPI(path string) string {
+	return clientAPIBaseURL + path
+}
+
+func DeviceAPI(path string) string {
+	return deviceAPIBaseURL + path
+}
+
+func CommandsAPI(path string) string {
+	return commandsAPIBaseURL + path
+}
+
+func AppAPI(path string) string {
+	return appAPIBaseURL + path
+}
+
+// FetchRingDevices gets all Ring devices and categorizes them
+func (c *RingRestClient) FetchRingDevices() (*RingDevicesResponse, error) {
+	response, err := c.Request("GET", ClientAPI("ring_devices"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ring devices: %w", err)
+	}
+
+	var devices RingDevicesResponse
+	if err := json.Unmarshal(response, &devices); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal devices response: %w", err)
+	}
+
+	// Process "other" devices
+	var onvifCameras []CameraData
+	var intercoms []CameraData
+
+	for _, device := range devices.Other {
+		kind, ok := device["kind"].(string)
+		if !ok {
+			continue
+		}
+
+		switch RingDeviceType(kind) {
+		case OnvifCameraType:
+			var camera CameraData
+			if deviceJson, err := json.Marshal(device); err == nil {
+				if err := json.Unmarshal(deviceJson, &camera); err == nil {
+					onvifCameras = append(onvifCameras, camera)
+				}
+			}
+		case IntercomHandsetAudio:
+			var intercom CameraData
+			if deviceJson, err := json.Marshal(device); err == nil {
+				if err := json.Unmarshal(deviceJson, &intercom); err == nil {
+					intercoms = append(intercoms, intercom)
+				}
+			}
+		}
+	}
+
+	// Combine all cameras into AllCameras slice
+	allCameras := make([]CameraData, 0)
+	allCameras = append(allCameras, interfaceSlice(devices.Doorbots)...)
+	allCameras = append(allCameras, interfaceSlice(devices.StickupCams)...)
+	allCameras = append(allCameras, interfaceSlice(devices.AuthorizedDoorbots)...)
+	allCameras = append(allCameras, interfaceSlice(onvifCameras)...)
+	allCameras = append(allCameras, interfaceSlice(intercoms)...)
+
+	devices.AllCameras = allCameras
+
+	return &devices, nil
+}
+
+func (c *RingRestClient) GetSocketTicket() (*SocketTicketResponse, error) {
+	response, err := c.Request("POST", AppAPI("clap/ticket/request/signalsocket"), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch socket ticket: %w", err)
+	}
+
+	var ticket SocketTicketResponse
+	if err := json.Unmarshal(response, &ticket); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal socket ticket response: %w", err)
+	}
+
+	return &ticket, nil
+}
+
+func generateHardwareID() string {
+	h := sha256.New()
+	h.Write([]byte("ring-client-go2rtc"))
+	return hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+func interfaceSlice(slice interface{}) []CameraData {
+	s := reflect.ValueOf(slice)
+	if s.Kind() != reflect.Slice {
+		return nil
+	}
+
+	ret := make([]CameraData, s.Len())
+	for i := 0; i < s.Len(); i++ {
+		if camera, ok := s.Index(i).Interface().(CameraData); ok {
+			ret[i] = camera
+		}
+	}
+	return ret
+}

--- a/pkg/ring/client.go
+++ b/pkg/ring/client.go
@@ -1,0 +1,551 @@
+package ring
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/webrtc"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	pion "github.com/pion/webrtc/v3"
+	"github.com/rs/zerolog/log"
+)
+
+type Client struct {
+	conn     	*webrtc.Conn
+	ws       	*websocket.Conn
+	api      	*RingRestClient
+	camera   	*CameraData
+	dialogID 	string
+	sessionID 	string 
+	done      	chan struct{}
+}
+
+type SessionBody struct {
+    DoorbotID int    `json:"doorbot_id"`
+    SessionID string `json:"session_id"`
+}
+
+type AnswerMessage struct {
+    Method string `json:"method"` // "sdp"
+    Body   struct {
+        SessionBody
+        SDP  string `json:"sdp"`
+        Type string `json:"type"` // "answer"
+    } `json:"body"`
+}
+
+type IceCandidateMessage struct {
+    Method string `json:"method"` // "ice"
+    Body   struct {
+        SessionBody
+        Ice       string 	`json:"ice"`
+        MLineIndex int    	`json:"mlineindex"`
+    } `json:"body"`
+}
+
+type SessionMessage struct {
+    Method string     	`json:"method"` // "session_created" or "session_started"
+    Body   SessionBody 	`json:"body"`
+}
+
+type PongMessage struct {
+    Method string     	`json:"method"` // "pong"
+    Body   SessionBody 	`json:"body"`
+}
+
+type NotificationMessage struct {
+    Method string `json:"method"` // "notification"
+    Body   struct {
+        SessionBody
+        IsOK bool   `json:"is_ok"`
+        Text string `json:"text"`
+    } `json:"body"`
+}
+
+type StreamInfoMessage struct {
+    Method string `json:"method"` // "stream_info"
+    Body   struct {
+        SessionBody
+        Transcoding       bool   `json:"transcoding"`
+        TranscodingReason string `json:"transcoding_reason"`
+    } `json:"body"`
+}
+
+type CloseMessage struct {
+    Method string `json:"method"` // "close"
+    Body   struct {
+        SessionBody
+        Reason struct {
+            Code int    `json:"code"`
+            Text string `json:"text"`
+        } `json:"reason"`
+    } `json:"body"`
+}
+
+type BaseMessage struct {
+    Method string          `json:"method"`
+    Body   map[string]any  `json:"body"`
+}
+
+// Close reason codes
+const (
+    CloseReasonNormalClose        	= 0
+    CloseReasonAuthenticationFailed = 5
+    CloseReasonTimeout           	= 6
+)
+
+func Dial(rawURL string) (*Client, error) {
+	// 1. Create Ring Rest API client
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	query := u.Query()
+	encodedToken := query.Get("refresh_token")
+	deviceID := query.Get("device_id")
+
+	if encodedToken == "" || deviceID == "" {
+		return nil, errors.New("ring: wrong query")
+	}
+
+	// URL-decode the refresh token
+	refreshToken, err := url.QueryUnescape(encodedToken)
+	if err != nil {
+		return nil, fmt.Errorf("ring: invalid refresh token encoding: %w", err)
+	}
+
+	println("Connecting to Ring WebSocket")
+	println("Refresh Token: ", refreshToken)
+	println("Device ID: ", deviceID)
+
+	// Initialize Ring API client
+	ringAPI, err := NewRingRestClient(RefreshTokenAuth{RefreshToken: refreshToken}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get camera details
+	devices, err := ringAPI.FetchRingDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	var camera *CameraData
+	for _, cam := range devices.AllCameras {
+		if fmt.Sprint(cam.DeviceID) == deviceID {
+			camera = &cam
+			break
+		}
+	}
+	if camera == nil {
+		return nil, errors.New("ring: camera not found")
+	}
+
+	// 2. Connect to signaling server
+	ticket, err := ringAPI.GetSocketTicket()
+	if err != nil {
+		return nil, err
+	}
+
+	println("WebSocket Ticket: ", ticket.Ticket)
+	println("WebSocket ResponseTimestamp: ", ticket.ResponseTimestamp)
+
+	// Create WebSocket connection
+	wsURL := fmt.Sprintf("wss://api.prod.signalling.ring.devices.a2z.com/ws?api_version=4.0&auth_type=ring_solutions&client_id=ring_site-%s&token=%s",
+		uuid.NewString(), url.QueryEscape(ticket.Ticket))
+
+	println("WebSocket URL: ", wsURL)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, map[string][]string{
+		"User-Agent": {"android:com.ringapp"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	println("WebSocket handshake completed successfully")
+
+	// 3. Create Peer Connection
+	println("Creating Peer Connection")
+
+	conf := pion.Configuration{
+		ICEServers: []pion.ICEServer{
+			{URLs: []string{
+				"stun:stun.kinesisvideo.us-east-1.amazonaws.com:443",
+				"stun:stun.kinesisvideo.us-east-2.amazonaws.com:443",
+				"stun:stun.kinesisvideo.us-west-2.amazonaws.com:443",
+				"stun:stun.l.google.com:19302",
+				"stun:stun1.l.google.com:19302",
+				"stun:stun2.l.google.com:19302",
+				"stun:stun3.l.google.com:19302",
+				"stun:stun4.l.google.com:19302",
+			}},
+		},
+		ICETransportPolicy: pion.ICETransportPolicyAll,
+        BundlePolicy: pion.BundlePolicyBalanced,
+	}
+
+	api, err := webrtc.NewAPI()
+	if err != nil {
+		println("Failed to create WebRTC API")
+		conn.Close()
+		return nil, err
+	}
+
+	pc, err := api.NewPeerConnection(conf)
+	if err != nil {
+		println("Failed to create Peer Connection")
+		conn.Close()
+		return nil, err
+	}
+
+	println("Peer Connection created")
+
+	// protect from sending ICE candidate before Offer
+	var sendOffer core.Waiter
+
+	// protect from blocking on errors
+	defer sendOffer.Done(nil)
+
+	// waiter will wait PC error or WS error or nil (connection OK)
+	var connState core.Waiter
+
+	prod := webrtc.NewConn(pc)
+	prod.FormatName = "ring/webrtc"
+	prod.Mode = core.ModeActiveProducer
+	prod.Protocol = "ws"
+	prod.URL = rawURL
+
+	client := &Client{
+		ws:       conn,
+		api:      ringAPI,
+		camera:   camera,
+		dialogID: uuid.NewString(),
+		conn:     prod,
+		done:     make(chan struct{}),
+	}
+
+	prod.Listen(func(msg any) {
+		switch msg := msg.(type) {
+		case *pion.ICECandidate:
+			_ = sendOffer.Wait()
+
+			iceCandidate := msg.ToJSON()
+
+			icePayload := map[string]interface{}{
+				"ice": iceCandidate.Candidate,
+				"mlineindex": iceCandidate.SDPMLineIndex,
+			}
+			
+			if err = client.sendSessionMessage("ice", icePayload); err != nil {
+				connState.Done(err)
+				return
+			}
+
+		case pion.PeerConnectionState:
+			switch msg {
+			case pion.PeerConnectionStateConnecting:
+			case pion.PeerConnectionStateConnected:
+				connState.Done(nil)
+			default:
+				connState.Done(errors.New("ring: " + msg.String()))
+			}
+		}
+	})
+
+	// Setup media configuration
+	medias := []*core.Media{
+		{
+			Kind: core.KindAudio,
+			Direction: core.DirectionSendRecv,
+			Codecs: []*core.Codec{
+				{
+					Name: "opus",
+					ClockRate: 48000,
+					Channels: 2,
+				},
+			},
+		},
+		{
+			Kind: core.KindVideo,
+			Direction: core.DirectionRecvonly,
+			Codecs: []*core.Codec{
+				{
+					Name: "H264",
+					ClockRate: 90000,
+				},
+			},
+		},
+	}
+
+	// 4. Create offer
+	offer, err := prod.CreateOffer(medias)
+	if err != nil {
+		println("Failed to create offer")
+		client.Stop()
+		return nil, err
+	}
+
+	println("Offer created")
+	println(offer)
+
+	// 5. Send offer
+	offerPayload := map[string]interface{}{
+		"stream_options": map[string]bool{
+			"audio_enabled": true,
+			"video_enabled": true,
+		},
+		"sdp": offer,
+	}
+
+	if err = client.sendSessionMessage("live_view", offerPayload); err != nil {
+		println("Failed to send live_view message")
+		client.Stop()
+		return nil, err
+	}
+
+	sendOffer.Done(nil)
+
+	// Ring expects a ping message every 5 seconds
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-client.done:
+				return
+			case <-ticker.C:
+				if pc.ConnectionState() == pion.PeerConnectionStateConnected {
+					if err := client.sendSessionMessage("ping", nil); err != nil {
+						println("Failed to send ping:", err)
+						return
+					}
+				}
+			}
+		}
+	}()
+	
+	go func() {
+		var err error
+
+		// will be closed when conn will be closed
+		defer func() {
+			connState.Done(err)
+		}()
+
+		for {
+			select {
+			case <-client.done:
+				return
+			default:
+				var res BaseMessage
+				if err = conn.ReadJSON(&res); err != nil {
+					select {
+					case <-client.done:
+						return
+					default:
+					}
+
+					if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+						println("WebSocket closed normally")
+					} else {
+						println("Failed to read JSON message:", err)
+						client.Stop()
+					}
+					return
+				}
+
+				body, _ := json.Marshal(res.Body)
+				bodyStr := string(body)
+
+				println("Received message:", res.Method)
+				println("Message body:", bodyStr)
+
+				// check if "doorbot_id" is present and matches the camera ID
+				if _, ok := res.Body["doorbot_id"]; !ok {
+					println("Received message without doorbot_id")
+					continue
+				}
+				
+				doorbotID := res.Body["doorbot_id"].(float64)
+				if doorbotID != float64(client.camera.ID) {
+					println("Received message from unknown doorbot:", doorbotID)
+					continue
+				}
+
+				if res.Method == "session_created" || res.Method == "session_started" {
+					if _, ok := res.Body["session_id"]; ok && client.sessionID == "" {
+						client.sessionID = res.Body["session_id"].(string)
+						println("Session established:", client.sessionID)
+					}
+				}
+
+				if _, ok := res.Body["session_id"]; ok {
+					if res.Body["session_id"].(string) != client.sessionID {
+						println("Received message with wrong session ID")
+						continue
+					}
+				}
+
+				rawMsg, _ := json.Marshal(res)
+
+				switch res.Method {
+				case "sdp":
+					// 6. Get answer
+					var msg AnswerMessage
+					if err = json.Unmarshal(rawMsg, &msg); err != nil {
+						println("Failed to parse SDP message:", err)
+						client.Stop()
+						return
+					}
+					if err = prod.SetAnswer(msg.Body.SDP); err != nil {
+						println("Failed to set answer:", err)
+						client.Stop()
+						return
+					}
+					if err = client.activateSession(); err != nil {
+						println("Failed to activate session:", err)
+						client.Stop()
+						return
+					}
+		
+				case "ice":
+					// 7. Continue to receiving candidates
+					var msg IceCandidateMessage
+					if err = json.Unmarshal(rawMsg, &msg); err != nil {
+						println("Failed to parse ICE message:", err)
+						client.Stop()
+						return
+					}
+
+					if err = prod.AddCandidate(msg.Body.Ice); err != nil {
+						client.Stop()
+						return
+					}
+
+				case "close":
+					client.Stop()
+					return
+
+				case "pong":
+					// Ignore
+					continue
+				}
+			}
+		}
+	}()
+
+	if err = connState.Wait(); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (c *Client) activateSession() error {
+	println("Activating session")
+
+	if err := c.sendSessionMessage("activate_session", nil); err != nil {
+		return err
+	}
+
+	streamPayload := map[string]interface{}{
+		"audio_enabled": true,
+		"video_enabled": true,
+	}
+
+	if err := c.sendSessionMessage("stream_options", streamPayload); err != nil {
+		return err
+	}
+
+	println("Session activated")
+
+	return nil
+}
+
+func (c *Client) sendSessionMessage(method string, body map[string]interface{}) error {
+	if body == nil {
+		body = make(map[string]interface{})
+	}
+
+	body["doorbot_id"] = c.camera.ID
+	if c.sessionID != "" {
+		body["session_id"] = c.sessionID
+	}
+
+	msg := map[string]interface{}{
+		"method":    method,
+		"dialog_id": c.dialogID,
+		"body":      body,
+	}
+
+	println("Sending session message:", method)
+
+	if err := c.ws.WriteJSON(msg); err != nil {
+		log.Error().Err(err).Msg("Failed to send JSON message")
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) GetMedias() []*core.Media {
+	println("Getting medias")
+	return c.conn.GetMedias()
+}
+
+func (c *Client) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver, error) {
+	println("Getting track")
+	return c.conn.GetTrack(media, codec)
+}
+
+func (c *Client) AddTrack(media *core.Media, codec *core.Codec, track *core.Receiver) error {
+	println("Adding track")
+	return c.conn.AddTrack(media, codec, track)
+}
+
+func (c *Client) Start() error {
+	println("Starting client")
+	return c.conn.Start()
+}
+
+func (c *Client) Stop() error {
+	select {
+	case <-c.done:
+		return nil
+	default:
+		println("Stopping client")
+		close(c.done)
+	}
+
+	if c.conn != nil {
+		_ = c.conn.Stop()
+		c.conn = nil
+	}
+
+	if c.ws != nil {
+		closePayload := map[string]interface{}{
+			"reason": map[string]interface{}{
+				"code": CloseReasonNormalClose,
+				"text": "",
+			},
+		}
+
+		_ = c.sendSessionMessage("close", closePayload)
+		_ = c.ws.Close()
+		c.ws = nil
+	}
+
+	return nil
+}
+
+func (c *Client) MarshalJSON() ([]byte, error) {
+	return c.conn.MarshalJSON()
+}

--- a/pkg/ring/client.go
+++ b/pkg/ring/client.go
@@ -238,6 +238,11 @@ func Dial(rawURL string) (*Client, error) {
 
 			iceCandidate := msg.ToJSON()
 
+			// skip empty ICE candidates
+			if iceCandidate.Candidate == "" {
+				return
+			}
+
 			icePayload := map[string]interface{}{
 				"ice": iceCandidate.Candidate,
 				"mlineindex": iceCandidate.SDPMLineIndex,
@@ -423,6 +428,12 @@ func Dial(rawURL string) (*Client, error) {
 						println("Failed to parse ICE message:", err)
 						client.Stop()
 						return
+					}
+
+					// check for empty ICE candidate
+					if msg.Body.Ice == "" {
+						println("Received empty ICE candidate")
+						continue
 					}
 
 					if err = prod.AddCandidate(msg.Body.Ice); err != nil {

--- a/pkg/ring/client.go
+++ b/pkg/ring/client.go
@@ -18,7 +18,7 @@ import (
 type Client struct {
 	api      	*RingRestClient
 	ws       	*websocket.Conn
-	prod     	*webrtc.Conn
+	prod     	core.Producer
 	camera   	*CameraData
 	dialogID 	string
 	sessionID 	string 
@@ -101,322 +101,337 @@ const (
 )
 
 func Dial(rawURL string) (*Client, error) {
-	// 1. Create Ring Rest API client
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
+    // 1. Parse URL and validate basic params
+    u, err := url.Parse(rawURL)
+    if err != nil {
+        return nil, err
+    }
 
-	query := u.Query()
-	encodedToken := query.Get("refresh_token")
-	deviceID := query.Get("device_id")
+    query := u.Query()
+    encodedToken := query.Get("refresh_token")
+    deviceID := query.Get("device_id")
+	_, isSnapshot := query["snapshot"]
 
-	if encodedToken == "" || deviceID == "" {
-		return nil, errors.New("ring: wrong query")
-	}
+    if encodedToken == "" || deviceID == "" {
+        return nil, errors.New("ring: wrong query")
+    }
 
-	// URL-decode the refresh token
-	refreshToken, err := url.QueryUnescape(encodedToken)
-	if err != nil {
-		return nil, fmt.Errorf("ring: invalid refresh token encoding: %w", err)
-	}
+    // URL-decode the refresh token
+    refreshToken, err := url.QueryUnescape(encodedToken)
+    if err != nil {
+        return nil, fmt.Errorf("ring: invalid refresh token encoding: %w", err)
+    }
 
-	// Initialize Ring API client
-	ringAPI, err := NewRingRestClient(RefreshTokenAuth{RefreshToken: refreshToken}, nil)
-	if err != nil {
-		return nil, err
-	}
+    // Initialize Ring API client
+    ringAPI, err := NewRingRestClient(RefreshTokenAuth{RefreshToken: refreshToken}, nil)
+    if err != nil {
+        return nil, err
+    }
 
-	// Get camera details
-	devices, err := ringAPI.FetchRingDevices()
-	if err != nil {
-		return nil, err
-	}
+    // Get camera details
+    devices, err := ringAPI.FetchRingDevices()
+    if err != nil {
+        return nil, err
+    }
 
-	var camera *CameraData
-	for _, cam := range devices.AllCameras {
-		if fmt.Sprint(cam.DeviceID) == deviceID {
-			camera = &cam
-			break
-		}
-	}
-	if camera == nil {
-		return nil, errors.New("ring: camera not found")
-	}
+    var camera *CameraData
+    for _, cam := range devices.AllCameras {
+        if fmt.Sprint(cam.DeviceID) == deviceID {
+            camera = &cam
+            break
+        }
+    }
+    if camera == nil {
+        return nil, errors.New("ring: camera not found")
+    }
 
-	// 2. Connect to signaling server
-	ticket, err := ringAPI.GetSocketTicket()
-	if err != nil {
-		return nil, err
-	}
+    // Create base client
+    client := &Client{
+        api:      ringAPI,
+        camera:   camera,
+        dialogID: uuid.NewString(),
+        done:     make(chan struct{}),
+    }
 
-	// Create WebSocket connection
-	wsURL := fmt.Sprintf("wss://api.prod.signalling.ring.devices.a2z.com/ws?api_version=4.0&auth_type=ring_solutions&client_id=ring_site-%s&token=%s",
-		uuid.NewString(), url.QueryEscape(ticket.Ticket))
+    // Check if snapshot request
+    if isSnapshot {
+        client.prod = NewSnapshotProducer(ringAPI, camera)
+        return client, nil
+    }
 
-	ws, _, err := websocket.DefaultDialer.Dial(wsURL, map[string][]string{
-		"User-Agent": {"android:com.ringapp"},
-	})
-	if err != nil {
-		return nil, err
-	}
+    // If not snapshot, continue with WebRTC setup
+    ticket, err := ringAPI.GetSocketTicket()
+    if err != nil {
+        return nil, err
+    }
 
-	// 3. Create Peer Connection
-	conf := pion.Configuration{
-		ICEServers: []pion.ICEServer{
-			{URLs: []string{
-				"stun:stun.kinesisvideo.us-east-1.amazonaws.com:443",
-				"stun:stun.kinesisvideo.us-east-2.amazonaws.com:443",
-				"stun:stun.kinesisvideo.us-west-2.amazonaws.com:443",
-				"stun:stun.l.google.com:19302",
-				"stun:stun1.l.google.com:19302",
-				"stun:stun2.l.google.com:19302",
-				"stun:stun3.l.google.com:19302",
-				"stun:stun4.l.google.com:19302",
-			}},
-		},
-		ICETransportPolicy: pion.ICETransportPolicyAll,
+    // Create WebSocket connection
+    wsURL := fmt.Sprintf("wss://api.prod.signalling.ring.devices.a2z.com/ws?api_version=4.0&auth_type=ring_solutions&client_id=ring_site-%s&token=%s",
+        uuid.NewString(), url.QueryEscape(ticket.Ticket))
+
+    client.ws, _, err = websocket.DefaultDialer.Dial(wsURL, map[string][]string{
+        "User-Agent": {"android:com.ringapp"},
+    })
+    if err != nil {
+        return nil, err
+    }
+
+    // Create Peer Connection
+    conf := pion.Configuration{
+        ICEServers: []pion.ICEServer{
+            {URLs: []string{
+                "stun:stun.kinesisvideo.us-east-1.amazonaws.com:443",
+                "stun:stun.kinesisvideo.us-east-2.amazonaws.com:443",
+                "stun:stun.kinesisvideo.us-west-2.amazonaws.com:443",
+                "stun:stun.l.google.com:19302",
+                "stun:stun1.l.google.com:19302",
+                "stun:stun2.l.google.com:19302",
+                "stun:stun3.l.google.com:19302",
+                "stun:stun4.l.google.com:19302",
+            }},
+        },
+        ICETransportPolicy: pion.ICETransportPolicyAll,
         BundlePolicy: pion.BundlePolicyBalanced,
-	}
+    }
 
-	api, err := webrtc.NewAPI()
-	if err != nil {
-		ws.Close()
-		return nil, err
-	}
+    api, err := webrtc.NewAPI()
+    if err != nil {
+        client.ws.Close()
+        return nil, err
+    }
 
-	pc, err := api.NewPeerConnection(conf)
-	if err != nil {
-		ws.Close()
-		return nil, err
-	}
+    pc, err := api.NewPeerConnection(conf)
+    if err != nil {
+        client.ws.Close()
+        return nil, err
+    }
 
-	// protect from sending ICE candidate before Offer
-	var sendOffer core.Waiter
+    // protect from sending ICE candidate before Offer
+    var sendOffer core.Waiter
 
-	// protect from blocking on errors
-	defer sendOffer.Done(nil)
+    // protect from blocking on errors
+    defer sendOffer.Done(nil)
 
-	// waiter will wait PC error or WS error or nil (connection OK)
-	var connState core.Waiter
+    // waiter will wait PC error or WS error or nil (connection OK)
+    var connState core.Waiter
 
-	prod := webrtc.NewConn(pc)
-	prod.FormatName = "ring/webrtc"
-	prod.Mode = core.ModeActiveProducer
-	prod.Protocol = "ws"
-	prod.URL = rawURL
+    prod := webrtc.NewConn(pc)
+    prod.FormatName = "ring/webrtc"
+    prod.Mode = core.ModeActiveProducer
+    prod.Protocol = "ws"
+    prod.URL = rawURL
 
-	client := &Client{
-		api:      ringAPI,
-		ws:       ws,
-		prod:     prod,
-		camera:   camera,
-		dialogID: uuid.NewString(),
-		done:     make(chan struct{}),
-	}
+    client.prod = prod
 
-	prod.Listen(func(msg any) {
-		switch msg := msg.(type) {
-		case *pion.ICECandidate:
-			_ = sendOffer.Wait()
+    prod.Listen(func(msg any) {
+        switch msg := msg.(type) {
+        case *pion.ICECandidate:
+            _ = sendOffer.Wait()
 
-			iceCandidate := msg.ToJSON()
+            iceCandidate := msg.ToJSON()
 
-			// skip empty ICE candidates
-			if iceCandidate.Candidate == "" {
-				return
-			}
+            // skip empty ICE candidates
+            if iceCandidate.Candidate == "" {
+                return
+            }
 
-			icePayload := map[string]interface{}{
-				"ice": iceCandidate.Candidate,
-				"mlineindex": iceCandidate.SDPMLineIndex,
-			}
-			
-			if err = client.sendSessionMessage("ice", icePayload); err != nil {
-				connState.Done(err)
-				return
-			}
+            icePayload := map[string]interface{}{
+                "ice": iceCandidate.Candidate,
+                "mlineindex": iceCandidate.SDPMLineIndex,
+            }
+            
+            if err = client.sendSessionMessage("ice", icePayload); err != nil {
+                connState.Done(err)
+                return
+            }
 
-		case pion.PeerConnectionState:
-			switch msg {
-			case pion.PeerConnectionStateConnecting:
-			case pion.PeerConnectionStateConnected:
-				connState.Done(nil)
-			default:
-				connState.Done(errors.New("ring: " + msg.String()))
-			}
-		}
-	})
+        case pion.PeerConnectionState:
+            switch msg {
+            case pion.PeerConnectionStateConnecting:
+            case pion.PeerConnectionStateConnected:
+                connState.Done(nil)
+            default:
+                connState.Done(errors.New("ring: " + msg.String()))
+            }
+        }
+    })
 
-	// Setup media configuration
-	medias := []*core.Media{
-		{
-			Kind: core.KindAudio,
-			Direction: core.DirectionSendRecv,
-			Codecs: []*core.Codec{
-				{
-					Name: "opus",
-					ClockRate: 48000,
-					Channels: 2,
-				},
-			},
-		},
-		{
-			Kind: core.KindVideo,
-			Direction: core.DirectionRecvonly,
-			Codecs: []*core.Codec{
-				{
-					Name: "H264",
-					ClockRate: 90000,
-				},
-			},
-		},
-	}
+    // Setup media configuration
+    medias := []*core.Media{
+        {
+            Kind: core.KindAudio,
+            Direction: core.DirectionSendRecv,
+            Codecs: []*core.Codec{
+                {
+                    Name: "opus",
+                    ClockRate: 48000,
+                    Channels: 2,
+                },
+            },
+        },
+        {
+            Kind: core.KindVideo,
+            Direction: core.DirectionRecvonly,
+            Codecs: []*core.Codec{
+                {
+                    Name: "H264",
+                    ClockRate: 90000,
+                },
+            },
+        },
+    }
 
-	// 4. Create offer
-	offer, err := prod.CreateOffer(medias)
-	if err != nil {
-		client.Stop()
-		return nil, err
-	}
+    // Create offer
+    offer, err := prod.CreateOffer(medias)
+    if err != nil {
+        client.Stop()
+        return nil, err
+    }
 
-	// 5. Send offer
-	offerPayload := map[string]interface{}{
-		"stream_options": map[string]bool{
-			"audio_enabled": true,
-			"video_enabled": true,
-		},
-		"sdp": offer,
-	}
+    // Send offer
+    offerPayload := map[string]interface{}{
+        "stream_options": map[string]bool{
+            "audio_enabled": true,
+            "video_enabled": true,
+        },
+        "sdp": offer,
+    }
 
-	if err = client.sendSessionMessage("live_view", offerPayload); err != nil {
-		client.Stop()
-		return nil, err
-	}
+    if err = client.sendSessionMessage("live_view", offerPayload); err != nil {
+        client.Stop()
+        return nil, err
+    }
 
-	sendOffer.Done(nil)
+    sendOffer.Done(nil)
 
-	// Ring expects a ping message every 5 seconds
-	go func() {
-		ticker := time.NewTicker(5 * time.Second)
-		defer ticker.Stop()
+    // Ring expects a ping message every 5 seconds
+    go client.startPingLoop(pc)
+    go client.startMessageLoop(&connState)
 
-		for {
-			select {
-			case <-client.done:
-				return
-			case <-ticker.C:
-				if pc.ConnectionState() == pion.PeerConnectionStateConnected {
-					if err := client.sendSessionMessage("ping", nil); err != nil {
-						return
-					}
-				}
-			}
-		}
-	}()
-	
-	go func() {
-		var err error
+    if err = connState.Wait(); err != nil {
+        return nil, err
+    }
 
-		// will be closed when conn will be closed
-		defer func() {
-			connState.Done(err)
-		}()
+    return client, nil
+}
 
-		for {
-			select {
-			case <-client.done:
-				return
-			default:
-				var res BaseMessage
-				if err = ws.ReadJSON(&res); err != nil {
-					select {
-					case <-client.done:
-						return
-					default:
-					}
+func (c *Client) startPingLoop(pc *pion.PeerConnection) {
+    ticker := time.NewTicker(5 * time.Second)
+    defer ticker.Stop()
 
-					client.Stop()
-					return
-				}
+    for {
+        select {
+        case <-c.done:
+            return
+        case <-ticker.C:
+            if pc.ConnectionState() == pion.PeerConnectionStateConnected {
+                if err := c.sendSessionMessage("ping", nil); err != nil {
+                    return
+                }
+            }
+        }
+    }
+}
 
-				// check if "doorbot_id" is present
-				if _, ok := res.Body["doorbot_id"]; !ok {
-					continue
-				}
-				
-				// check if the message is from the correct doorbot
-				doorbotID := res.Body["doorbot_id"].(float64)
-				if doorbotID != float64(client.camera.ID) {
-					continue
-				}
+func (c *Client) startMessageLoop(connState *core.Waiter) {
+    var err error
 
-				// check if the message is from the correct session
-				if res.Method == "session_created" || res.Method == "session_started" {
-					if _, ok := res.Body["session_id"]; ok && client.sessionID == "" {
-						client.sessionID = res.Body["session_id"].(string)
-					}
-				}
+    // will be closed when conn will be closed
+    defer func() {
+        connState.Done(err)
+    }()
 
-				if _, ok := res.Body["session_id"]; ok {
-					if res.Body["session_id"].(string) != client.sessionID {
-						continue
-					}
-				}
+    for {
+        select {
+        case <-c.done:
+            return
+        default:
+            var res BaseMessage
+            if err = c.ws.ReadJSON(&res); err != nil {
+                select {
+                case <-c.done:
+                    return
+                default:
+                }
 
-				rawMsg, _ := json.Marshal(res)
+                c.Stop()
+                return
+            }
 
-				switch res.Method {
-				case "sdp":
-					// 6. Get answer
-					var msg AnswerMessage
-					if err = json.Unmarshal(rawMsg, &msg); err != nil {
-						client.Stop()
-						return
-					}
-					if err = prod.SetAnswer(msg.Body.SDP); err != nil {
-						client.Stop()
-						return
-					}
-					if err = client.activateSession(); err != nil {
-						client.Stop()
-						return
-					}
-		
-				case "ice":
-					// 7. Continue to receiving candidates
-					var msg IceCandidateMessage
-					if err = json.Unmarshal(rawMsg, &msg); err != nil {
-						break
-					}
+            // check if "doorbot_id" is present
+            if _, ok := res.Body["doorbot_id"]; !ok {
+                continue
+            }
+            
+            // check if the message is from the correct doorbot
+            doorbotID := res.Body["doorbot_id"].(float64)
+            if doorbotID != float64(c.camera.ID) {
+                continue
+            }
 
-					// check for empty ICE candidate
-					if msg.Body.Ice == "" {
-						break
-					}
+            // check if the message is from the correct session
+            if res.Method == "session_created" || res.Method == "session_started" {
+                if _, ok := res.Body["session_id"]; ok && c.sessionID == "" {
+                    c.sessionID = res.Body["session_id"].(string)
+                }
+            }
 
-					if err = prod.AddCandidate(msg.Body.Ice); err != nil {
-						client.Stop()
-						return
-					}
+            if _, ok := res.Body["session_id"]; ok {
+                if res.Body["session_id"].(string) != c.sessionID {
+                    continue
+                }
+            }
 
-				case "close":
-					client.Stop()
-					return
+            rawMsg, _ := json.Marshal(res)
 
-				case "pong":
-					// Ignore
-					continue
-				}
-			}
-		}
-	}()
+            switch res.Method {
+            case "sdp":
+                if prod, ok := c.prod.(*webrtc.Conn); ok {
+                    // Get answer
+                    var msg AnswerMessage
+                    if err = json.Unmarshal(rawMsg, &msg); err != nil {
+                        c.Stop()
+                        return
+                    }
+                    if err = prod.SetAnswer(msg.Body.SDP); err != nil {
+                        c.Stop()
+                        return
+                    }
+                    if err = c.activateSession(); err != nil {
+                        c.Stop()
+                        return
+                    }
+                }
+    
+            case "ice":
+                if prod, ok := c.prod.(*webrtc.Conn); ok {
+                    // Continue to receiving candidates
+                    var msg IceCandidateMessage
+                    if err = json.Unmarshal(rawMsg, &msg); err != nil {
+                        break
+                    }
 
-	if err = connState.Wait(); err != nil {
-		return nil, err
-	}
+                    // check for empty ICE candidate
+                    if msg.Body.Ice == "" {
+                        break
+                    }
 
-	return client, nil
+                    if err = prod.AddCandidate(msg.Body.Ice); err != nil {
+                        c.Stop()
+                        return
+                    }
+                }
+
+            case "close":
+                c.Stop()
+                return
+
+            case "pong":
+                // Ignore
+                continue
+            }
+        }
+    }
 }
 
 func (c *Client) activateSession() error {
@@ -471,16 +486,18 @@ func (c *Client) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver,
 }
 
 func (c *Client) AddTrack(media *core.Media, codec *core.Codec, track *core.Receiver) error {
-	if media.Kind == core.KindAudio {
-		// Enable speaker
-		speakerPayload := map[string]interface{}{
-			"stealth_mode": false,
-		}
+    if webrtcProd, ok := c.prod.(*webrtc.Conn); ok {
+        if media.Kind == core.KindAudio {
+            // Enable speaker
+            speakerPayload := map[string]interface{}{
+                "stealth_mode": false,
+            }
+            _ = c.sendSessionMessage("camera_options", speakerPayload)
+        }
+        return webrtcProd.AddTrack(media, codec, track)
+    }
 
-		_ = c.sendSessionMessage("camera_options", speakerPayload);
-	}
-
-    return c.prod.AddTrack(media, codec, track)
+    return fmt.Errorf("add track not supported for snapshot")
 }
 
 func (c *Client) Start() error {
@@ -517,5 +534,9 @@ func (c *Client) Stop() error {
 }
 
 func (c *Client) MarshalJSON() ([]byte, error) {
-	return c.prod.MarshalJSON()
+    if webrtcProd, ok := c.prod.(*webrtc.Conn); ok {
+        return webrtcProd.MarshalJSON()
+    }
+	
+	return nil, errors.New("ring: can't marshal")
 }

--- a/pkg/ring/snapshot.go
+++ b/pkg/ring/snapshot.go
@@ -1,0 +1,64 @@
+package ring
+
+import (
+	"fmt"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
+)
+
+type SnapshotProducer struct {
+    core.Connection
+
+    client  *RingRestClient
+    camera  *CameraData
+}
+
+func NewSnapshotProducer(client *RingRestClient, camera *CameraData) *SnapshotProducer {
+    return &SnapshotProducer{
+        Connection: core.Connection{
+            ID:         core.NewID(),
+            FormatName: "ring/snapshot",
+            Protocol:   "https",
+            Medias: []*core.Media{
+                {
+                    Kind:      core.KindVideo,
+                    Direction: core.DirectionRecvonly,
+                    Codecs: []*core.Codec{
+                        {
+                            Name:        core.CodecJPEG,
+                            ClockRate:   90000,
+                            PayloadType: core.PayloadTypeRAW,
+                        },
+                    },
+                },
+            },
+        },
+        client: client,
+        camera: camera,
+    }
+}
+
+func (p *SnapshotProducer) Start() error {
+    // Fetch snapshot
+    response, err := p.client.Request("GET", fmt.Sprintf("https://app-snaps.ring.com/snapshots/next/%d", int(p.camera.ID)), nil)
+    if err != nil {
+        return fmt.Errorf("failed to get snapshot: %w", err)
+    }
+
+    pkt := &rtp.Packet{
+        Header:  rtp.Header{Timestamp: core.Now90000()},
+        Payload: response,
+    }
+
+    // Send to all receivers
+	for _, receiver := range p.Receivers {
+        receiver.WriteRTP(pkt)
+    }
+
+    return nil
+}
+
+func (p *SnapshotProducer) Stop() error {
+    return p.Connection.Stop()
+}

--- a/www/add.html
+++ b/www/add.html
@@ -220,7 +220,16 @@
 
 <button id="ring">Ring</button>
 <div class="module">
-    <form id="ring-form" style="margin-bottom: 10px">
+    <form id="ring-credentials-form" style="margin-bottom: 10px">
+        <input type="email" name="email" placeholder="email">
+        <input type="password" name="password" placeholder="password">
+        <div id="tfa-field" style="display: none">
+            <input type="text" name="code" placeholder="2FA code">
+            <div id="tfa-prompt"></div>
+        </div>
+        <input type="submit" value="Login">
+    </form>
+    <form id="ring-token-form" style="margin-bottom: 10px">
         <input type="text" name="refresh_token" placeholder="refresh_token">
         <input type="submit" value="Login">
     </form>
@@ -231,15 +240,32 @@
         ev.target.nextElementSibling.style.display = 'block';
     });
 
-    document.getElementById('ring-form').addEventListener('submit', async ev => {
+    async function handleRingAuth(ev) {
         ev.preventDefault();
-
         const query = new URLSearchParams(new FormData(ev.target));
         const url = new URL('api/ring?' + query.toString(), location.href);
 
         const r = await fetch(url, {cache: 'no-cache'});
-        await getSources('ring-table', r);
-    });
+        const data = await r.json();
+        
+        if (data.needs_2fa) {
+            document.getElementById('tfa-field').style.display = 'block';
+            document.getElementById('tfa-prompt').textContent = data.prompt || 'Enter 2FA code';
+            return;
+        }
+
+        if (!r.ok) {
+            const table = document.getElementById('ring-table');
+            table.innerText = data.error || 'Unknown error';
+            return;
+        }
+
+        const table = document.getElementById('ring-table');
+        drawTable(table, data);
+    }
+
+    document.getElementById('ring-credentials-form').addEventListener('submit', handleRingAuth);
+    document.getElementById('ring-token-form').addEventListener('submit', handleRingAuth);
 </script>
 
 <button id="gopro">GoPro</button>

--- a/www/add.html
+++ b/www/add.html
@@ -35,7 +35,7 @@
     function drawTable(table, data) {
         const cols = ['id', 'name', 'info', 'url', 'location'];
         const th = (row) => cols.reduce((html, k) => k in row ? `${html}<th>${k}</th>` : html, '<tr>') + '</tr>';
-        const td = (row) => cols.reduce((html, k) => k in row ? `${html}<td>${row[k]}</td>` : html, '<tr>') + '</tr>';
+        const td = (row) => cols.reduce((html, k) => k in row ? `${html}<td style="word-break: break-word;white-space: normal;">${row[k]}</td>` : html, '<tr>') + '</tr>';
 
         const thead = th(data.sources[0]);
         const tbody = data.sources.reduce((html, source) => `${html}${td(source)}`, '');
@@ -218,6 +218,29 @@
     });
 </script>
 
+<button id="ring">Ring</button>
+<div class="module">
+    <form id="ring-form" style="margin-bottom: 10px">
+        <input type="text" name="refresh_token" placeholder="refresh_token">
+        <input type="submit" value="Login">
+    </form>
+    <table id="ring-table"></table>
+</div>
+<script>
+    document.getElementById('ring').addEventListener('click', async ev => {
+        ev.target.nextElementSibling.style.display = 'block';
+    });
+
+    document.getElementById('ring-form').addEventListener('submit', async ev => {
+        ev.preventDefault();
+
+        const query = new URLSearchParams(new FormData(ev.target));
+        const url = new URL('api/ring?' + query.toString(), location.href);
+
+        const r = await fetch(url, {cache: 'no-cache'});
+        await getSources('ring-table', r);
+    });
+</script>
 
 <button id="gopro">GoPro</button>
 <div class="module">


### PR DESCRIPTION
Added Ring camera integration that allows users to connect their Ring cameras. Users can authenticate either via email/password (including 2FA support) or by providing a refresh token. (see below)

![go2rtc_ring](https://github.com/user-attachments/assets/0a1f5b0a-f0ea-4fa7-9671-3222408bc1b5)

After successful authentication, all available Ring cameras are displayed with their corresponding source configuration (`ring:?device_id=XXX&refresh_token=XXX`). These source configurations can then be used to add individual Ring cameras to go2rtc, which handles the WebRTC connection to stream the camera feed. Two-Way audio is also supported.

A separate producer was added for snapshot endpoints (`ring:?device_id=XXX&refresh_token=XXX&snapshot`) to directly obtain a snapshot from the Ring API

The Ring integration implementation is based on the [ring-client-api](https://github.com/dgreif/ring) library

<hr>

Question: When making requests to Ring's API, sometimes a new refresh token is returned. What would be the best approach to handle and persist these updated refresh tokens in go2rtc's configuration @AlexxIT  ?

Regarding to [ring-client-api wiki](https://github.com/dgreif/ring/wiki/Refresh-Tokens#refresh-token-updates), it is only important for push notification, which is not used here..

> @ring-client-api
> It may seem possible to simply re-use the initially generated token multiple times, and indeed it will generally work for authentication even if newer tokens are not saved...