### PR TITLE
Support TURN REST API (Shared Secret) Authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/pion/sdp/v3 v3.0.17
 	github.com/pion/srtp/v3 v3.0.10
 	github.com/pion/stun/v3 v3.1.1
+	github.com/pion/turn/v4 v4.1.4
 	github.com/pion/webrtc/v4 v4.2.3
 	github.com/rs/zerolog v1.34.0
 	github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1
@@ -41,7 +42,6 @@ require (
 	github.com/pion/sctp v1.9.2 // indirect
 	github.com/pion/transport/v3 v3.1.1 // indirect
 	github.com/pion/transport/v4 v4.0.1 // indirect
-	github.com/pion/turn/v4 v4.1.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	golang.org/x/mod v0.32.0 // indirect

--- a/www/schema.json
+++ b/www/schema.json
@@ -623,6 +623,15 @@
               },
               "credential": {
                 "type": "string"
+              },
+              "shared_secret": {
+                "type": "string",
+                "description": "Shared secret for TURN REST API authentication (use-auth-secret)"
+              },
+              "credential_ttl": {
+                "type": "integer",
+                "description": "Credential lifetime in seconds (default: 86400)",
+                "default": 86400
               }
             }
           }


### PR DESCRIPTION
Closes #500 

Pion's turn/v4 library (already an indirect dependency) provides GenerateLongTermTURNRESTCredentials() which generates time-limited HMAC-SHA1 credentials from a shared secret — exactly what coturn expects.

3 files with minimal changes:

`webrtc.go` : custom ICEServerConfig struct with shared_secret and credential_ttl fields, a resolveICEServers() function that generates fresh credentials per connection, and moving config resolution into the PeerConnection closure
`go.mod` : promote pion/turn/v4 to direct dependency
`schema.json` : add the new fields to the JSON schema

Usage:
```
webrtc:
  ice_servers:
    - urls: [stun:stun.l.google.com:19302]
    - urls: [turn:my-coturn:3478]
      shared_secret: "my-secret"
```