### PR TITLE
Add `media` query param to dvrip source

### DIFF
--- a/pkg/dvrip/dvrip.go
+++ b/pkg/dvrip/dvrip.go
@@ -1,10 +1,14 @@
 package dvrip
 
-import "github.com/AlexxIT/go2rtc/pkg/core"
+import (
+	"net/url"
 
-func Dial(url string) (core.Producer, error) {
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+func Dial(rawURL string) (core.Producer, error) {
 	client := &Client{}
-	if err := client.Dial(url); err != nil {
+	if err := client.Dial(rawURL); err != nil {
 		return nil, err
 	}
 
@@ -18,6 +22,11 @@ func Dial(url string) (core.Producer, error) {
 
 	if client.stream != "" {
 		prod := &Producer{Connection: conn, client: client}
+
+		if u, err := url.Parse(rawURL); err == nil {
+			prod.Media = u.Query().Get("media")
+		}
+
 		if err := prod.probe(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This works very similar to the `#media` in RTSP source.

```yaml
streams:
  # take only video
  test: dvrip://admin:pass@192.168.1.37:34567?channel=0&subtype=0&media=video
  # take only audio
  test: dvrip://admin:pass@192.168.1.37:34567?channel=0&subtype=0&media=audio
```
