### PR TITLE
﻿Add client for SwitchBot Camera WebRTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,13 +682,18 @@ Supports connection to [Wyze](https://www.wyze.com/) cameras, using WebRTC proto
 
 Supports [Amazon Kinesis Video Streams](https://aws.amazon.com/kinesis/video-streams/), using WebRTC protocol. You need to specify signalling WebSocket URL with all credentials in query params, `client_id` and `ice_servers` list in [JSON format](https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer).
 
+**switchbot**
+
+Support connection to [SwitchBot](https://us.switch-bot.com/) cameras that are based on Kinesis Video Streams. Specifically, this includes [Pan/Tilt Cam Plus 2K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-2k) and [Pan/Tilt Cam Plus 3K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-3k). (`Outdoor Spotlight Cam 1080P`,`Outdoor Spotlight Cam 2K`, `Pan/Tilt Cam`,`Pan/Tilt Cam 2K`, `Indoor Cam` are based on Tuya, so this feature is not available .)
+
 ```yaml
 streams:
-  webrtc-whep:    webrtc:http://192.168.1.123:1984/api/webrtc?src=camera1
-  webrtc-go2rtc:  webrtc:ws://192.168.1.123:1984/api/ws?src=camera1
-  webrtc-openipc: webrtc:ws://192.168.1.123/webrtc_ws#format=openipc#ice_servers=[{"urls":"stun:stun.kinesisvideo.eu-north-1.amazonaws.com:443"}]
-  webrtc-wyze:    webrtc:http://192.168.1.123:5000/signaling/camera1?kvs#format=wyze
-  webrtc-kinesis: webrtc:wss://...amazonaws.com/?...#format=kinesis#client_id=...#ice_servers=[{...},{...}]
+  webrtc-whep:               webrtc:http://192.168.1.123:1984/api/webrtc?src=camera1
+  webrtc-go2rtc:             webrtc:ws://192.168.1.123:1984/api/ws?src=camera1
+  webrtc-openipc:            webrtc:ws://192.168.1.123/webrtc_ws#format=openipc#ice_servers=[{"urls":"stun:stun.kinesisvideo.eu-north-1.amazonaws.com:443"}]
+  webrtc-wyze:               webrtc:http://192.168.1.123:5000/signaling/camera1?kvs#format=wyze
+  webrtc-kinesis:            webrtc:wss://...amazonaws.com/?...#format=kinesis#client_id=...#ice_servers=[{...},{...}]
+  webrtc-switchbot:          webrtc:wss://...amazonaws.com/?...#format=switchbot#resolution=HD#client_id=...#ice_servers=[{...},{...}]
 ```
 
 **PS.** For `kinesis` sources you can use [echo](#source-echo) to get connection params using `bash`/`python` or any other script language.

--- a/README.md
+++ b/README.md
@@ -684,16 +684,16 @@ Supports [Amazon Kinesis Video Streams](https://aws.amazon.com/kinesis/video-str
 
 **switchbot**
 
-Support connection to [SwitchBot](https://us.switch-bot.com/) cameras that are based on Kinesis Video Streams. Specifically, this includes [Pan/Tilt Cam Plus 2K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-2k) and [Pan/Tilt Cam Plus 3K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-3k). (`Outdoor Spotlight Cam 1080P`,`Outdoor Spotlight Cam 2K`, `Pan/Tilt Cam`,`Pan/Tilt Cam 2K`, `Indoor Cam` are based on Tuya, so this feature is not available .)
+Support connection to [SwitchBot](https://us.switch-bot.com/) cameras that are based on Kinesis Video Streams. Specifically, this includes [Pan/Tilt Cam Plus 2K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-2k) and [Pan/Tilt Cam Plus 3K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-3k). `Outdoor Spotlight Cam 1080P`, `Outdoor Spotlight Cam 2K`, `Pan/Tilt Cam`, `Pan/Tilt Cam 2K`, `Indoor Cam` are based on Tuya, so this feature is not available.
 
 ```yaml
 streams:
-  webrtc-whep:               webrtc:http://192.168.1.123:1984/api/webrtc?src=camera1
-  webrtc-go2rtc:             webrtc:ws://192.168.1.123:1984/api/ws?src=camera1
-  webrtc-openipc:            webrtc:ws://192.168.1.123/webrtc_ws#format=openipc#ice_servers=[{"urls":"stun:stun.kinesisvideo.eu-north-1.amazonaws.com:443"}]
-  webrtc-wyze:               webrtc:http://192.168.1.123:5000/signaling/camera1?kvs#format=wyze
-  webrtc-kinesis:            webrtc:wss://...amazonaws.com/?...#format=kinesis#client_id=...#ice_servers=[{...},{...}]
-  webrtc-switchbot:          webrtc:wss://...amazonaws.com/?...#format=switchbot#resolution=HD#client_id=...#ice_servers=[{...},{...}]
+  webrtc-whep:      webrtc:http://192.168.1.123:1984/api/webrtc?src=camera1
+  webrtc-go2rtc:    webrtc:ws://192.168.1.123:1984/api/ws?src=camera1
+  webrtc-openipc:   webrtc:ws://192.168.1.123/webrtc_ws#format=openipc#ice_servers=[{"urls":"stun:stun.kinesisvideo.eu-north-1.amazonaws.com:443"}]
+  webrtc-wyze:      webrtc:http://192.168.1.123:5000/signaling/camera1?kvs#format=wyze
+  webrtc-kinesis:   webrtc:wss://...amazonaws.com/?...#format=kinesis#client_id=...#ice_servers=[{...},{...}]
+  webrtc-switchbot: webrtc:wss://...amazonaws.com/?...#format=switchbot#resolution=hd#client_id=...#ice_servers=[{...},{...}]
 ```
 
 **PS.** For `kinesis` sources you can use [echo](#source-echo) to get connection params using `bash`/`python` or any other script language.

--- a/internal/webrtc/client.go
+++ b/internal/webrtc/client.go
@@ -41,9 +41,11 @@ func streamsHandler(rawURL string) (core.Producer, error) {
 				// https://aws.amazon.com/kinesis/video-streams/
 				// https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/what-is-kvswebrtc.html
 				// https://github.com/orgs/awslabs/repositories?q=kinesis+webrtc
-				return kinesisClient(rawURL, query, "webrtc/kinesis")
+				return kinesisClient(rawURL, query, "webrtc/kinesis", &kinesisClientOpts{})
 			} else if format == "openipc" {
 				return openIPCClient(rawURL, query)
+			} else if format == "switchbot" {
+				return switchbotClient(rawURL, query)
 			} else {
 				return go2rtcClient(rawURL)
 			}

--- a/internal/webrtc/client.go
+++ b/internal/webrtc/client.go
@@ -41,7 +41,7 @@ func streamsHandler(rawURL string) (core.Producer, error) {
 				// https://aws.amazon.com/kinesis/video-streams/
 				// https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/what-is-kvswebrtc.html
 				// https://github.com/orgs/awslabs/repositories?q=kinesis+webrtc
-				return kinesisClient(rawURL, query, "webrtc/kinesis", &kinesisClientOpts{})
+				return kinesisClient(rawURL, query, "webrtc/kinesis", nil)
 			} else if format == "openipc" {
 				return openIPCClient(rawURL, query)
 			} else if format == "switchbot" {

--- a/internal/webrtc/switchbot.go
+++ b/internal/webrtc/switchbot.go
@@ -1,0 +1,62 @@
+package webrtc
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	pion "github.com/pion/webrtc/v3"
+)
+
+// SessionDescription is used to expose local and remote session descriptions.
+type SwitchBotSessionDescription struct {
+	Type       string              `json:"type"`
+	SDP        string              `json:"sdp"`
+	Resolution SwitchBotResolution `json:"resolution"`
+	PlayType   int                 `json:"play_type"`
+}
+
+func switchbotClient(rawURL string, query url.Values) (core.Producer, error) {
+	return kinesisClient(rawURL, query, "webrtc/switchbot", &kinesisClientOpts{
+		SessionDescriptionModifier: func(sd *pion.SessionDescription) ([]byte, error) {
+			resolution, ok := parseSwitchBotResolution(query.Get("resolution"))
+			if !ok {
+				resolution = SwitchBotResolutionSD
+			}
+			json, err := json.Marshal(SwitchBotSessionDescription{
+				Type:       sd.Type.String(),
+				SDP:        sd.SDP,
+				Resolution: resolution,
+				PlayType:   0,
+			})
+			return json, err
+		},
+		MediaModifier: func() ([]*core.Media, error) {
+			return []*core.Media{
+				{Kind: core.KindVideo, Direction: core.DirectionRecvonly},
+				//{Kind: core.KindAudio, Direction: core.DirectionRecvonly},
+				//{Kind: core.KindAudio, Direction: core.DirectionSendRecv},
+				//{Kind: "Data", Direction: core.DirectionSendRecv},
+			}, nil
+		},
+	})
+}
+
+type SwitchBotResolution int
+
+const (
+	SwitchBotResolutionHD SwitchBotResolution = 0
+	SwitchBotResolutionSD                     = 1
+)
+
+func parseSwitchBotResolution(str string) (SwitchBotResolution, bool) {
+	var (
+		resolutionMap = map[string]SwitchBotResolution{
+			"hd": SwitchBotResolutionHD,
+			"sd": SwitchBotResolutionSD,
+		}
+	)
+	c, ok := resolutionMap[strings.ToLower(str)]
+	return c, ok
+}

--- a/internal/webrtc/switchbot.go
+++ b/internal/webrtc/switchbot.go
@@ -1,62 +1,40 @@
 package webrtc
 
 import (
-	"encoding/json"
 	"net/url"
-	"strings"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
-	pion "github.com/pion/webrtc/v3"
+	"github.com/AlexxIT/go2rtc/pkg/webrtc"
 )
-
-// SessionDescription is used to expose local and remote session descriptions.
-type SwitchBotSessionDescription struct {
-	Type       string              `json:"type"`
-	SDP        string              `json:"sdp"`
-	Resolution SwitchBotResolution `json:"resolution"`
-	PlayType   int                 `json:"play_type"`
-}
 
 func switchbotClient(rawURL string, query url.Values) (core.Producer, error) {
-	return kinesisClient(rawURL, query, "webrtc/switchbot", &kinesisClientOpts{
-		SessionDescriptionModifier: func(sd *pion.SessionDescription) ([]byte, error) {
-			resolution, ok := parseSwitchBotResolution(query.Get("resolution"))
-			if !ok {
-				resolution = SwitchBotResolutionSD
-			}
-			json, err := json.Marshal(SwitchBotSessionDescription{
-				Type:       sd.Type.String(),
-				SDP:        sd.SDP,
-				Resolution: resolution,
-				PlayType:   0,
-			})
-			return json, err
-		},
-		MediaModifier: func() ([]*core.Media, error) {
-			return []*core.Media{
-				{Kind: core.KindVideo, Direction: core.DirectionRecvonly},
-				//{Kind: core.KindAudio, Direction: core.DirectionRecvonly},
-				//{Kind: core.KindAudio, Direction: core.DirectionSendRecv},
-				//{Kind: "Data", Direction: core.DirectionSendRecv},
-			}, nil
-		},
-	})
-}
-
-type SwitchBotResolution int
-
-const (
-	SwitchBotResolutionHD SwitchBotResolution = 0
-	SwitchBotResolutionSD                     = 1
-)
-
-func parseSwitchBotResolution(str string) (SwitchBotResolution, bool) {
-	var (
-		resolutionMap = map[string]SwitchBotResolution{
-			"hd": SwitchBotResolutionHD,
-			"sd": SwitchBotResolutionSD,
+	return kinesisClient(rawURL, query, "webrtc/switchbot", func(prod *webrtc.Conn, query url.Values) (any, error) {
+		medias := []*core.Media{
+			{Kind: core.KindVideo, Direction: core.DirectionRecvonly},
 		}
-	)
-	c, ok := resolutionMap[strings.ToLower(str)]
-	return c, ok
+
+		offer, err := prod.CreateOffer(medias)
+		if err != nil {
+			return nil, err
+		}
+
+		v := struct {
+			Type       string `json:"type"`
+			SDP        string `json:"sdp"`
+			Resolution int    `json:"resolution"`
+			PlayType   int    `json:"play_type"`
+		}{
+			Type: "offer",
+			SDP:  offer,
+		}
+
+		switch query.Get("resolution") {
+		case "hd":
+			v.Resolution = 0
+		case "sd":
+			v.Resolution = 1
+		}
+
+		return v, nil
+	})
 }


### PR DESCRIPTION
## What is being changed

This pull request enhances WebRTC source support.

It adds a client that supports the special SDP Offer SessionDescription for SwitchBot.

Support connection to [SwitchBot](https://us.switch-bot.com/) cameras that are based on Kinesis Video Streams. Specifically, this includes [Pan/Tilt Cam Plus 2K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-2k) and [Pan/Tilt Cam Plus 3K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-3k).
(`Outdoor Spotlight Cam 1080P`, `Outdoor Spotlight Cam 2K`, `Pan/Tilt Cam`, `Pan/Tilt Cam 2K`, `Indoor Cam` are based on Tuya, so this feature is not available.)

The Readme has been updated with an example of how to write to yaml.

I have been using the Go language for less than 10 hours, so my understanding of grammar and general coding rules is immature.

## Steps to verify operation
I have prepared this [Github Pages](https://hsakoh.github.io/go2rtc/SwitchBotKVS.html).
It mimics the communication of the smartphone app and obtains KVS credentials.

However, since some APIs do not support CORS, you need to launch Chrome with the following command to use this page:
`"C:\Program Files\Google\Chrome\Application\chrome.exe" --disable-web-security`

This HTML saves data in the browser's storage and only sends external communications emulating the app to SwitchBot.

1. Enter your **Email Address** and **Password**, then click the **Login** button.
   - Once the access token and refresh token are displayed, click the **Save Tokens** button.

2. Click the **User Info** button to identify the user's **BotRegion**.
   - Next, click the **Endpoint** button to identify the endpoint for each region.
   - Once the **Wonderlabs Endpoint** is displayed, click the **Save BotRegion/Endpoints** button.

3. Click the **GroupGetAll** button to list all groups.
   - Then, click the **DeviceGetAll** button.
   - When the list of devices and virtual IR devices is displayed, click the **Save Groups/Devices** button.

4. From the dropdown menu, select your camera, then click the **Call connectAsViewer** button.
   - Then, click the **Generate SignedUrl** button.

Since the KVS JavaScript SDK is used for signing, the signed URL will expire in 299 seconds.
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/blob/master/src/SigV4RequestSigner.ts#L86

I have confirmed that the video can be viewed in H.265 using the following Chrome options: 
`--enable-features=PlatformHEVCEncoderSupport,WebRtcAllowH265Receive,WebRtcAllowH265Send --force-fieldtrials=WebRTC-Video-H26xPacketBuffer/Enabled`
Additionally, I have confirmed that the video can be viewed by converting it to h264 with ffmpeg.

```
streams:
    cam:
        - ffmpeg:webrtc-switchbot#video=h264
    webrtc-switchbot:
      - webrtc:wss://....kinesisvideo...amazonaws.com/...#format=switchbot#resolution=HD#client_id=....#ice_servers=[{"urls":"stun:stun.kinesisvideo.ap-northeast-1.amazonaws.com:443"}...]
```
