### PR TITLE
Security Patch: Sanitize credentials on websocket error messages

### DIFF
--- a/internal/api/ws/ws.go
+++ b/internal/api/ws/ws.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"regexp"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
 )
@@ -133,10 +133,7 @@ func apiWS(w http.ResponseWriter, r *http.Request) {
 		if handler := wsHandlers[msg.Type]; handler != nil {
 			go func() {
 				if err = handler(tr, msg); err != nil {
-					// Some streams such as ffmpeg might return credentials on error messages
-					errMsg := err.Error()
-					sanitizer := regexp.MustCompile(`(\w+)://(.*)@`)
-					errMsg = sanitizer.ReplaceAllString(errMsg, "$1://******@")
+					errMsg := core.StripUserinfo(err.Error())
 					tr.Write(&Message{Type: "error", Value: msg.Type + ": " + errMsg})
 				}
 			}()

--- a/pkg/core/core_test.go
+++ b/pkg/core/core_test.go
@@ -118,3 +118,17 @@ func TestName(t *testing.T) {
 	// stage3
 	_ = prod2.Stop()
 }
+
+func TestStripUserinfo(t *testing.T) {
+	s := `streams:
+  test:
+    - ffmpeg:rtsp://username:password@10.1.2.3:554/stream1
+    - ffmpeg:rtsp://10.1.2.3:554/stream1@#video=copy
+`
+	s = StripUserinfo(s)
+	require.Equal(t, `streams:
+  test:
+    - ffmpeg:rtsp://***@10.1.2.3:554/stream1
+    - ffmpeg:rtsp://10.1.2.3:554/stream1@#video=copy
+`, s)
+}

--- a/pkg/core/helpers.go
+++ b/pkg/core/helpers.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"crypto/rand"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -76,4 +77,15 @@ func Assert(ok bool) {
 func Caller() string {
 	_, file, line, _ := runtime.Caller(1)
 	return file + ":" + strconv.Itoa(line)
+}
+
+const (
+	unreserved = `A-Za-z0-9-._~`
+	subdelims  = `!$&'()*+,;=`
+	userinfo   = unreserved + subdelims + `%:`
+)
+
+func StripUserinfo(s string) string {
+	sanitizer := regexp.MustCompile(`://[` + userinfo + `]+@`)
+	return sanitizer.ReplaceAllString(s, `://***@`)
 }


### PR DESCRIPTION
I've found that `ffmpeg` can sometimes leak credentials through WebSocket error messages, as shown below:
<img width="761" height="104" alt="image" src="https://github.com/user-attachments/assets/f36149eb-e264-43af-81cc-21f17c8083a0" />

### How to reproduce

1. Create a `ffmpeg` stream with a non-existing URL.
```
streams:
  TEST:
    - ffmpeg:rtsp://username:password@10.1.2.3:554/stream1
```

2. Open the WebRTC stream URL:
```
http://localhost:1984/stream.html?src=TEST&mode=webrtc
```

The connection timed out error is an example, but I came across it on a 500 error caused by network instability between go2rtc and the cameras.

### How it could be exploited

On a system which uses _go2rtc_ for providing web access to RTSP cameras, a bad actor could disrupt a camera's network, attempt to open a WebRTC stream through _go2rtc_ and then read the WebSocket messages to get the system credentials for said camera. 
This can also happen on partial network outages, where the _go2rtc_ server is temporarily unable to communicate with the camera, but still able to communicate with clients.

It's not unusual - although terrible practice - to have a common password for multiple cameras, which can escalate the threat.

### Proposed Solution

This PR uses a simple regex to censor URL credentials sent on websocket error responses:

<img width="761" height="104" alt="image" src="https://github.com/user-attachments/assets/3672781d-00db-4325-9070-aeb8442484de" />

> Disclaimer 1: I'm not a Go developer, please let me know of any stylistic or organization issues with the code
> Disclaimer 2: This might affect other places where the raw error is returned, I didn't look deep into it. I believe however that WS is the widest attack surface on this issue.
