### PR TITLE
Add EXPOSE to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,8 +47,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then apk add --no-cache libva-intel-driver
 
 COPY --from=build /build/go2rtc /usr/local/bin/
 
-EXPOSE 1984 8554 8555
-EXPOSE 8555/udp
+EXPOSE 1984 8554 8555 8555/udp
 ENTRYPOINT ["/sbin/tini", "--"]
 VOLUME /config
 WORKDIR /config

--- a/docker/hardware.Dockerfile
+++ b/docker/hardware.Dockerfile
@@ -49,8 +49,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 
 COPY --from=build /build/go2rtc /usr/local/bin/
 
-EXPOSE 1984 8554 8555
-EXPOSE 8555/udp
+EXPOSE 1984 8554 8555 8555/udp
 ENTRYPOINT ["/usr/bin/tini", "--"]
 VOLUME /config
 WORKDIR /config

--- a/docker/rockchip.Dockerfile
+++ b/docker/rockchip.Dockerfile
@@ -43,8 +43,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
 COPY --from=build /build/go2rtc /usr/local/bin/
 ADD --chmod=755 https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/download/6.1-8-no_extra_dump/ffmpeg /usr/local/bin
 
-EXPOSE 1984 8554 8555
-EXPOSE 8555/udp
+EXPOSE 1984 8554 8555 8555/udp
 ENTRYPOINT ["/usr/bin/tini", "--"]
 VOLUME /config
 WORKDIR /config


### PR DESCRIPTION
FYI this doesn't actually forward the ports when running. That still has to be done manually in docker compose or docker run. It's just an indication that these are the ports used. Other services, like traefik, can use this information to automatically reverse proxy requests to the correct port.