### PR TITLE
Update Windows artifact names for consistency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,19 +21,19 @@ jobs:
         uses: actions/setup-go@v5
         with: { go-version: '1.25' }
 
-      - name: Build go2rtc_win64
+      - name: Build go2rtc_win_x64
         env: { GOOS: windows, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_win64
+      - name: Upload go2rtc_win_x64
         uses: actions/upload-artifact@v4
-        with: { name: go2rtc_win64, path: go2rtc.exe }
+        with: { name: go2rtc_win_x64, path: go2rtc.exe }
 
-      - name: Build go2rtc_win32
+      - name: Build go2rtc_win_x32
         env: { GOOS: windows, GOARCH: 386 }
         run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_win32
+      - name: Upload go2rtc_win_x32
         uses: actions/upload-artifact@v4
-        with: { name: go2rtc_win32, path: go2rtc.exe }
+        with: { name: go2rtc_win_x32, path: go2rtc.exe }
 
       - name: Build go2rtc_win_arm64
         env: { GOOS: windows, GOARCH: arm64 }

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Ultimate camera streaming application with support for RTSP, WebRTC, HomeKit, FF
 
 Download binary for your OS from [latest release](https://github.com/AlexxIT/go2rtc/releases/):
 
-- `go2rtc_win64.zip` - Windows 10+ 64-bit
-- `go2rtc_win32.zip` - Windows 10+ 32-bit
+- `go2rtc_win_x64.zip` - Windows 10+ 64-bit
+- `go2rtc_win_x32.zip` - Windows 10+ 32-bit
 - `go2rtc_win_arm64.zip` - Windows ARM 64-bit
 - `go2rtc_linux_amd64` - Linux 64-bit
 - `go2rtc_linux_i386` - Linux 32-bit

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -2,12 +2,12 @@
 
 @SET GOOS=windows
 @SET GOARCH=amd64
-@SET FILENAME=go2rtc_win64.zip
+@SET FILENAME=go2rtc_win_x64.zip
 go build -ldflags "-s -w" -trimpath && 7z a -mx9 -sdel %FILENAME% go2rtc.exe
 
 @SET GOOS=windows
 @SET GOARCH=386
-@SET FILENAME=go2rtc_win32.zip
+@SET FILENAME=go2rtc_win_x32.zip
 go build -ldflags "-s -w" -trimpath && 7z a -mx9 -sdel %FILENAME% go2rtc.exe
 
 @SET GOOS=windows

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,8 +29,8 @@ export CGO_ENABLED=0
 
 set -x  # Print commands and their arguments as they are executed.
 
-GOOS=windows  GOARCH=amd64        build_zip go2rtc_win64.zip     go2rtc.exe
-GOOS=windows  GOARCH=386          build_zip go2rtc_win32.zip     go2rtc.exe
+GOOS=windows  GOARCH=amd64        build_zip go2rtc_win_x64.zip     go2rtc.exe
+GOOS=windows  GOARCH=386          build_zip go2rtc_win_x32.zip     go2rtc.exe
 GOOS=windows  GOARCH=arm64        build_zip go2rtc_win_arm64.zip go2rtc.exe
 
 GOOS=linux    GOARCH=amd64        build_upx go2rtc_linux_amd64


### PR DESCRIPTION
Standardize the naming convention for Windows artifacts to improve clarity and consistency across the build process. This change updates the names used in the build and upload steps.

I recommend merging this before #2067