### PR TITLE
Fix error handling in stream creation and patching tests

### DIFF
--- a/internal/streams/stream_test.go
+++ b/internal/streams/stream_test.go
@@ -10,13 +10,15 @@ import (
 
 func TestRecursion(t *testing.T) {
 	// create stream with some source
-	stream1 := New("from_yaml", "does_not_matter")
+	stream1, err := New("from_yaml", "does_not_matter")
+	require.NoError(t, err)
 	require.Len(t, streams, 1)
 
 	// ask another unnamed stream that links go2rtc
 	query, err := url.ParseQuery("src=rtsp://localhost:8554/from_yaml?video")
-	require.Nil(t, err)
-	stream2 := GetOrPatch(query)
+	require.NoError(t, err)
+	stream2, err := GetOrPatch(query)
+	require.NoError(t, err)
 
 	// check stream is same
 	require.Equal(t, stream1, stream2)
@@ -29,9 +31,11 @@ func TestTempate(t *testing.T) {
 	HandleFunc("rtsp", func(url string) (core.Producer, error) { return nil, nil }) // bypass HasProducer
 
 	// config from yaml
-	stream1 := New("camera.from_hass", "ffmpeg:{input}#video=copy")
+	stream1, err := New("camera.from_hass", "ffmpeg:{input}#video=copy")
+	require.NoError(t, err)
 	// request from hass
-	stream2 := Patch("camera.from_hass", "rtsp://example.com")
+	stream2, err := Patch("camera.from_hass", "rtsp://example.com")
+	require.NoError(t, err)
 
 	require.Equal(t, stream1, stream2)
 	require.Equal(t, "ffmpeg:rtsp://example.com#video=copy", stream1.producers[0].url)

--- a/pkg/alsa/device/asound_arch.c
+++ b/pkg/alsa/device/asound_arch.c
@@ -1,3 +1,4 @@
+//go:build ignore
 #include <stdio.h>
 #include <stddef.h>
 #include <sys/ioctl.h>

--- a/pkg/v4l2/device/videodev2_arch.c
+++ b/pkg/v4l2/device/videodev2_arch.c
@@ -1,3 +1,4 @@
+//go:build ignore
 #include <stdio.h>
 #include <stddef.h>
 #include <linux/videodev2.h>


### PR DESCRIPTION
Improve error handling in tests for stream creation and patching to ensure that errors are properly checked and handled.