### PR TITLE
webrtc: Fix ice_servers parsing for a list of URLs

### DIFF
--- a/pkg/webrtc/client_test.go
+++ b/pkg/webrtc/client_test.go
@@ -107,4 +107,12 @@ func TestUnmarshalICEServers(t *testing.T) {
 	servers, err := UnmarshalICEServers([]byte(s))
 	require.Nil(t, err)
 	require.Len(t, servers, 2)
+	require.Equal(t, []string{"xxx"}, servers[0].URLs)
+
+	s = `[{"urls":"xxx"},{"urls":["yyy","zzz"]}]`
+	servers, err = UnmarshalICEServers([]byte(s))
+	require.Nil(t, err)
+	require.Len(t, servers, 2)
+	require.Equal(t, []string{"xxx"}, servers[0].URLs)
+	require.Equal(t, []string{"yyy", "zzz"}, servers[1].URLs)
 }

--- a/pkg/webrtc/helpers.go
+++ b/pkg/webrtc/helpers.go
@@ -331,8 +331,12 @@ func UnmarshalICEServers(b []byte) ([]webrtc.ICEServer, error) {
 		}
 
 		switch v := src[i].URLs.(type) {
-		case []string:
-			srv.URLs = v
+		case []any:
+			for _, u := range v {
+				if s, ok := u.(string); ok {
+					srv.URLs = append(srv.URLs, s)
+				}
+			}
 		case string:
 			srv.URLs = []string{v}
 		}


### PR DESCRIPTION
Unmarshal gives a []any instead of a []string like the code expected. Fixed the cast & handling for the list plus tests.