### PR TITLE
Fix Stream API for DELETE

### DIFF
--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -93,7 +93,7 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "DELETE":
-		delete(streams, name)
+		Delete(name)
 
 		if err := app.PatchConfig([]string{"streams", src}, nil); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -11,9 +11,10 @@ import (
 func apiStreams(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	src := query.Get("src")
+	name := query.Get("name")
 
 	// without source - return all streams list
-	if src == "" && r.Method != "POST" {
+	if src == "" && name == "" && r.Method != "POST" {
 		api.ResponseJSON(w, streams)
 		return
 	}
@@ -43,7 +44,6 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "PUT":
-		name := query.Get("name")
 		if name == "" {
 			name = src
 		}
@@ -58,7 +58,6 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "PATCH":
-		name := query.Get("name")
 		if name == "" {
 			http.Error(w, "", http.StatusBadRequest)
 			return
@@ -94,7 +93,7 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "DELETE":
-		delete(streams, src)
+		delete(streams, name)
 
 		if err := app.PatchConfig([]string{"streams", src}, nil); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
Quick fix for streams REST Delete Endpoint. Was using src instead of name for the streams map key. 
Also should use Delete method instead of calling delete(streams, name) for lock. 
Great project! Just starting to experiment. 