### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,14 +102,14 @@ jobs:
         env: { GOOS: freebsd, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_freebsd_amd64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_freebsd_amd64, path: go2rtc }
 
       - name: Build go2rtc_freebsd_arm64
         env: { GOOS: freebsd, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_freebsd_arm64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: { name: go2rtc_freebsd_arm64, path: go2rtc }
 
   docker-master:


### PR DESCRIPTION
Fix:

Build binaries
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/