### PR TITLE
Add Support for SwitchBot VideoDoorbell

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ Supports [Amazon Kinesis Video Streams](https://aws.amazon.com/kinesis/video-str
 
 **switchbot**
 
-Support connection to [SwitchBot](https://us.switch-bot.com/) cameras that are based on Kinesis Video Streams. Specifically, this includes [Pan/Tilt Cam Plus 2K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-2k) and [Pan/Tilt Cam Plus 3K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-3k). `Outdoor Spotlight Cam 1080P`, `Outdoor Spotlight Cam 2K`, `Pan/Tilt Cam`, `Pan/Tilt Cam 2K`, `Indoor Cam` are based on Tuya, so this feature is not available.
+Support connection to [SwitchBot](https://us.switch-bot.com/) cameras that are based on Kinesis Video Streams. Specifically, this includes [Pan/Tilt Cam Plus 2K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-2k) and [Pan/Tilt Cam Plus 3K](https://us.switch-bot.com/pages/switchbot-pan-tilt-cam-plus-3k) and [Smart Video Doorbell](https://www.switchbot.jp/products/switchbot-smart-video-doorbell). `Outdoor Spotlight Cam 1080P`, `Outdoor Spotlight Cam 2K`, `Pan/Tilt Cam`, `Pan/Tilt Cam 2K`, `Indoor Cam` are based on Tuya, so this feature is not available.
 
 ```yaml
 streams:
@@ -693,7 +693,7 @@ streams:
   webrtc-openipc:   webrtc:ws://192.168.1.123/webrtc_ws#format=openipc#ice_servers=[{"urls":"stun:stun.kinesisvideo.eu-north-1.amazonaws.com:443"}]
   webrtc-wyze:      webrtc:http://192.168.1.123:5000/signaling/camera1?kvs#format=wyze
   webrtc-kinesis:   webrtc:wss://...amazonaws.com/?...#format=kinesis#client_id=...#ice_servers=[{...},{...}]
-  webrtc-switchbot: webrtc:wss://...amazonaws.com/?...#format=switchbot#resolution=hd#client_id=...#ice_servers=[{...},{...}]
+  webrtc-switchbot: webrtc:wss://...amazonaws.com/?...#format=switchbot#resolution=hd#play_type=0#client_id=...#ice_servers=[{...},{...}]
 ```
 
 **PS.** For `kinesis` sources, you can use [echo](#source-echo) to get connection params using `bash`, `python` or any other script language.

--- a/internal/webrtc/switchbot.go
+++ b/internal/webrtc/switchbot.go
@@ -3,6 +3,8 @@ package webrtc
 import (
 	"net/url"
 
+	"strconv"
+
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/webrtc"
 )
@@ -33,6 +35,13 @@ func switchbotClient(rawURL string, query url.Values) (core.Producer, error) {
 			v.Resolution = 0
 		case "sd":
 			v.Resolution = 1
+		case "auto":
+			v.Resolution = 2
+		}
+
+		playtype, err := strconv.Atoi(query.Get("play_type"))
+		if err == nil {
+			v.PlayType = playtype
 		}
 
 		return v, nil


### PR DESCRIPTION
## What is being changed

This pull request enhances WebRTC source support.

Support for SwitchBot’s new product, the Video Doorbell, is being added.
This change further customizes the special SDP Offer SessionDescription for SwitchBot added in pull request #1629. 
(Since the new video doorbell has a different PlayType, I will change it to be configurable in query.)