### PR TITLE
 Fix: Handle RTSP cameras requiring fragment-implied config in dynamic snapshot API

### DIFF
--- a/internal/mjpeg/init.go
+++ b/internal/mjpeg/init.go
@@ -36,8 +36,7 @@ func Init() {
 var log zerolog.Logger
 
 func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
-	src := r.URL.Query().Get("src")
-	stream := streams.Get(src)
+	stream := streams.GetOrPatch(r.URL.Query())
 	if stream == nil {
 		http.Error(w, api.StreamNotFound, http.StatusNotFound)
 		return


### PR DESCRIPTION
This PR fixes an issue where fetching snapshots using the /api/frame.jpeg endpoint with a dynamic src=URL parameter would fail for certain RTSP cameras.

This change ensures that dynamic snapshot requests work correctly for these cameras, allowing snapshots to be taken from 'unconfigured' cameras (via ?src=URL) that previously failed.