### PR TITLE
Possible fix for Raspberry Pi 4 hardware-encoded H.264 streams

### DIFF
--- a/pkg/flv/muxer.go
+++ b/pkg/flv/muxer.go
@@ -30,11 +30,27 @@ func (m *Muxer) GetInit() []byte {
 
 	obj := map[string]any{}
 
+	var metaWidth, metaHeight uint16
+	var metaFPS float64
+
 	for _, codec := range m.codecs {
 		switch codec.Name {
 		case core.CodecH264:
 			b[4] |= FlagsVideo
 			obj["videocodecid"] = CodecAVC
+
+			// Try to extract width/height and optional FPS from SPS
+			if sps, _ := h264.GetParameterSet(codec.FmtpLine); len(sps) > 0 {
+				if s := h264.DecodeSPS(sps); s != nil {
+					if metaWidth == 0 || metaHeight == 0 {
+						metaWidth = s.Width()
+						metaHeight = s.Height()
+					}
+					if f := s.FPS(); f > 0 {
+						metaFPS = f
+					}
+				}
+			}
 
 		case core.CodecAAC:
 			b[4] |= FlagsAudio
@@ -45,6 +61,15 @@ func (m *Muxer) GetInit() []byte {
 		}
 	}
 
+	// Fill optional width/height/framerate if known
+	if metaWidth > 0 && metaHeight > 0 {
+		obj["width"] = metaWidth
+		obj["height"] = metaHeight
+	}
+	if metaFPS > 0 {
+		obj["framerate"] = metaFPS
+	}
+
 	data := amf.EncodeItems("@setDataFrame", "onMetaData", obj)
 	b = append(b, EncodeTag(TagData, 0, data)...)
 
@@ -52,18 +77,12 @@ func (m *Muxer) GetInit() []byte {
 		switch codec.Name {
 		case core.CodecH264:
 			sps, pps := h264.GetParameterSet(codec.FmtpLine)
-			if len(sps) == 0 {
-				sps = []byte{0x67, 0x42, 0x00, 0x0a, 0xf8, 0x41, 0xa2}
-			} else {
+			if len(sps) > 0 && len(pps) > 0 {
 				h264.FixPixFmt(sps)
+				config := h264.EncodeConfig(sps, pps)
+				video := append(encodeAVData(codec, 0), config...)
+				b = append(b, EncodeTag(TagVideo, 0, video)...)
 			}
-			if len(pps) == 0 {
-				pps = []byte{0x68, 0xce, 0x38, 0x80}
-			}
-
-			config := h264.EncodeConfig(sps, pps)
-			video := append(encodeAVData(codec, 0), config...)
-			b = append(b, EncodeTag(TagVideo, 0, video)...)
 
 		case core.CodecAAC:
 			s := core.Between(codec.FmtpLine, "config=", ";")
@@ -85,8 +104,42 @@ func (m *Muxer) GetPayloader(codec *core.Codec) func(packet *rtp.Packet) []byte 
 	switch codec.Name {
 	case core.CodecH264:
 		buf := encodeAVData(codec, 1)
+		// Some RTSP servers (FFmpeg) don't provide sprop-parameter-sets in SDP.
+		// That makes initial FLV sequence header fallback to a generic SPS/PPS,
+		// which can confuse some RTMP ingests. Emit a real AVC sequence header
+		// once we see SPS/PPS inside the first Access Unit.
+		var sentRealHeader bool
 
 		return func(packet *rtp.Packet) []byte {
+			var header []byte
+			if !sentRealHeader {
+				// Try to extract SPS/PPS from the current AVCC payload
+				var sps, pps []byte
+				for _, nalu := range h264.SplitNALU(packet.Payload) {
+					switch h264.NALUType(nalu) {
+					case h264.NALUTypeSPS:
+						sps = nalu[4:]
+					case h264.NALUTypePPS:
+						pps = nalu[4:]
+					}
+				}
+				if len(sps) > 0 && len(pps) > 0 {
+					conf := h264.EncodeConfig(sps, pps)
+					hdr := append(encodeAVData(codec, 0), conf...)
+					// Propagate discovered SPS/PPS into codec fmtp so late joiners (e.g., WebRTC)
+					// have sprop-parameter-sets available.
+					if c := h264.ConfigToCodec(conf); c != nil {
+						codec.FmtpLine = c.FmtpLine
+					}
+					if ts0 == 0 {
+						ts0 = packet.Timestamp
+					}
+					timeMS := (packet.Timestamp - ts0) / k
+					header = EncodeTag(TagVideo, timeMS, hdr)
+					sentRealHeader = true
+				}
+			}
+
 			if h264.IsKeyframe(packet.Payload) {
 				buf[0] = 1<<4 | 7
 			} else {
@@ -100,7 +153,15 @@ func (m *Muxer) GetPayloader(codec *core.Codec) func(packet *rtp.Packet) []byte 
 			}
 
 			timeMS := (packet.Timestamp - ts0) / k
-			return EncodeTag(TagVideo, timeMS, buf)
+			frame := EncodeTag(TagVideo, timeMS, buf)
+			if len(header) > 0 {
+				// Emit real config immediately before the first frame containing SPS/PPS
+				out := make([]byte, 0, len(header)+len(frame))
+				out = append(out, header...)
+				out = append(out, frame...)
+				return out
+			}
+			return frame
 		}
 
 	case core.CodecAAC:

--- a/pkg/h264/sps.go
+++ b/pkg/h264/sps.go
@@ -364,3 +364,17 @@ func FixPixFmt(sps []byte) {
 		}
 	}
 }
+
+// FPS returns frames per second if timing info is present in SPS, otherwise 0.
+// Formula: fps = time_scale / (2 * num_units_in_tick) for progressive streams.
+// If timing info is absent, returns 0.
+func (s *SPS) FPS() float64 {
+	if s == nil {
+		return 0
+	}
+	if s.timing_info_present_flag == 0 || s.num_units_in_tick == 0 {
+		return 0
+	}
+	// Most streams are progressive; the H.264 spec uses the factor 2.
+	return float64(s.time_scale) / (2.0 * float64(s.num_units_in_tick))
+}

--- a/pkg/webrtc/api.go
+++ b/pkg/webrtc/api.go
@@ -200,7 +200,7 @@ func RegisterDefaultCodecs(m *webrtc.MediaEngine) error {
 			RTPCodecCapability: webrtc.RTPCodecCapability{
 				MimeType:     webrtc.MimeTypeH264,
 				ClockRate:    90000,
-				SDPFmtpLine:  "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640032",
+				SDPFmtpLine:  "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=640029",
 				RTCPFeedback: videoRTCPFeedback,
 			},
 			PayloadType: 98, // Chrome v110 - PayloadType: 112


### PR DESCRIPTION
To preface: This PR is very much vibe coded. I don’t have real knowledge of the project internals or Go. The changes are based on trial and error while testing Raspberry Pi 4 hardware encoding with a Logitech MJPEG webcam.  
I have no hard feelings when this PR is closed, I know that reviewing code takes time.

This is by no means an ask for merging this, but more of a "hoping" that parts of this code may help the projects or others.

## Problem
I am using a Raspberry Pi 4 (64bit) for streaming to a RTMP Provider using different USB Webcams by employing this project and ffmpeg (v7.1.1).  
For efficiency reasons I'm trying to use hardware encoding using `h264_v4l2m2m`.  
While the command works, the WebRTC Preview and the image received on the rtmp side is broken, rtmp receives an artifacted grey image, the preview says it's corrupted.

### Go2Rtc Config
As an example this is the config I'm using:
```yml

streams:
  Test:
    - exec:ffmpeg -hide_banner -nostats -use_wallclock_as_timestamps 1 -thread_queue_size 64 -f v4l2 -input_format mjpeg -framerate 24 -video_size 1920x1080 -i /dev/video0 -f lavfi -i "anullsrc=cl=stereo:r=48000" -c:a aac -b:a 128k -ar 48000 -ac 2 -b:v 5000k -maxrate 6000k -bufsize 15000k -vf "scale=in_range=pc:out_range=tv,pad=iw:1088:0:0:color=black,setsar=1,format=yuv420p" -c:v h264_v4l2m2m -g 48 -bf 0 -bsf:v h264_metadata=crop_bottom=8:video_full_range_flag=0:aud=insert -fps_mode cfr -f rtsp -rtsp_transport tcp {output}#killsignal=2#killtimeout=5
```

## Changes
Using codex I've described the problems mentioned above, arriving at the changes presented in this PR.

Transcript from codex:
### FLV/RTMP
  - pkg/flv/muxer.go
      - Add onMetaData width/height and framerate (parsed from H.264 SPS).
      - Don’t emit placeholder AVC config when fmtp lacks SPS/PPS.
      - Inject a real AVC sequence header once SPS/PPS appear in-band.
      - Propagate discovered SPS/PPS to codec.FmtpLine (sprop-parameter-sets) so later consumers pick them up.

###  H.264 pipeline
  - pkg/h264/sps.go
      - Add (*SPS) FPS() to compute fps from VUI timing (used in FLV metadata).
  - pkg/h264/rtp.go
      - Capture SPS/PPS from in-band AVCC and use as latest parameter set.
      - Prepend latest SPS/PPS to IDR if they’re missing (fixes first-frame decode).
  - pkg/h264/payloader.go
      - Remember latest SPS/PPS and prepend as STAP-A before IDR frames when needed.
  - pkg/webrtc/api.go
      - Advertise H.264 High 4.1 (profile-level-id=640029) for better compatibility.

## Result
With the changes included, and a fresh compile for my pi, the ffmpeg command now outputs a working image both in the preview and on my rtmp provider.
