### PR TITLE
Add RTSP UDP transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Format: `rtsp...#{param1}#{param2}#{param3}`
 - Ignore audio - `#media=video` or ignore video - `#media=audio` 
 - Ignore two way audio API `#backchannel=0` - important for some glitchy cameras
 - Use WebSocket transport `#transport=ws...`
+- Use UDP transport `#transport=udp`
 
 **RTSP over WebSocket**
 
@@ -268,6 +269,7 @@ streams:
   axis-rtsp-ws:  rtsp://192.168.1.123:4567/axis-media/media.amp?overview=0&camera=1&resolution=1280x720&videoframeskipmode=empty&Axis-Orig-Sw=true#transport=ws://user:pass@192.168.1.123:4567/rtsp-over-websocket
   # WebSocket without authorization, RTSP - with
   dahua-rtsp-ws: rtsp://user:pass@192.168.1.123/cam/realmonitor?channel=1&subtype=1&proto=Private3#transport=ws://192.168.1.123/rtspoverwebsocket
+  udp_camera:   rtsp://user:pass@192.168.1.345:554/stream1#transport=udp
 ```
 
 #### Source: RTMP

--- a/pkg/rtsp/ports.go
+++ b/pkg/rtsp/ports.go
@@ -1,0 +1,75 @@
+package rtsp
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+var mu sync.Mutex
+
+type UDPPortPair struct {
+	RTPListener  *net.UDPConn
+	RTCPListener *net.UDPConn
+	RTPPort      int
+	RTCPPort     int
+}
+
+func (p *UDPPortPair) Close() {
+	if p.RTPListener != nil {
+		_ = p.RTPListener.Close()
+	}
+	if p.RTCPListener != nil {
+		_ = p.RTCPListener.Close()
+	}
+}
+
+func GetUDPPorts(ip net.IP, maxAttempts int) (*UDPPortPair, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if ip == nil {
+		ip = net.IPv4(0, 0, 0, 0)
+	}
+
+	for i := 0; i < maxAttempts; i++ {
+		// Get a random even port from the OS
+		tempListener, err := net.ListenUDP("udp", &net.UDPAddr{IP: ip, Port: 0})
+		if err != nil {
+			continue
+		}
+
+		addr := tempListener.LocalAddr().(*net.UDPAddr)
+		basePort := addr.Port
+		tempListener.Close()
+
+		// 11. RTP over Network and Transport Protocols (https://www.ietf.org/rfc/rfc3550.txt)
+		// For UDP and similar protocols,
+		// RTP SHOULD use an even destination port number and the corresponding
+		// RTCP stream SHOULD use the next higher (odd) destination port number
+		if basePort%2 == 1 {
+			basePort--
+		}
+
+		// Try to bind both ports
+		rtpListener, err := net.ListenUDP("udp", &net.UDPAddr{IP: ip, Port: basePort})
+		if err != nil {
+			continue
+		}
+
+		rtcpListener, err := net.ListenUDP("udp", &net.UDPAddr{IP: ip, Port: basePort + 1})
+		if err != nil {
+			rtpListener.Close()
+			continue
+		}
+
+		return &UDPPortPair{
+			RTPListener:  rtpListener,
+			RTCPListener: rtcpListener,
+			RTPPort:      basePort,
+			RTCPPort:     basePort + 1,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("failed to allocate consecutive UDP ports after %d attempts", maxAttempts)
+}


### PR DESCRIPTION
This pull request introduces support for UDP transport in the RTSP client, addressing a long-standing limitation where UDP connections were only possible through FFmpeg (which sometimes introduces latency). The implementation adds native UDP transport support alongside various enhancements and fixes to improve functionality and maintainability.

### Key Features
- **Native UDP Transport**: Direct UDP connections to RTSP cameras without FFmpeg dependency
- **Reduced Latency**: Eliminates potential delays introduced by FFmpeg in UDP scenarios
- **Backward Compatibility**: Existing TCP configurations remain unchanged
- **Flexible Configuration**: Simple URL parameter to specify transport method

### Example Configuration
```yaml
streams:
  udp_camera: rtsp://192.168.1.123:554#transport=udp
  tcp_camera: rtsp://192.168.1.123:554#transport=tcp  # explicit TCP (optional)
  default_camera: rtsp://192.168.1.123:554            # defaults to TCP
```
  
### Benefits

- Lower latency for UDP-capable cameras
- Reduced system resources (no FFmpeg overhead for UDP)
- Better performance in network environments where UDP is preferred

Closes: #1718 #1305 #538
Fixes: #1725 #673 #658 #451 #386 #132

**Note**: Some of the referenced issues were previously addressable via FFmpeg fallback, but this native UDP implementation eliminates that dependency and associated latency concerns.

**Note**: This implementation adds UDP transport for outgoing connections to RTSP cameras. The go2rtc RTSP server itself remains TCP-only for incoming connections.