### PR TITLE
Allow rtsp params (like #backchannel=0) from onvif sources

### DIFF
--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -34,9 +34,6 @@ func Init() {
 var log zerolog.Logger
 
 func streamOnvif(rawURL string) (core.Producer, error) {
-	// Split the ONVIF URL to extract hash-based arguments
-	rawURL, rawQuery, _ := strings.Cut(rawURL, "#")
-
 	client, err := onvif.NewClient(rawURL)
 	if err != nil {
 		return nil, err
@@ -48,8 +45,8 @@ func streamOnvif(rawURL string) (core.Producer, error) {
 	}
 
 	// Append hash-based arguments to the retrieved URI
-	if rawQuery != "" {
-		uri = uri + "#" + rawQuery
+	if i := strings.IndexByte(rawURL, '#'); i > 0 {
+		uri += rawURL[i:]
 	}
 
 	log.Debug().Msgf("[onvif] new uri=%s", uri)


### PR DESCRIPTION
I added these lines since i needed to disable the backchannel on an onvif source and I did not find a way to do it, so I added this parameters re-append in the resulting stream uri.
I did this because i have issues with the video stream disconnecting when reproducing audio files to the camera if the source is just onvif.

This would allow sources like onvif://user:password@ip:port/onvif/device_service#backchannel=0 to work with the backchannel disabled.
An example from my usage is:
```
streams:
  camera1:
    - onvif://user:password@ip:8000/onvif/device_service#backchannel=0
    - onvif://user:password@ip:8000/onvif/device_service#backchannel=1#media=audio
```

This is a re-creation of PR #1959 because I messed up the branches on my fork