### PR TITLE
docs: fix link to updated JSONSchema

### DIFF
--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -35,7 +35,7 @@ rtsp:
 Editors like [GoLand](https://www.jetbrains.com/go/) and [VS Code](https://code.visualstudio.com/) supports autocomplete and syntax validation.
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/AlexxIT/go2rtc/master/website/schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/AlexxIT/go2rtc/master/www/schema.json
 ```
 
 ## Defaults


### PR DESCRIPTION
Moved in commit 1ec40f2fc33cfb4b71cbf1e6ea60580c3aa1e55d, this is just a small PR updating the documentation to point to its new home