### PR TITLE
fix: Unpairing HomeKit streams

### DIFF
--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
@@ -23,7 +22,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		urls := findHomeKitURLs()
+		urls := streams.FindPrefixURLs("homekit")
 		for id, u := range urls {
 			deviceID := u.Query().Get("device_id")
 			for _, source := range sources {
@@ -112,7 +111,7 @@ func apiUnpair(id string) error {
 		return errors.New(api.StreamNotFound)
 	}
 
-	rawURL := findHomeKitURL(stream.Sources())
+	rawURL := streams.FindPrefixURL("homekit", stream.Sources())
 	if rawURL == "" {
 		return errors.New("not homekit source")
 	}
@@ -124,16 +123,4 @@ func apiUnpair(id string) error {
 	streams.Delete(id)
 
 	return app.PatchConfig([]string{"streams", id}, nil)
-}
-
-func findHomeKitURLs() map[string]*url.URL {
-	urls := map[string]*url.URL{}
-	for name, sources := range streams.GetAllSources() {
-		if rawURL := findHomeKitURL(sources); rawURL != "" {
-			if u, err := url.Parse(rawURL); err == nil {
-				urls[name] = u
-			}
-		}
-	}
-	return urls
 }

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -79,7 +79,7 @@ func Init() {
 			Handler:       homekit.ServerHandler(srv),
 		}
 
-		if url := findHomeKitURL(stream.Sources()); url != "" {
+		if url := streams.FindPrefixURL("homekit", stream.Sources()); url != "" {
 			// 1. Act as transparent proxy for HomeKit camera
 			dial := func() (net.Conn, error) {
 				client, err := homekit.Dial(url, srtp.Server)
@@ -188,26 +188,6 @@ func hapHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil && err != io.EOF {
 		log.Error().Err(err).Caller().Send()
 	}
-}
-
-func findHomeKitURL(sources []string) string {
-	if len(sources) == 0 {
-		return ""
-	}
-
-	url := sources[0]
-	if strings.HasPrefix(url, "homekit") {
-		return url
-	}
-
-	if strings.HasPrefix(url, "hass") {
-		location, _ := streams.Location(url)
-		if strings.HasPrefix(location, "homekit") {
-			return url
-		}
-	}
-
-	return ""
 }
 
 func parseBitrate(s string) int {

--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/pkg/hap"
 	"github.com/AlexxIT/go2rtc/pkg/probe"
 )
 
@@ -94,6 +95,13 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "DELETE":
+		stream := Get(src)
+		if stream != nil {
+			if rawURL := FindPrefixURL("homekit", stream.Sources()); rawURL != "" {
+				_ = hap.Unpair(rawURL)
+			}
+		}
+
 		delete(streams, src)
 
 		if err := app.PatchConfig([]string{"streams", src}, nil); err != nil {

--- a/internal/streams/helpers.go
+++ b/internal/streams/helpers.go
@@ -20,3 +20,37 @@ func ParseQuery(s string) url.Values {
 	}
 	return params
 }
+
+func FindPrefixURL(prefix string, sources []string) string {
+	if len(sources) == 0 {
+		return ""
+	}
+
+	url := sources[0]
+	if strings.HasPrefix(url, prefix) {
+		return url
+	}
+
+	if prefix == "homekit" {
+		if strings.HasPrefix(url, "hass") {
+			location, _ := Location(url)
+			if strings.HasPrefix(location, prefix) {
+				return url
+			}
+		}
+	}
+
+	return ""
+}
+
+func FindPrefixURLs(prefix string) map[string]*url.URL {
+	urls := map[string]*url.URL{}
+	for name, sources := range GetAllSources() {
+		if rawURL := FindPrefixURL(prefix, sources); rawURL != "" {
+			if u, err := url.Parse(rawURL); err == nil {
+				urls[name] = u
+			}
+		}
+	}
+	return urls
+}


### PR DESCRIPTION
During my tests with camera.ui, I encountered the following issue:

After I paired a HomeKit camera using go2rtc, and later deleted it through the API (without unpairing it), I was no longer able to unpair the camera. In HomeKit Discovery, the camera was shown as paired, without the possibility to unpair it.

Refactoring and code simplification (due to circular dependencies)

* Removed the `findHomeKitURLs` and `findHomeKitURL` functions from `internal/homekit/api.go` and `internal/homekit/homekit.go`, respectively, and replaced their usage with the new `streams.FindPrefixURLs` and `streams.FindPrefixURL` functions.
* Added `FindPrefixURL` and `FindPrefixURLs` functions to `internal/streams/helpers.go` to handle URL finding logic based on a prefix.

Dependency updates:

* Added the `hap` package to `internal/streams/api.go` for handling HomeKit unpairing.

Enhancements to stream deletion:

* Updated the `apiStreams` function in `internal/streams/api.go` to unpair HomeKit streams before deletion.