### PR TITLE
📝 docs(README): update documentation for clarity and accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ streams:
 - **Dahua Doorbell** users may want to change [audio codec](https://github.com/AlexxIT/go2rtc/issues/49#issuecomment-2127107379) for proper two-way audio. Make sure not to request backchannel multiple times by adding `#backchannel=0` to other stream sources of the same doorbell. The `unicast=true&proto=Onvif` is preferred for two-way audio as this makes the doorbell accept multiple codecs for the incoming audio
 - **Reolink** users may want NOT to use RTSP protocol at all, some camera models have a very awful, unusable stream implementation
 - **Ubiquiti UniFi** users may want to disable HTTPS verification. Use `rtspx://` prefix instead of `rtsps://`. And don't use `?enableSrtp` [suffix](https://github.com/AlexxIT/go2rtc/issues/81)
-- **TP-Link Tapo** users may skip login and password, because go2rtc support login [without them](https://drmnsamoliu.github.io/video.html)
+- **TP-Link Tapo** users may skip login and password, because go2rtc supports login [without them](https://drmnsamoliu.github.io/video.html)
 - If your camera has two RTSP links, you can add both as sources. This is useful when streams have different codecs, for example AAC audio with main stream and PCMU/PCMA audio with second stream
 - If the stream from your camera is glitchy, try using [ffmpeg source](#source-ffmpeg). It will not add CPU load if you don't use transcoding
 - If the stream from your camera is very glitchy, try to use transcoding with [ffmpeg source](#source-ffmpeg)
@@ -727,7 +727,7 @@ streams:
 
 ## Source: Ring
 
-This source type support Ring cameras with [two-way audio](#two-way-audio) support. If you have a `refresh_token` and `device_id` - you can use it in `go2rtc.yaml` config file. Otherwise, you can use the go2rtc interface and add your ring account (WebUI > Add > Ring). Once added, it will list all your Ring cameras.
+This source type supports Ring cameras with [two-way audio](#two-way-audio) support. If you have a `refresh_token` and `device_id`, you can use them in the `go2rtc.yaml` config file. Otherwise, you can use the go2rtc web interface and add your Ring account (WebUI > Add > Ring). Once added, it will list all your Ring cameras.
 
 ```yaml
 streams:
@@ -745,9 +745,9 @@ This source type supports Roborock vacuums with cameras. Known working models:
 - Roborock S7 MaxV - video and two-way audio
 - Roborock Qrevo MaxV - video and two-way audio
 
-Source supports loading Roborock credentials from Home Assistant [custom integration](https://github.com/humbertogontijo/homeassistant-roborock) or the [core integration](https://www.home-assistant.io/integrations/roborock). Otherwise, you need to log in to your Roborock account (MiHome account is not supported). Go to: go2rtc WebUI > Add webpage. Copy `roborock://...` source for your vacuum and paste it to `go2rtc.yaml` config.
+This source supports loading Roborock credentials from the Home Assistant [custom integration](https://github.com/humbertogontijo/homeassistant-roborock) or the [core integration](https://www.home-assistant.io/integrations/roborock). Otherwise, you need to log in to your Roborock account (MiHome account is not supported). Go to go2rtc WebUI > Add webpage. Copy the `roborock://...` source for your vacuum and paste it into your `go2rtc.yaml` config.
 
-If you have a graphic PIN for your vacuum, add it as a numeric PIN (lines: 123, 456, 789) to the end of the `roborock` link.
+If you have a pattern PIN for your vacuum, add it as a numeric PIN (lines: 123, 456, 789) to the end of the `roborock` link.
 
 ## Source: Doorbird
 
@@ -948,7 +948,7 @@ streams:
 
 The HTTP API is the main part for interacting with the application. Default address: `http://localhost:1984/`.
 
-**Important!** go2rtc passes requests from localhost and from Unix sockets without HTTP authorisation, even if you have it configured! It is your responsibility to set up secure external access to the API. If not properly configured, an attacker can gain access to your cameras and even your server.
+**Important!** go2rtc passes requests from localhost and Unix sockets without HTTP authorization, even if you have it configured. It is your responsibility to set up secure external access to the API. If not properly configured, an attacker can gain access to your cameras and even your server.
 
 [API description](api/README.md).
 
@@ -1348,7 +1348,7 @@ Some examples:
 
 **Audio**
 
-- Go2rtc support [automatic repack](#built-in-transcoding) `PCMA/PCMU/PCM` codecs to `FLAC` for MSE/MP4/HLS so they will work almost anywhere
+- go2rtc supports [automatic repackaging](#built-in-transcoding) of `PCMA/PCMU/PCM` codecs into `FLAC` for MSE/MP4/HLS so they'll work almost anywhere
 - **WebRTC** audio codecs: `PCMU/8000`, `PCMA/8000`, `OPUS/48000/2`
 - `OPUS` and `MP3` inside **MP4** are part of the standard, but some players do not support them anyway (especially Apple)
 
@@ -1399,15 +1399,15 @@ PCMU/xxx => PCMU/8000 => WebRTC
 
 # Codecs negotiation
 
-For example, you want to watch RTSP-stream from [Dahua IPC-K42](https://www.dahuasecurity.com/fr/products/All-Products/Network-Cameras/Wireless-Series/Wi-Fi-Series/4MP/IPC-K42) camera in your Chrome browser.
+For example, you want to watch an RTSP stream from a [Dahua IPC-K42](https://www.dahuasecurity.com/fr/products/All-Products/Network-Cameras/Wireless-Series/Wi-Fi-Series/4MP/IPC-K42) camera in your Chrome browser.
 
 - this camera supports two-way audio standard **ONVIF Profile T**
-- this camera supports codecs **H264, H265** for send video, and you select `H264` in camera settings
+- this camera supports codecs **H264, H265** for sending video, and you select `H264` in camera settings
 - this camera supports codecs **AAC, PCMU, PCMA** for sending audio (from mic), and you select `AAC/16000` in camera settings
 - this camera supports codecs **AAC, PCMU, PCMA** for receiving audio (to speaker), you don't need to select them
 - your browser supports codecs **H264, VP8, VP9, AV1** for receiving video, you don't need to select them
 - your browser supports codecs **OPUS, PCMU, PCMA** for sending and receiving audio, you don't need to select them
-- you can't get camera audio directly, because its audio codecs don't match with your browser codecs
+- you can't get the camera audio directly because its audio codecs don't match your browser's codecs
   - so you decide to use transcoding via FFmpeg and add this setting to the config YAML file
   - you have chosen `OPUS/48000/2` codec, because it is higher quality than the `PCMU/8000` or `PCMA/8000`
 
@@ -1420,7 +1420,7 @@ streams:
     - ffmpeg:rtsp://admin:password@192.168.1.123/cam/realmonitor?channel=1&subtype=0#audio=opus
 ```
 
-**go2rtc** automatically matches codecs for your browser and all your stream sources. This is called **multi-source two-way codec negotiation**. And this is one of the main features of this app.
+**go2rtc** automatically matches codecs for your browser across all of your stream sources. This is called **multi-source two-way codec negotiation**, and it's one of the main features of this app.
 
 ![Codec negotiation](assets/codecs.svg)
 

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -1,17 +1,17 @@
-- By default go2rtc will search config file `go2rtc.yaml` in current work directory
-- go2rtc support multiple config files:
-  - `go2rtc -c config1.yaml -c config2.yaml -c config3.yaml` 
-- go2rtc support inline config as multiple formats from command line:
+- By default, go2rtc will search for the `go2rtc.yaml` config file in the current working directory
+- go2rtc supports multiple config files:
+  - `go2rtc -c config1.yaml -c config2.yaml -c config3.yaml`
+- go2rtc supports inline config in multiple formats from the command line:
   - **YAML**: `go2rtc -c '{log: {format: text}}'`
   - **JSON**: `go2rtc -c '{"log":{"format":"text"}}'`
   - **key=value**: `go2rtc -c log.format=text`
-- Every next config will overwrite previous (but only defined params)
+- Each subsequent config will overwrite the previous one (but only for defined params)
 
 ```
 go2rtc -config "{log: {format: text}}" -config /config/go2rtc.yaml -config "{rtsp: {listen: ''}}" -config /usr/local/go2rtc/go2rtc.yaml
 ```
 
-or simple version
+or a simpler version
 
 ```
 go2rtc -c log.format=text -c /config/go2rtc.yaml -c rtsp.listen='' -c /usr/local/go2rtc/go2rtc.yaml
@@ -32,7 +32,7 @@ rtsp:
 
 ## JSON Schema
 
-Editors like [GoLand](https://www.jetbrains.com/go/) and [VS Code](https://code.visualstudio.com/) supports autocomplete and syntax validation.
+Editors like [GoLand](https://www.jetbrains.com/go/) and [VS Code](https://code.visualstudio.com/) support autocomplete and syntax validation.
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/AlexxIT/go2rtc/master/www/schema.json

--- a/internal/ffmpeg/hardware/README.md
+++ b/internal/ffmpeg/hardware/README.md
@@ -2,21 +2,21 @@
 
 You **DON'T** need hardware acceleration if:
 
-- you not using [FFmpeg source](https://github.com/AlexxIT/go2rtc#source-ffmpeg)
-- you using only `#video=copy` for FFmpeg source
-- you using only `#audio=...` (any audio) transcoding for FFmpeg source
+- you're not using the [FFmpeg source](https://github.com/AlexxIT/go2rtc#source-ffmpeg)
+- you're using only `#video=copy` for the FFmpeg source
+- you're using only `#audio=...` (any audio) transcoding for the FFmpeg source
 
-You **NEED** hardware acceleration if you using `#video=h264`, `#video=h265`, `#video=mjpeg` (video) transcoding.
+You **NEED** hardware acceleration if you're using `#video=h264`, `#video=h265`, `#video=mjpeg` (video) transcoding.
 
 ## Important
 
-- Acceleration is disabled by default because it can be unstable (it can be changed in future)
+- Acceleration is disabled by default because it can be unstable (this may change in the future)
 - go2rtc can automatically detect supported hardware acceleration if enabled
-- go2rtc will enable hardware decoding only if hardware encoding supported
+- go2rtc will enable hardware decoding only if hardware encoding is supported
 - go2rtc will use the same GPU for decoder and encoder
-- Intel and AMD will switch to software decoder if input codec is not supported with hardware decoder
-- NVidia will fail if input codec is not supported with hardware decoder
-- Raspberry always uses software decoder
+- Intel and AMD will switch to a software decoder if the input codec isn't supported by the hardware decoder
+- NVIDIA will fail if the input codec isn't supported by the hardware decoder
+- Raspberry Pi always uses a software decoder
 
 ```yaml
 streams:
@@ -31,41 +31,41 @@ streams:
 
 There are two versions of the Docker container and Hass Add-on:
 
-- Latest (alpine) support hardware acceleration for Intel iGPU (CPU with Graphics) and Raspberry.
-- Hardware (debian 12) support Intel iGPU, AMD GPU, NVidia GPU.
+- Latest (Alpine) supports hardware acceleration for Intel iGPU (CPU with graphics) and Raspberry Pi.
+- Hardware (Debian 12) supports Intel iGPU, AMD GPU, NVIDIA GPU.
 
 ## Intel iGPU
 
 **Supported on:** Windows binary, Linux binary, Docker, Hass Addon.
 
-If you have Intel CPU Sandy Bridge (2011) with Graphics, you already have support hardware decoding/encoding for `AVC/H.264`.
+If you have an Intel Sandy Bridge (2011) CPU with graphics, you already have hardware decoding/encoding support for `AVC/H.264`.
 
-If you have Intel CPU Skylake (2015) with Graphics, you already have support hardware decoding/encoding for `AVC/H.264`, `HEVC/H.265` and `MJPEG`.
+If you have an Intel Skylake (2015) CPU with graphics, you already have hardware decoding/encoding support for `AVC/H.264`, `HEVC/H.265` and `MJPEG`.
 
 Read more [here](https://en.wikipedia.org/wiki/Intel_Quick_Sync_Video#Hardware_decoding_and_encoding) and [here](https://en.wikipedia.org/wiki/Intel_Graphics_Technology#Capabilities_(GPU_video_acceleration)).
 
 Linux and Docker:
 
-- It may be important to have the latest version of the OS with the latest version of the Linux kernel. For example, on my **Debian 10 (kernel 4.19)** it did not work, but after update to **Debian 11 (kernel 5.10)** all was fine.
-- In case of trouble check you have `/dev/dri/` folder on your host.
+- It may be important to have a recent OS and Linux kernel. For example, on my **Debian 10 (kernel 4.19)** it did not work, but after updating to **Debian 11 (kernel 5.10)** everything was fine.
+- If you run into trouble, check that you have the `/dev/dri/` folder on your host.
 
-Docker users should add `--privileged` option to container for access to Hardware.
+Docker users should add the `--privileged` option to the container for access to the hardware.
 
 **PS.** Supported via [VAAPI](https://trac.ffmpeg.org/wiki/Hardware/VAAPI) engine on Linux and [DXVA2+QSV](https://trac.ffmpeg.org/wiki/Hardware/QuickSync) engine on Windows.
 
 ## AMD GPU
 
-*I don't have the hardware for test support!!!*
+*I don't have the hardware to test this!!!*
 
 **Supported on:** Linux binary, Docker, Hass Addon.
 
-Docker users should install: `alexxit/go2rtc:master-hardware`. Docker users should add `--privileged` option to container for access to Hardware.
+Docker users should install: `alexxit/go2rtc:master-hardware`. Docker users should add the `--privileged` option to the container for access to the hardware.
 
 Hass Addon users should install **go2rtc master hardware** version.
 
 **PS.** Supported via [VAAPI](https://trac.ffmpeg.org/wiki/Hardware/VAAPI) engine.
 
-## NVidia GPU
+## NVIDIA GPU
 
 **Supported on:** Windows binary, Linux binary, Docker.
 
@@ -79,11 +79,11 @@ Read more [here](https://docs.frigate.video/configuration/hardware_acceleration)
 
 **Supported on:** Linux binary, Docker, Hass Addon.
 
-I don't recommend using transcoding on the Raspberry Pi 3. It's extremely slow, even with hardware acceleration. Also it may fail when transcoding 2K+ stream.
+I don't recommend using transcoding on the Raspberry Pi 3. It's extremely slow, even with hardware acceleration. Also, it may fail when transcoding a 2K+ stream.
 
 ## Raspberry Pi 4
 
-*I don't have the hardware for test support!!!*
+*I don't have the hardware to test this!!!*
 
 **Supported on:** Linux binary, Docker, Hass Addon.
 
@@ -91,16 +91,16 @@ I don't recommend using transcoding on the Raspberry Pi 3. It's extremely slow, 
 
 ## macOS
 
-In my tests, transcoding is faster on the M1 CPU than on the M1 GPU. Transcoding time on M1 CPU better than any Intel iGPU and comparable to NVidia RTX 2070.
+In my tests, transcoding is faster on the M1 CPU than on the M1 GPU. Transcoding time on the M1 CPU is better than any Intel iGPU and comparable to an NVIDIA RTX 2070.
 
 **PS.** Supported via [videotoolbox](https://trac.ffmpeg.org/wiki/HWAccelIntro#VideoToolbox) engine.
 
 ## Rockchip
 
-- Important to use custom FFmpeg with Rockchip support from [@nyanmisaka](https://github.com/nyanmisaka/ffmpeg-rockchip)
+- It's important to use a custom FFmpeg build with Rockchip support from [@nyanmisaka](https://github.com/nyanmisaka/ffmpeg-rockchip)
   - Static binaries from [@MarcA711](https://github.com/MarcA711/Rockchip-FFmpeg-Builds/releases/)
-- Important to have Linux kernel 5.10 or 6.1
+- It's important to have Linux kernel 5.10 or 6.1
 
 **Tested**
 
-- [Orange Pi 3B](https://www.armbian.com/orangepi3b/) with Armbian 6.1, support transcoding H264, H265, MJPEG
+- [Orange Pi 3B](https://www.armbian.com/orangepi3b/) with Armbian 6.1, supports transcoding H.264, H.265, MJPEG

--- a/internal/gopro/README.md
+++ b/internal/gopro/README.md
@@ -3,14 +3,14 @@
 Supported models: HERO9, HERO10, HERO11, HERO12.  
 Supported OS: Linux, Mac, Windows, [HassOS](https://www.home-assistant.io/installation/)
 
-The other camera models have different APIs. I will try to add them in the next versions.
+Other camera models have different APIs. I will try to add them in future versions.
 
 ## Config
 
 - USB-connected cameras create a new network interface in the system
 - Linux users do not need to install anything
 - Windows users should install the [network driver](https://community.gopro.com/s/article/GoPro-Webcam)
-- if the camera is detected but the stream does not start - you need to disable firewall
+- if the camera is detected but the stream does not start, you need to disable the firewall
 
 1. Discover camera address: WebUI > Add > GoPro
 2. Add camera to config

--- a/internal/mjpeg/README.md
+++ b/internal/mjpeg/README.md
@@ -1,13 +1,13 @@
 # MJPEG
 
-**Important.** For stream in MJPEG format, your source MUST contain the MJPEG codec. If your stream has an MJPEG codec, you can receive **MJPEG stream** or **JPEG snapshots** via API.
+**Important.** For a stream in MJPEG format, your source MUST contain the MJPEG codec. If your stream has the MJPEG codec, you can receive an **MJPEG stream** or **JPEG snapshots** via the API.
 
 You can receive an MJPEG stream in several ways:
 
 - some cameras support MJPEG codec inside [RTSP stream](#source-rtsp) (ex. second stream for Dahua cameras)
 - some cameras have an HTTP link with [MJPEG stream](#source-http)
 - some cameras have an HTTP link with snapshots - go2rtc can convert them to [MJPEG stream](#source-http)
-- you can convert H264/H265 stream from your camera via [FFmpeg integraion](#source-ffmpeg)
+- you can convert an H264/H265 stream from your camera via [FFmpeg integration](#source-ffmpeg)
 
 With this example, your stream will have both H264 and MJPEG codecs:
 
@@ -23,7 +23,7 @@ streams:
 **MJPEG stream**
 
 ```
-http://192.168.1.123:1984/api/stream.mjpeg?src=camera1`
+http://192.168.1.123:1984/api/stream.mjpeg?src=camera1
 ```
 
 **JPEG snapshots**
@@ -32,13 +32,13 @@ http://192.168.1.123:1984/api/stream.mjpeg?src=camera1`
 http://192.168.1.123:1984/api/frame.jpeg?src=camera1
 ```
 
-- You can use `width`/`w` and/or `height`/`h` params.
+- You can use `width`/`w` and/or `height`/`h` parameters.
 - You can use `rotate` param with `90`, `180`, `270` or `-90` values.
 - You can use `hardware`/`hw` param [read more](https://github.com/AlexxIT/go2rtc/wiki/Hardware-acceleration).
 - You can use `cache` param (`1m`, `10s`, etc.) to get a cached snapshot.
   - The snapshot is cached only when requested with the `cache` parameter.
   - A cached snapshot will be used if its time is not older than the time specified in the `cache` parameter.
-  - The `cache` parameter does not check the image sizes from the cache and those specified in the query.
+  - The `cache` parameter does not check the image dimensions from the cache and those specified in the query.
 
 ## Stream as ASCII to Terminal
 
@@ -49,9 +49,9 @@ http://192.168.1.123:1984/api/frame.jpeg?src=camera1
 - this feature works only with MJPEG codec (use transcoding)
 - choose a low frame rate (FPS)
 - choose the width and height to fit in your terminal
-- different terminals support different numbers of colours (8, 256, rgb)
-- escape text param with urlencode
-- you can stream any camera or file from a disc
+- different terminals support different numbers of colors (8, 256, rgb)
+- URL-encode the `text` parameter
+- you can stream any camera or file from disk
 
 **go2rtc.yaml** - transcoding to MJPEG, terminal size - 210x59 (16/9), fps - 10
 
@@ -66,7 +66,7 @@ streams:
   - example: `30` (black), `37` (white), `38;5;226` (yellow)
 - `back` - background color, values: empty, `8`, `256`, `rgb`, [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code)
   - example: `40` (black), `47` (white), `48;5;226` (yellow)
-- `text` - character set, values: empty, one char, `block`, list of chars (in order of brightness)
+- `text` - character set, values: empty, one character, `block`, list of chars (in order of brightness)
   - example: `%20` (space), `block` (keyword for block elements), `ox` (two chars)
 
 **Examples**

--- a/internal/ngrok/README.md
+++ b/internal/ngrok/README.md
@@ -1,19 +1,19 @@
-With ngrok integration, you can get external access to your streams in situations when you have Internet with a private IP address.
+With the ngrok integration, you can get external access to your streams when your Internet connection is behind a private IP address.
 
 - you may need external access for two different things:
-    - WebRTC stream, so you need a tunnel WebRTC TCP port (ex. 8555)
-    - go2rtc web interface, so you need a tunnel API HTTP port (ex. 1984)
+    - WebRTC streams (tunnel the WebRTC TCP port, e.g. 8555)
+    - go2rtc web interface (tunnel the API HTTP port, e.g. 1984)
 - ngrok supports authorization for your web interface
 - ngrok automatically adds HTTPS to your web interface
 
 The ngrok free subscription has the following limitations:
 
-- You can reserve a free domain for serving the web interface, but the TCP address you get will always be random and change with each restart of the ngrok agent (not a problem for WebRTC stream)
+- You can reserve a free domain for serving the web interface, but the TCP address you get will always be random and will change with each restart of the ngrok agent (not a problem for WebRTC streams)
 - You can forward multiple ports from a single agent, but you can only run one ngrok agent on the free plan
 
-go2rtc will automatically get your external TCP address (if you enable it in ngrok config) and use it with WebRTC connection (if you enable it in webrtc config).
+go2rtc will automatically get your external TCP address (if you enable it in the ngrok config) and use it for WebRTC connections (if you enable it in the WebRTC config).
 
-You need to manually download the [ngrok agent app](https://ngrok.com/download) for your OS and register with the [ngrok service](https://ngrok.com/signup).
+You need to manually download the [ngrok agent](https://ngrok.com/download) for your OS and register with the [ngrok service](https://ngrok.com/signup).
 
 **Tunnel for only WebRTC Stream**
 

--- a/internal/streams/preload.go
+++ b/internal/streams/preload.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Preload struct {
-	stream *Stream      // Don't output the stream to JSON to not worry about its secrets.
+	stream *Stream      // Don't include the stream in JSON to avoid leaking secrets.
 	Cons   *probe.Probe `json:"consumer"`
 	Query  string       `json:"query"`
 }

--- a/internal/tuya/README.md
+++ b/internal/tuya/README.md
@@ -2,7 +2,7 @@
 
 *[New in v1.9.13](https://github.com/AlexxIT/go2rtc/releases/tag/v1.9.13)*
 
-[Tuya](https://www.tuya.com/) proprietary camera protocol with **two way audio** support. Go2rtc supports `Tuya Smart API` and `Tuya Cloud API`.
+[Tuya](https://www.tuya.com/) is a proprietary camera protocol with **two-way audio** support. go2rtc supports `Tuya Smart API` and `Tuya Cloud API`.
 
 **Tuya Smart API (recommended)**:
 - Cameras can be discovered through the go2rtc web interface via Tuya Smart account (Add > Tuya > Select region and fill in email and password > Login).
@@ -15,7 +15,7 @@
 
 ## Configuration
 
-Use `resolution` parameter to select the stream (not all cameras support `hd` stream through WebRTC even if the camera has it):
+Use the `resolution` parameter to select the stream (not all cameras support an `hd` stream through WebRTC even if the camera supports it):
 - `hd` - HD stream (default)
 - `sd` - SD stream
 

--- a/internal/webrtc/README.md
+++ b/internal/webrtc/README.md
@@ -1,15 +1,15 @@
-What you should to know about WebRTC:
+What you should know about WebRTC:
 
-- It's almost always a **direct [peer-to-peer](https://en.wikipedia.org/wiki/Peer-to-peer) connection** from your browser to go2rtc app
-- When you use Home Assistant, Frigate, Nginx, Nabu Casa, Cloudflare and other software - they are only **involved in establishing** the connection, but they are **not involved in transferring** media data
+- It's almost always a **direct [peer-to-peer](https://en.wikipedia.org/wiki/Peer-to-peer) connection** from your browser to the go2rtc app
+- When you use Home Assistant, Frigate, Nginx, Nabu Casa, Cloudflare, and other software, they are only **involved in establishing** the connection; they are **not involved in transferring** media data
 - WebRTC media cannot be transferred inside an HTTP connection
-- Usually, WebRTC uses random UDP ports on client and server side to establish a connection
-- Usually, WebRTC uses public [STUN](https://en.wikipedia.org/wiki/STUN) servers to establish a connection outside LAN, such servers are only needed to establish a connection and are not involved in data transfer
-- Usually, WebRTC will automatically discover all of your local addresses and all of your public addresses and try to establish a connection
+- Usually, WebRTC uses random UDP ports on the client and server to establish a connection
+- Usually, WebRTC uses public [STUN](https://en.wikipedia.org/wiki/STUN) servers to establish a connection outside the LAN; these servers are only needed to establish a connection and are not involved in data transfer
+- Usually, WebRTC will automatically discover all of your local and public addresses and try to establish a connection
 
 If an external connection via STUN is used:
 
-- Uses [UDP hole punching](https://en.wikipedia.org/wiki/UDP_hole_punching) technology to bypass NAT even if you not open your server to the World
+- Uses [UDP hole punching](https://en.wikipedia.org/wiki/UDP_hole_punching) technology to bypass NAT even if you haven't opened your server to the world
 - For about 20% of users, the technology will not work because of the [Symmetric NAT](https://tomchen.github.io/symmetric-nat-test/)
 - UDP is not suitable for transmitting 2K and 4K high bit rate video over open networks because of the high loss rate:
   - https://habr.com/ru/companies/flashphoner/articles/480006/
@@ -26,7 +26,7 @@ webrtc:
 
 ## Config
 
-**Important!** This example is not for copy pasting!
+**Important!** This example is not for copy/pasting!
 
 ```yaml
 webrtc:
@@ -41,34 +41,34 @@ webrtc:
     - home.duckdns.org:8555  # if you have domain
 
   # add custom STUN and TURN servers
-  # use `ice_servers: []` for remove defaults and leave empty
+  # use `ice_servers: []` to remove defaults and leave it empty
   ice_servers:
     - urls: [ stun:stun1.l.google.com:19302 ]
     - urls: [ turn:123.123.123.123:3478 ]
       username: your_user
       credential: your_pass
 
-  # optional filter list for auto discovery logic
+  # optional filter list for auto-discovery logic
   # some settings only make sense if you don't specify a fixed UDP port
   filters:
-    # list of host candidates from auto discovery to be sent
-    # including candidates from the `listen` option
-    # use `candidates: []` to remove all auto discovery candidates
+    # list of host candidates from auto-discovery to be sent
+    # includes candidates from the `listen` option
+    # use `candidates: []` to remove all auto-discovery candidates
     candidates: [ 192.168.1.123 ]
 
     # enable localhost candidates
     loopback: true
 
-    # list of network types to be used for connection
-    # including candidates from the `listen` option
+    # list of network types to be used for the connection
+    # includes candidates from the `listen` option
     networks: [ udp4, udp6, tcp4, tcp6 ]
 
-    # list of interfaces to be used for connection
-    # including interfaces from unspecified `listen` option (empty host)
+    # list of interfaces to be used for the connection
+    # includes interfaces from unspecified `listen` option (empty host)
     interfaces: [ eno1 ]
 
-    # list of host IP-addresses to be used for connection
-    # including IPs from unspecified `listen` option (empty host)
+    # list of host IP addresses to be used for the connection
+    # includes IPs from unspecified `listen` option (empty host)
     ips: [ 192.168.1.123 ]
 
     # range for random UDP ports [min, max] to be used for connection
@@ -76,15 +76,15 @@ webrtc:
     udp_ports: [ 50000, 50100 ]
 ```
 
-By default go2rtc uses **fixed TCP** port and **fixed UDP** ports for each **direct** WebRTC connection - `listen: ":8555"`.
+By default, go2rtc uses a **fixed TCP** port and **fixed UDP** ports for each **direct** WebRTC connection: `listen: ":8555"`.
 
-You can set **fixed TCP** and **random UDP** port for all connections - `listen: ":8555/tcp"`.
+You can set a **fixed TCP** port and a **random UDP** port for all connections: `listen: ":8555/tcp"`.
 
-Don't know why, but you can disable TCP port and leave only random UDP ports - `listen: ""`.
+You can also disable the TCP port and leave only random UDP ports: `listen: ""`.
 
 ## Config filters
 
-**Important!** By default go2rtc exclude all Docker-like candidates (`172.16.0.0/12`). This can not be disabled.
+**Important!** By default, go2rtc excludes all Docker-like candidates (`172.16.0.0/12`). This cannot be disabled.
 
 Filters allow you to exclude unnecessary candidates. Extra candidates don't make your connection worse or better. But the wrong filter settings can break everything. Skip this setting if you don't understand it.
 
@@ -98,7 +98,7 @@ webrtc:
     networks: [ udp4, tcp4 ]  # skip IPv6, if it's not supported for you
 ```
 
-For example, go2rtc inside closed docker container (ex. [Frigate](https://frigate.video/)). You shouldn't filter docker interfaces, otherwise go2rtc will not be able to connect anywhere. But you can filter the docker candidates because no one can connect to them.
+For example, go2rtc is inside a closed Docker container (e.g. [Frigate](https://frigate.video/)). You shouldn't filter Docker interfaces; otherwise, go2rtc won't be able to connect anywhere. But you can filter the Docker candidates because no one can connect to them.
 
 ```yaml
 webrtc:

--- a/internal/xiaomi/README.md
+++ b/internal/xiaomi/README.md
@@ -6,7 +6,7 @@ This source allows you to view cameras from the [Xiaomi Mi Home](https://home.mi
 
 Since 2020, Xiaomi has introduced a unified protocol for cameras called `miss`. I think it means **Mi Secure Streaming**. Until this point, the camera protocols were in chaos. Almost every model had different authorization, encryption, command lists, and media packet formats.
 
-Go2rtc support two formats: `xiaomi/mess` and `xiaomi/legacy`.
+go2rtc supports two formats: `xiaomi/mess` and `xiaomi/legacy`.
 And multiple P2P protocols: `cs2+udp`, `cs2+tcp`, several versions of `tutk+udp`.
 
 Almost all cameras in the `xiaomi/mess` format and the `cs2` protocol work well.
@@ -16,7 +16,7 @@ The `tutk` protocol is the worst thing that's ever happened to the P2P world. It
 **Important:**
 
 1. **Not all cameras are supported**. The list of supported cameras is collected in [this issue](https://github.com/AlexxIT/go2rtc/issues/1982).
-2. Each time you connect to the camera, you need internet access to obtain encryption keys.
+2. Each time you connect to the camera, you need Internet access to obtain encryption keys.
 3. Connection to the camera is local only.
 
 **Features:**
@@ -28,7 +28,7 @@ The `tutk` protocol is the worst thing that's ever happened to the P2P world. It
 
 ## Setup
 
-1. Goto go2rtc WebUI > Add > Xiaomi > Login with username and password
+1. Go to go2rtc WebUI > Add > Xiaomi > Login with username and password
 2. Receive verification code by email or phone if required.
 3. Complete the captcha if required.
 4. If everything is OK, your account will be added, and you can load cameras from it.
@@ -40,7 +40,7 @@ xiaomi:
   1234567890: V1:***
 
 streams:
-  xiaomi1: 	xiaomi://1234567890:cn@192.168.1.123?did=9876543210&model=isa.camera.hlc7
+  xiaomi1: xiaomi://1234567890:cn@192.168.1.123?did=9876543210&model=isa.camera.hlc7
 ```
 
 ## Configuration
@@ -49,14 +49,14 @@ Quality in the `miss` protocol is specified by a number from 0 to 5. Usually 0 m
 Go2rtc by default sets quality to 2. But some new cameras have HD quality at number 3.
 Old cameras may have broken codec settings at number 3, so this number should not be set for all cameras.
 
-You can change camera's quality: `subtype=hd/sd/auto/0-5`.
+You can change camera quality: `subtype=hd/sd/auto/0-5`.
 
 ```yaml
 streams:
   xiaomi1: xiaomi://***&subtype=sd
 ```
 
-You can use second channel for Dual cameras: `channel=2`.
+You can use a second channel for dual cameras: `channel=2`.
 
 ```yaml
 streams:

--- a/pkg/h264/rtp.go
+++ b/pkg/h264/rtp.go
@@ -89,7 +89,7 @@ func RTPDepay(codec *core.Codec, handler core.HandlerFunc) core.HandlerFunc {
 
 		// should not be that huge SPS
 		if NALUType(payload) == NALUTypeSPS && binary.BigEndian.Uint32(payload) >= PSMaxSize {
-			// some Chinese buggy cameras has single packet with SPS+PPS+IFrame separated by 00 00 00 01
+			// some Chinese buggy cameras have a single packet with SPS+PPS+IFrame separated by 00 00 00 01
 			// https://github.com/AlexxIT/WebRTC/issues/391
 			// https://github.com/AlexxIT/WebRTC/issues/392
 			payload = annexb.FixAnnexBInAVCC(payload)


### PR DESCRIPTION

## Summary

- Fix grammar errors (subject-verb agreement, missing articles, verb forms)
- Correct spelling mistakes (`integraion` → `integration`, `Goto` → `Go to`)
- Standardize terminology (`NVidia` → `NVIDIA`, `Raspberry` → `Raspberry Pi`)
- Improve punctuation (replace dashes with commas, add missing commas)
- Use consistent American English spelling (`authorisation` → `authorization`, `colours` → `colors`)
- Normalize product name capitalization (`Go2rtc` → `go2rtc` where appropriate)

## Changes

**Documentation files:**
- `README.md` — grammar and punctuation fixes
- `internal/app/README.md` — subject-verb agreement, clearer wording
- `internal/ffmpeg/hardware/README.md` — brand names, grammar corrections
- `internal/gopro/README.md` — punctuation and articles
- `internal/mjpeg/README.md` — typo fix (`integraion`), terminology
- `internal/ngrok/README.md` — clearer phrasing, consistent abbreviations
- `internal/tuya/README.md` — hyphenation, capitalization
- `internal/webrtc/README.md` — grammar (`should to know` → `should know`), punctuation
- `internal/xiaomi/README.md` — various grammar fixes, removed stray tab

**Code comments:**
- `internal/streams/preload.go` — clearer comment wording
- `pkg/h264/rtp.go` — fix subject-verb agreement in comment


<sup>Nu raz poshla takaya p'yanka...</sup>