### PR TITLE
RTSP: Fix timestamp reset after reconnect

### DIFF
--- a/pkg/aac/adts.go
+++ b/pkg/aac/adts.go
@@ -8,8 +8,19 @@ import (
 	"github.com/pion/rtp"
 )
 
+const ADTSHeaderSize = 7
+
 func IsADTS(b []byte) bool {
-	return len(b) > 7 && b[0] == 0xFF && b[1]&0xF6 == 0xF0
+	// AAAAAAAA AAAABCCD EEFFFFGH HHIJKLMM MMMMMMMM MMMOOOOO OOOOOOPP (QQQQQQQQ QQQQQQQQ)
+	// A	12	Syncword, all bits must be set to 1.
+	// C	2	Layer, always set to 0.
+	return len(b) >= ADTSHeaderSize && b[0] == 0xFF && b[1]&0b1111_0110 == 0xF0
+}
+
+func HasCRC(b []byte) bool {
+	// AAAAAAAA AAAABCCD EEFFFFGH HHIJKLMM MMMMMMMM MMMOOOOO OOOOOOPP (QQQQQQQQ QQQQQQQQ)
+	// D	1	Protection absence, set to 1 if there is no CRC and 0 if there is CRC.
+	return b[1]&0b1 == 0
 }
 
 func ADTSToCodec(b []byte) *core.Codec {
@@ -58,7 +69,7 @@ func ADTSToCodec(b []byte) *core.Codec {
 func ReadADTSSize(b []byte) uint16 {
 	// AAAAAAAA AAAABCCD EEFFFFGH HHIJKLMM MMMMMMMM MMMOOOOO OOOOOOPP (QQQQQQQQ QQQQQQQQ)
 	_ = b[5] // bounds
-	return uint16(b[3]&0x03)<<(8+3) | uint16(b[4])<<3 | uint16(b[5]>>5)
+	return uint16(b[3]&0b11)<<11 | uint16(b[4])<<3 | uint16(b[5]>>5)
 }
 
 func WriteADTSSize(b []byte, size uint16) {

--- a/pkg/aac/rtp.go
+++ b/pkg/aac/rtp.go
@@ -8,7 +8,6 @@ import (
 )
 
 const RTPPacketVersionAAC = 0
-const ADTSHeaderSize = 7
 
 func RTPDepay(handler core.HandlerFunc) core.HandlerFunc {
 	var timestamp uint32
@@ -65,7 +64,8 @@ func RTPDepay(handler core.HandlerFunc) core.HandlerFunc {
 }
 
 func RTPPay(handler core.HandlerFunc) core.HandlerFunc {
-	sequencer := rtp.NewRandomSequencer()
+	var seq uint16
+	var ts uint32
 
 	return func(packet *rtp.Packet) {
 		if packet.Version != RTPPacketVersionAAC {
@@ -85,12 +85,15 @@ func RTPPay(handler core.HandlerFunc) core.HandlerFunc {
 			Header: rtp.Header{
 				Version:        2,
 				Marker:         true,
-				SequenceNumber: sequencer.NextSequenceNumber(),
-				Timestamp:      packet.Timestamp,
+				SequenceNumber: seq,
+				Timestamp:      ts,
 			},
 			Payload: payload,
 		}
 		handler(&clone)
+
+		seq++
+		ts += AUTime
 	}
 }
 


### PR DESCRIPTION
When a new client connects and requests a different track (e.g., first client wants video only, second client wants video+audio), go2rtc performs a reconnect. Some cameras (e.g., Tapo via ONVIF) reset their RTP timestamps to 0 after reconnect, which causes existing clients to receive packets with much lower timestamps than before.

**Error in ffmpeg:**
```
[null] Application provided invalid, non monotonically increasing dts to muxer in stream 0: 1051 >= 0
```

This causes ffmpeg to skip frames until it reaches the last valid PTS.

## Solution

Detect timestamp resets (when `timestamp == 0` after having received packets before) and apply a constant offset to maintain timestamp continuity for existing clients.

## Testing

```bash
# Terminal 1: First client (video only)
ffmpeg -loglevel debug -rtsp_transport tcp -i "rtsp://localhost:8554/camera?video" -f null -

# Terminal 2: Second client (video+audio) - triggers reconnect
ffmpeg -loglevel debug -rtsp_transport tcp -i "rtsp://localhost:8554/camera" -f null -
```

**Expected:** No "non monotonically increasing dts" errors in first client.