### PR TITLE
Log unknown producers

### DIFF
--- a/internal/streams/handlers.go
+++ b/internal/streams/handlers.go
@@ -27,6 +27,10 @@ func HasProducer(url string) bool {
 		if _, ok := redirects[scheme]; ok {
 			return true
 		}
+
+		log.Warn().Str("scheme", scheme).Msg("[streams] Unknown producer scheme")
+	} else {
+		log.Warn().Str("url", url).Msg("[streams] Invalid producer URL")
 	}
 
 	return false


### PR DESCRIPTION
So we have a warning log entry if an unknown (or not activated) source is used. This helps if a user tries to use a source that is not enabled or does not exist.