### PR TITLE
onvif: Add Support for Camera Names and Main/Sub stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1223,23 +1223,30 @@ With ONVIF support, go2rtc can:
 
 ```yaml
 onvif:
-  - name: Camera 1
-    main_stream: camera1
-    sub_stream: camera1_lq
-  - name: Camera 2
-    main_stream: camera2
-    sub_stream: camera2_lq
+  profiles:
+    - name: Camera 1
+      streams:
+        - camera1#res=1920x1080
+        - camera1_lq#res=1270x720#codec=H265
+    - name: Camera 2
+      streams:
+        - camera2
+        - camera2_lq#res=640x360
 
 streams:
   camera1:
     - rtsp://admin:admin@192.168.1.1/cam/realmonitor?channel=1&subtype=0&unicast=true
   camera1_lq:
-    - ffmpeg:camera1#video=h264#height=360
+    - ffmpeg:camera1#video=h265#height=360
   camera2:
     - rtsp://admin:admin@192.168.1.2/cam/realmonitor?channel=1&subtype=0&unicast=true
   camera2_lq:
     - ffmpeg:camera2#video=h264#height=360
 ```
+
+Default params for `streams`:
+- `res=1920x1080`
+- `codec=H264`
 
 **Example Dahua NVR configuration:**
 - **Channel**: <camera channel on NVR>

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Available modules:
 - [mp4](#module-mp4) - MSE, MP4 stream and MP4 snapshot Server
 - [hls](#module-hls) - HLS TS or fMP4 stream Server
 - [mjpeg](#module-mjpeg) - MJPEG Server
+- [onvif](#module-onvif) - ONVIF server
 - [ffmpeg](#source-ffmpeg) - FFmpeg integration
 - [ngrok](#module-ngrok) - ngrok integration (external access for private network)
 - [hass](#module-hass) - Home Assistant integration
@@ -587,7 +588,7 @@ Support import camera links from [Home Assistant](https://www.home-assistant.io/
 
 - [Generic Camera](https://www.home-assistant.io/integrations/generic/), setup via GUI
 - [HomeKit Camera](https://www.home-assistant.io/integrations/homekit_controller/)
-- [ONVIF](https://www.home-assistant.io/integrations/onvif/)
+- [ONVIF](https://www.home-assistant.io/integrations/onvif/) via [Module: ONVIF](#module-onvif)
 - [Roborock](https://github.com/humbertogontijo/homeassistant-roborock) vacuums with camera
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1224,9 +1224,9 @@ With ONVIF support, go2rtc can:
 ```yaml
 onvif:
   profiles:
-    - name: Camera 1
+    - name: Camera 1  
       streams:
-        - camera1#res=1920x1080
+        - camera1#codec=H265
         - camera1_lq#res=1270x720#codec=H265
     - name: Camera 2
       streams:
@@ -1237,7 +1237,7 @@ streams:
   camera1:
     - rtsp://admin:admin@192.168.1.1/cam/realmonitor?channel=1&subtype=0&unicast=true
   camera1_lq:
-    - ffmpeg:camera1#video=h265#height=360
+    - ffmpeg:camera1#video=h265#height=720
   camera2:
     - rtsp://admin:admin@192.168.1.2/cam/realmonitor?channel=1&subtype=0&unicast=true
   camera2_lq:

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Ultimate camera streaming application with support RTSP, WebRTC, HomeKit, FFmpeg
   * [Module: MP4](#module-mp4)
   * [Module: HLS](#module-hls)
   * [Module: MJPEG](#module-mjpeg)
+  * [Module: ONVIF](#module-onvif)
   * [Module: Log](#module-log)
 * [Security](#security)
 * [Codecs filters](#codecs-filters)
@@ -1207,6 +1208,46 @@ API examples:
 **PS.** This module also supports streaming to the server console (terminal) in the **animated ASCII art** format ([read more](https://github.com/AlexxIT/go2rtc/blob/master/internal/mjpeg/README.md)):
 
 [![](https://img.youtube.com/vi/sHj_3h_sX7M/mqdefault.jpg)](https://www.youtube.com/watch?v=sHj_3h_sX7M)
+
+### Module: ONVIF
+
+This module provides an **ONVIF server** that allows go2rtc to act as an ONVIF-compatible device, making it easier to integrate cameras with ONVIF-supported software like Dahua NVRs or Home Assistant.
+
+With ONVIF support, go2rtc can:
+- Expose configured streams as ONVIF profiles.
+- Provide additional ONVIF functionalities like `GetOSDs` to show camera name in Dahua NVR.
+- Maintain a **consistent camera order** to prevent issues with NVRs that rely on `GetProfilesResponse` for identification.
+
+**Example Configuration**
+
+```yaml
+onvif:
+  - name: Camera 1
+    main_stream: camera1
+    sub_stream: camera1_lq
+  - name: Camera 2
+    main_stream: camera2
+    sub_stream: camera2_lq
+
+streams:
+  camera1:
+    - rtsp://admin:admin@192.168.1.1/cam/realmonitor?channel=1&subtype=0&unicast=true
+  camera1_lq:
+    - ffmpeg:camera1#video=h264#height=360
+  camera2:
+    - rtsp://admin:admin@192.168.1.2/cam/realmonitor?channel=1&subtype=0&unicast=true
+  camera2_lq:
+    - ffmpeg:camera2#video=h264#height=360
+```
+
+**Example Dahua NVR configuration:**
+- **Channel**: <camera channel on NVR>
+- **Manufacturer**: ONVIF
+- **IP Address**: <go2rtc IP>
+- **RTSP Port**: Self-adaptive
+- **HTTP Port**: <go2rtc http api port, eg. 1984>
+- **Username / Password**: Currently auth is not supported by go2rtc
+- **Remote CH No.**: <camera index from onvif array, counting from 1>
 
 ### Module: Log
 

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Support import camera links from [Home Assistant](https://www.home-assistant.io/
 
 - [Generic Camera](https://www.home-assistant.io/integrations/generic/), setup via GUI
 - [HomeKit Camera](https://www.home-assistant.io/integrations/homekit_controller/)
-- [ONVIF](https://www.home-assistant.io/integrations/onvif/) via [Module: ONVIF](#module-onvif)
+- [ONVIF](https://www.home-assistant.io/integrations/onvif/)
 - [Roborock](https://github.com/humbertogontijo/homeassistant-roborock) vacuums with camera
 
 ```yaml
@@ -1114,7 +1114,7 @@ You have several options on how to add a camera to Home Assistant:
 2. Camera [any source](#module-streams) => [go2rtc config](#configuration) => [Generic Camera](https://www.home-assistant.io/integrations/generic/)
    - Install any [go2rtc](#fast-start)
    - Add your stream to [go2rtc config](#configuration)
-   - Hass > Settings > Integrations > Add Integration > [ONVIF](https://my.home-assistant.io/redirect/config_flow_start/?domain=onvif) > Host: `127.0.0.1`, Port: `1984`
+   - Hass > Settings > Integrations > Add Integration > [ONVIF](https://my.home-assistant.io/redirect/config_flow_start/?domain=onvif) > Host: `127.0.0.1`, Port: `1984` (using [Module: ONVIF](#module-onvif))
    - Hass > Settings > Integrations > Add Integration > [Generic Camera](https://my.home-assistant.io/redirect/config_flow_start/?domain=generic) > Stream Source URL: `rtsp://127.0.0.1:8554/camera1` (change to your stream name, leave everything else as is)
 
 You have several options on how to watch the stream from the cameras in Home Assistant:

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -166,8 +166,6 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 
 	case onvif.MediaGetProfile:
 		token := onvif.FindTagValue(b, "ProfileToken")
-		fmt.Println("MediaGetProfile:")
-		fmt.Println(string(token))
 		for _, cam := range OnvifCameras {
 			if(cam.MainStream == token || cam.SubStream == token){
 				b = onvif.GetProfileResponse(cam)

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -29,15 +29,6 @@ func Init() {
 	app.LoadConfig(&cfg)
 	OnvifCameras = cfg.OnvifCameras
 
-	// Debug print
-	data, err := json.MarshalIndent(OnvifCameras, "", "  ")
-	if err != nil {
-		fmt.Println("Error marshalling JSON:", err)
-	} else {
-		fmt.Println("Loaded ONVIF cameras configuration:")
-		fmt.Println(string(data))
-	}
-
 	sort.Slice(OnvifCameras, func(i, j int) bool {
 		return OnvifCameras[i].ID < OnvifCameras[j].ID
 	})

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -30,7 +30,7 @@ func Init() {
 	OnvifCameras = cfg.OnvifCameras
 
 	sort.Slice(OnvifCameras, func(i, j int) bool {
-		return OnvifCameras[i].ID < OnvifCameras[j].ID
+		return OnvifCameras[i].Index < OnvifCameras[j].Index
 	})
 
 	log = app.GetLogger("onvif")

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"time"
-	"sort"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/app"
@@ -28,10 +27,6 @@ func Init() {
 
 	app.LoadConfig(&cfg)
 	OnvifCameras = cfg.OnvifCameras
-
-	sort.Slice(OnvifCameras, func(i, j int) bool {
-		return OnvifCameras[i].Index < OnvifCameras[j].Index
-	})
 
 	log = app.GetLogger("onvif")
 

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -7,7 +7,7 @@ import (
 )
 
 type OnvifCamera struct {
-    ID         int    `yaml:"id"`
+    Index      int    `yaml:"index"`
     Name       string `yaml:"name"`
     MainStream string `yaml:"main_stream"`
     SubStream  string `yaml:"sub_stream,omitempty"`

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -197,7 +197,7 @@ func appendProfile(e *Envelope, tag string, profile OnvifProfile) {
         return
     }
 
-    // Pierwszy stream jako główny
+    // get first stream as main stream
     firstStream := profile.Streams[0]
     firstName, firstWidth, firstHeight, _ := ParseStream(firstStream)
 

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -7,7 +7,6 @@ import (
 )
 
 type OnvifCamera struct {
-    Index      int    `yaml:"index"`
     Name       string `yaml:"name"`
     MainStream string `yaml:"main_stream"`
     SubStream  string `yaml:"sub_stream,omitempty"`


### PR DESCRIPTION
This PR introduces the following improvements:  

✅ **Support for Camera Names in Dahua NVRs** (and potentially other NVRs).  
✅ **Support for both main and substreams.**  

## New ONVIF Functions  
- `GetOSDs`  
- `GetOSDOptions`  

## Why This Change?  
Dahua NVRs can handle multiple cameras from a single ONVIF server, but they **identify cameras by their order in `GetProfilesResponse`**, rather than by their names.  
Previously, `go2rtc` sorted cameras by name, which caused issues:  
- If a new camera was added, **Dahua would reorder the cameras and mix up the streams**.  
- To prevent this, the order of cameras is now preserved **based on the array order in the ONVIF configuration**.

## Example Configuration
```yaml
onvif:
  profiles:
    - name: Camera 1
      streams:
        - camera1#res=1920x1080
        - camera1_lq#res=1270x720#codec=H265
    - name: Camera 2
      streams:
        - camera2
        - camera2_lq#res=640x360

streams:
  camera1:
    - rtsp://admin:admin@192.168.1.1/cam/realmonitor?channel=1&subtype=0&unicast=true
  camera1_lq:
    - ffmpeg:camera1#video=h264#height=360
  camera2:
    - rtsp://admin:admin@192.168.1.2/cam/realmonitor?channel=1&subtype=0&unicast=true
  camera2_lq:
    - ffmpeg:camera2#video=h264#height=360
```

By default:
- `res=1920x1080`
- `codec=H264`

## Impact
- Maintains consistent camera ordering in Dahua NVRs.
- Prevents cameras from being mixed up when adding new ones.
- Enhances ONVIF support by exposing additional features (GetOSDs, GetOSDOptions).
- When section `onvif` is not exist in config, everything works like was before.