### PR TITLE
Fix doorbird overload when backchannel audio is used

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	app.Version = "1.9.9"
+	app.Version = "1.9.9dev#01"
 
 	// 1. Core modules: app, api/ws, streams
 

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 )
 
 func main() {
-	app.Version = "1.9.9dev#01"
+	app.Version = "1.9.9"
 
 	// 1. Core modules: app, api/ws, streams
 

--- a/pkg/doorbird/backchannel.go
+++ b/pkg/doorbird/backchannel.go
@@ -14,7 +14,10 @@ type Client struct {
 	conn net.Conn
 }
 
-var dialLimiter = time.Tick(time.Second) // 1 tick per second
+var dialLimiter = time.Tick(time.Second)
+// Limit to one connection per second
+// https://www.doorbird.com/downloads/api_lan.pdf?rev=0.36
+// As described on page 5
 
 func Dial(rawURL string) (*Client, error) {
 	<-dialLimiter // Wait for the next tick before dialing

--- a/pkg/doorbird/backchannel.go
+++ b/pkg/doorbird/backchannel.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/url"
 	"time"
-
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/pion/rtp"
 )
@@ -15,7 +14,11 @@ type Client struct {
 	conn net.Conn
 }
 
+var dialLimiter = time.Tick(time.Second) // 1 tick per second
+
 func Dial(rawURL string) (*Client, error) {
+	<-dialLimiter // Wait for the next tick before dialing
+
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err
@@ -38,6 +41,7 @@ func Dial(rawURL string) (*Client, error) {
 		"Content-Length: 9999999\r\n" +
 		"Connection: Keep-Alive\r\n" +
 		"Cache-Control: no-cache\r\n" +
+		"Use-Content-Length: true\r\n" +
 		"\r\n"
 
 	_ = conn.SetWriteDeadline(time.Now().Add(core.ConnDeadline))


### PR DESCRIPTION
Added one connection per second limit as described in api documentation