### PR TITLE
Add compiled go2rtc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ go2rtc_linux*
 go2rtc_mac*
 go2rtc_win*
 
+/go2rtc
+
 0_test.go
 
 .DS_Store


### PR DESCRIPTION
This is the standard output location when you compile go2rtc.

It should avoid issues like [this](https://github.com/AlexxIT/go2rtc/pull/1909#discussion_r2426085632).