### PR TITLE
Add JPEG quality adjustment via quality parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,7 @@ API examples:
   - You can use `width`/`w` and/or `height`/`h` params 
   - You can use `rotate` param with `90`, `180`, `270` or `-90` values
   - You can use `hardware`/`hw` param [read more](https://github.com/AlexxIT/go2rtc/wiki/Hardware-acceleration)
+  - You can use `quality` param to change jpeg quality (for example `1`)
 
 **PS.** This module also supports streaming to the server console (terminal) in the **animated ASCII art** format ([read more](https://github.com/AlexxIT/go2rtc/blob/master/internal/mjpeg/README.md)):
 

--- a/internal/ffmpeg/jpeg.go
+++ b/internal/ffmpeg/jpeg.go
@@ -45,7 +45,7 @@ func parseQuery(query url.Values) *ffmpeg.Args {
 
 	var width = -1
 	var height = -1
-	var r, hw string
+	var r, hw, quality string
 
 	for k, v := range query {
 		switch k {
@@ -57,6 +57,8 @@ func parseQuery(query url.Values) *ffmpeg.Args {
 			r = v[0]
 		case "hardware", "hw":
 			hw = v[0]
+		case "quality":
+			quality = v[0]
 		}
 	}
 
@@ -77,6 +79,10 @@ func parseQuery(query url.Values) *ffmpeg.Args {
 
 	if hw != "" {
 		hardware.MakeHardware(args, hw, defaults)
+	}
+
+	if quality != "" {
+		args.Codecs = append(args.Codecs, fmt.Sprintf("-q:v %s", quality))
 	}
 
 	return args


### PR DESCRIPTION
This pull request introduces the ability to adjust JPEG quality in the FFmpeg-based processing pipeline by adding a `quality` parameter. The value of this parameter is directly passed to `-q:v` in FFmpeg, allowing users to control the output image compression level.

## Changes
### 1. Modified `internal/ffmpeg/jpeg.go`
- Added a `quality` variable to parse query parameters.
- Implemented logic to append `-q:v {quality}` to the FFmpeg arguments if the parameter is provided.

### 2. Updated `README.md`
- Added documentation for the new `quality` parameter, explaining that it allows users to change the JPEG quality (e.g., `quality=1`).

## Usage Example
Users can now control the JPEG compression level via a URL query parameter:

```
http://<go2rtc_ip>:1984/api/frame.jpeg?src=camera&quality=1
```

**Where:**
- **quality=1** → Highest quality, larger file size.
- **quality=31** → Lowest quality, smaller file size.

## Why this change?
This update provides greater flexibility in adjusting image quality and file size based on user needs, making the API more versatile.