### PR TITLE
xiaomi/cs2: fix TCP keepalive to match official Mi Home app

### DIFF
--- a/pkg/xiaomi/cs2/conn.go
+++ b/pkg/xiaomi/cs2/conn.go
@@ -24,16 +24,8 @@ func Dial(host, transport string) (*Conn, error) {
 		isTCP:  isTCP,
 		rawCh0: make(chan []byte, 10),
 		rawCh2: make(chan []byte, 100),
-		done:   make(chan struct{}),
 	}
 	go c.worker()
-
-	// For TCP connections, start independent keepalive goroutine
-	// Official Mi Home app sends PING every 1 second bidirectionally
-	if isTCP {
-		go c.keepalive()
-	}
-
 	return c, nil
 }
 
@@ -46,7 +38,6 @@ type Conn struct {
 	seqCh3 uint16
 	rawCh0 chan []byte
 	rawCh2 chan []byte
-	done   chan struct{} // signals connection close to keepalive goroutine
 
 	cmdMu  sync.Mutex
 	cmdAck func()
@@ -63,7 +54,6 @@ const (
 	msgDrwAck    = 0xD1
 	msgPing      = 0xE0
 	msgPong      = 0xE1
-	msgAlive     = 0xF0 // Camera heartbeat/alive signal
 	msgClose     = 0xF1
 )
 
@@ -112,38 +102,17 @@ func handshake(host, transport string) (net.Conn, error) {
 	return conn, nil
 }
 
-// keepalive sends PING every 1 second for TCP connections.
-// Based on PCAP analysis of official Mi Home app: both sides send PING bidirectionally,
-// neither responds with PONG. This keeps the connection alive.
-func (c *Conn) keepalive() {
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	ping := []byte{magic, msgPing, 0, 0}
-
-	for {
-		select {
-		case <-c.done:
-			return
-		case <-ticker.C:
-			if _, err := c.conn.Write(ping); err != nil {
-				return
-			}
-		}
-	}
-}
-
 func (c *Conn) worker() {
 	defer func() {
 		close(c.rawCh0)
 		close(c.rawCh2)
-		close(c.done) // signal keepalive goroutine to stop
 	}()
 
 	chAck := make([]uint16, 4) // only for UDP
 	buf := make([]byte, 1200)
 	var ch2WaitSize int
 	var ch2WaitData []byte
+	var keepaliveTS time.Time
 
 	for {
 		n, err := c.conn.Read(buf)
@@ -156,7 +125,14 @@ func (c *Conn) worker() {
 		case msgDrw:
 			ch := buf[5]
 
-			if !c.isTCP {
+			if c.isTCP {
+				// For TCP we should send ping every second to keep connection alive.
+				// Based on PCAP analysis: official Mi Home app sends PING every ~1s.
+				if now := time.Now(); now.After(keepaliveTS) {
+					_, _ = c.conn.Write([]byte{magic, msgPing, 0, 0})
+					keepaliveTS = now.Add(time.Second)
+				}
+			} else {
 				// For UDP we should using ack.
 				seqHI := buf[6]
 				seqLO := buf[7]
@@ -204,11 +180,7 @@ func (c *Conn) worker() {
 			}
 
 		case msgPing:
-			// Official Mi Home app: both sides send PING, neither responds with PONG
-			// Just acknowledge receipt, don't send PONG
-			continue
-		case msgAlive:
-			// Some cameras may send 0xF0 as heartbeat - just ignore like PING
+			_, _ = c.conn.Write([]byte{magic, msgPong, 0, 0})
 			continue
 		case msgPong, msgP2PRdyUDP, msgP2PRdyTCP, msgClose:
 			continue // skip it


### PR DESCRIPTION
# Pull Request: Fix Xiaomi CS2 TCP Keepalive

> edit: attached pcap file for reference

## Title
`xiaomi/cs2: fix TCP keepalive to match official Mi Home app`

---

## Summary

Fixes connection resets and timeouts during prolonged streaming sessions with Xiaomi cameras using the CS2 P2P protocol over TCP.

**Root Cause:** The keepalive mechanism was incorrect - sending PING every 5 seconds (only when receiving data) and responding to PING with PONG.

**Fix:** Based on PCAP analysis of official Mi Home app traffic:
- Send PING every 1 second via independent goroutine
- Don't respond to PING with PONG (official app doesn't either)
- Both sides send PING bidirectionally as heartbeats

---

## Problem

Users with Xiaomi cameras (`chuangmi.camera.*` models) experience:
- `connection reset by peer` errors after several minutes of streaming
- `i/o timeout` errors during long sessions
- Frequent reconnection cycles (working briefly, then disconnecting)

Example error:
```
error="miss: read media: cs2: read tcp 192.168.x.x:xxxxx->192.168.x.x:xxxxx: read: connection reset by peer"
```

---

## Analysis

Captured and analyzed PCAP traffic from official Mi Home Android app:

| Message Type | Count in PCAP |
|-------------|---------------|
| PING (0xE0) | **199** |
| PONG (0xE1) | **0** |
| ALIVE (0xF0) | **0** |

**Key findings:**
1. Official app sends PING every ~1 second continuously
2. Camera also sends PING every ~1 second
3. **Neither side responds with PONG** - they just both keep pinging
4. This continues throughout the entire streaming session

**Before (broken behavior):**
```go
// In worker loop, tied to receiving data
if now := time.Now(); now.After(keepaliveTS) {
    c.conn.Write([]byte{magic, msgPing, 0, 0})
    keepaliveTS = now.Add(5 * time.Second)  // Too slow!
}

// Responded to PING with PONG (wrong!)
case msgPing:
    c.conn.Write([]byte{magic, msgPong, 0, 0})
```

**After (matches official app):**
```go
// Independent goroutine, sends every 1 second
func (c *Conn) keepalive() {
    ticker := time.NewTicker(time.Second)
    for {
        select {
        case <-c.done:
            return
        case <-ticker.C:
            c.conn.Write([]byte{magic, msgPing, 0, 0})
        }
    }
}

// Don't respond to PING
case msgPing:
    continue  // Just acknowledge, no PONG
```

---

## Changes

- `pkg/xiaomi/cs2/conn.go`:
  - Add `done` channel to `Conn` struct for goroutine lifecycle management
  - Add `msgAlive` constant (0xF0) for completeness
  - Add `keepalive()` goroutine that sends PING every 1 second for TCP
  - Remove old data-dependent keepalive from worker loop
  - Fix PING handler to not send PONG (matches official app)
  - Add handler for `msgAlive` (0xF0) that some cameras may send

---

## Testing

- ✅ 30-second test: No errors
- ✅ 10-minute test: Stream stable, no disconnects

---

## Related Issues

- #2026 

## Attached the pcap file
[p2p.pcap.zip](https://github.com/user-attachments/files/24548840/p2p.pcap.zip)

