### PR TITLE
Add support for H.265 codec verification

### DIFF
--- a/www/video-rtc.js
+++ b/www/video-rtc.js
@@ -583,7 +583,7 @@ export class VideoRTC extends HTMLElement {
             if (stream.getVideoTracks().length > 0) rtcPriority += 0x220;
             if (stream.getAudioTracks().length > 0) rtcPriority += 0x102;
 
-            if (this.mseCodecs.indexOf('hvc1.') >= 0) msePriority += 0x230;
+            if (this.mseCodecs.indexOf('hvc1.') >= 0 && !VideoRTC.isH265Supported()) msePriority += 0x230;
             if (this.mseCodecs.indexOf('avc1.') >= 0) msePriority += 0x210;
             if (this.mseCodecs.indexOf('mp4a.') >= 0) msePriority += 0x101;
 
@@ -662,6 +662,23 @@ export class VideoRTC extends HTMLElement {
         };
 
         this.send({type: 'mp4', value: this.codecs(this.video.canPlayType)});
+    }
+
+    static isH265Supported() {
+        try {
+            const videoCodecs = RTCRtpSender?.getCapabilities('video')?.codecs;
+            
+            if (!videoCodecs) {
+            return false;
+            }
+            
+            return videoCodecs.some(codec => 
+            codec.mimeType.toLowerCase().includes('h265') || 
+            codec.mimeType.toLowerCase().includes('hevc')
+            );
+        } catch {
+            return false;
+        }
     }
 
     static btoa(buffer) {

--- a/www/video-rtc.js
+++ b/www/video-rtc.js
@@ -673,8 +673,8 @@ export class VideoRTC extends HTMLElement {
             }
             
             return videoCodecs.some(codec => 
-            codec.mimeType.toLowerCase().includes('h265') || 
-            codec.mimeType.toLowerCase().includes('hevc')
+                codec.mimeType.toLowerCase().includes('h265') || 
+                codec.mimeType.toLowerCase().includes('hevc')
             );
         } catch {
             return false;


### PR DESCRIPTION
This pull request includes updates to the `VideoRTC` class in the `www/video-rtc.js` file to enhance codec support checking. The most important changes are the addition of a new method to check for H.265 support and the modification of codec priority assignment logic.

Enhancements to codec support checking:

* [`www/video-rtc.js`](diffhunk://#diff-01439c19c5fa27a48083cf52f057f72050f7aa5f6a7f3712dae51ca377217bb9R667-R683): Added a new static method `isH265Supported` to check if H.265/HEVC codecs are supported by the browser.
* [`www/video-rtc.js`](diffhunk://#diff-01439c19c5fa27a48083cf52f057f72050f7aa5f6a7f3712dae51ca377217bb9L586-R586): Updated the condition for assigning `msePriority` for 'hvc1.' codecs to include a check using the new `isH265Supported` method.