### PR TITLE
Adding onvif name and hardware in info field of onvif discovery

### DIFF
--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
@@ -186,12 +185,11 @@ func apiOnvif(w http.ResponseWriter, r *http.Request) {
 				u.Path = ""
 			}
 
-			var info string
-			info = strings.TrimSpace(device.Name + " " + device.Hardware)
-			if info == "" {
-				info = "ONVIF Device"
-			}
-			items = append(items, &api.Source{Name: u.Host, URL: u.String(), Info: info})
+			items = append(items, &api.Source{
+				Name: u.Host,
+				URL:  u.String(),
+				Info: device.Name + " " + device.Hardware,
+			})
 		}
 	} else {
 		client, err := onvif.NewClient(src)


### PR DESCRIPTION
I like the onvif discover functinality in the add section, but I wanted some device information.
So I added code to extract the `onvif://www.onvif.org/name` and `onvif://www.onvif.org/hardware` fields from the onvif envelope and used it to populate the `Info` field already present in the `api.Source` object.
To better present this change, I created the `DiscoveryDevice` type in `pkg/onvif/helpers.go` with the fields being:
```go
type DiscoveryDevice struct {
	URL      string
	Name     string
	Hardware string
}
``` 
For clarity purposes, I also renamed the function `DiscoveryStreamingURLs` to `DiscoveryStreamingDevices` from the same package.