### PR TITLE
Fix documentation grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ website/.vitepress/dist
 
 node_modules
 package-lock.json
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ PS. The application is compiled with the latest versions of the Go language for 
 
 ### go2rtc: Docker
 
-The Docker containers [`alexxit/go2rtc`](https://hub.docker.com/r/alexxit/go2rtc) and [`ghcr.io/alexxit/go2rtc`](https://github.com/AlexxIT/go2rtc/pkgs/container/go2rtc) supports multiple architectures including `386`, `amd64`, `arm/v6`, `arm/v7` and `arm64`.
-This containers offers the same functionality as the Home Assistant [add-on](#go2rtc-home-assistant-add-on) but is designed to operate independently of Home Assistant.
+The Docker containers [`alexxit/go2rtc`](https://hub.docker.com/r/alexxit/go2rtc) and [`ghcr.io/alexxit/go2rtc`](https://github.com/AlexxIT/go2rtc/pkgs/container/go2rtc) support multiple architectures including `386`, `amd64`, `arm/v6`, `arm/v7` and `arm64`.
+These containers offer the same functionality as the Home Assistant [add-on](#go2rtc-home-assistant-add-on) but are designed to operate independently of Home Assistant.
 It comes preinstalled with [FFmpeg](internal/ffmpeg/README.md) and [Python](internal/echo/README.md).
 
 ### go2rtc: Home Assistant add-on

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,9 +4,9 @@ Images are built automatically via [GitHub actions](https://github.com/AlexxIT/g
 
 ## Versions
 
-- `alexxit/go2rtc:latest` - latest release based on `alpine` (`amd64`, `386`, `arm/v6`, `arm/v7`, `arm64`) with support hardware transcoding for Intel iGPU and Raspberry
-- `alexxit/go2rtc:latest-hardware` - latest release based on `debian 13` (`amd64`) with support hardware transcoding for Intel iGPU, AMD GPU and NVidia GPU
-- `alexxit/go2rtc:latest-rockchip` - latest release based on `debian 12` (`arm64`) with support hardware transcoding for Rockchip RK35xx
+- `alexxit/go2rtc:latest` - latest release based on `alpine` (`amd64`, `386`, `arm/v6`, `arm/v7`, `arm64`) with support for hardware transcoding for Intel iGPU and Raspberry
+- `alexxit/go2rtc:latest-hardware` - latest release based on `debian 13` (`amd64`) with support for hardware transcoding for Intel iGPU, AMD GPU and NVidia GPU
+- `alexxit/go2rtc:latest-rockchip` - latest release based on `debian 12` (`arm64`) with support for hardware transcoding for Rockchip RK35xx
 - `alexxit/go2rtc:master` - latest unstable version based on `alpine`
 - `alexxit/go2rtc:master-hardware` - latest unstable version based on `debian 13` (`amd64`)
 - `alexxit/go2rtc:master-rockchip` - latest unstable version based on `debian 12` (`arm64`)

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -25,7 +25,7 @@ go2rtc -c log.format=text -c /config/go2rtc.yaml -c rtsp.listen='' -c /usr/local
 
 ## Environment variables
 
-There is support for loading external variables into the config. First, they will be attempted to be loaded from [credential files](https://systemd.io/CREDENTIALS). If `CREDENTIALS_DIRECTORY` is not set, then the key will be loaded from an environment variable. If no environment variable is set, then the string will be left as-is.
+There is support for loading external variables into the config. First, they will be loaded from [credential files](https://systemd.io/CREDENTIALS). If `CREDENTIALS_DIRECTORY` is not set, then the key will be loaded from an environment variable. If no environment variable is set, then the string will be left as-is.
 
 ```yaml
 streams:

--- a/internal/doorbird/README.md
+++ b/internal/doorbird/README.md
@@ -4,7 +4,7 @@
 
 This source type supports [Doorbird](https://www.doorbird.com/) devices including MJPEG stream, audio stream as well as two-way audio.
 
-It is recommended to create a sepearate user within your doorbird setup for go2rtc. Minimum permissions for the user are:
+It is recommended to create a separate user within your doorbird setup for go2rtc. Minimum permissions for the user are:
 
 - Watch always
 - API operator

--- a/internal/echo/README.md
+++ b/internal/echo/README.md
@@ -2,7 +2,7 @@
 
 Some sources may have a dynamic link. And you will need to get it using a Bash or Python script. Your script should echo a link to the source. RTSP, FFmpeg or any of the supported sources.
 
-**Docker** and **Home Assistant add-on** users has preinstalled `python3`, `curl`, `jq`.
+**Docker** and **Home Assistant add-on** users have preinstalled `python3`, `curl`, `jq`.
 
 ## Configuration
 
@@ -13,7 +13,7 @@ streams:
 
 ## Install python libraries
 
-**Docker** and **Hass Add-on** users has preinstalled `python3` without any additional libraries, like [requests](https://requests.readthedocs.io/) or others. If you need some additional libraries - you need to install them to folder with your script:
+**Docker** and **Hass Add-on** users have preinstalled `python3` without any additional libraries, like [requests](https://requests.readthedocs.io/) or others. If you need some additional libraries - you need to install them to folder with your script:
 
 1. Install [SSH & Web Terminal](https://github.com/hassio-addons/addon-ssh)
 2. Goto Add-on Web UI

--- a/internal/exec/README.md
+++ b/internal/exec/README.md
@@ -8,7 +8,7 @@ If you want to use **RTSP** transport, the command must contain the `{output}` a
 
 The source can be used with:
 
-- [FFmpeg](https://ffmpeg.org/) - go2rtc ffmpeg source just a shortcut to exec source
+- [FFmpeg](https://ffmpeg.org/) - go2rtc ffmpeg source is just a shortcut to exec source
 - [FFplay](https://ffmpeg.org/ffplay.html) - play audio on your server
 - [GStreamer](https://gstreamer.freedesktop.org/)
 - [Raspberry Pi Cameras](https://www.raspberrypi.com/documentation/computers/camera_software.html)

--- a/internal/flussonic/README.md
+++ b/internal/flussonic/README.md
@@ -2,4 +2,4 @@
 
 [`new in v1.9.10`](https://github.com/AlexxIT/go2rtc/releases/tag/v1.9.10)
 
-Support streams from [Flusonic](https://flussonic.com/) server. Related [issue](https://github.com/AlexxIT/go2rtc/issues/1678).
+Support streams from [Flussonic](https://flussonic.com/) server. Related [issue](https://github.com/AlexxIT/go2rtc/issues/1678).

--- a/internal/hass/README.md
+++ b/internal/hass/README.md
@@ -24,8 +24,8 @@ streams:
 
 Any cameras in WebRTC format are supported. But at the moment Home Assistant only supports some [Nest](https://www.home-assistant.io/integrations/nest/) cameras in this format.
 
-**Important.** The Nest API only allows you to get a link to a stream for 5 minutes. 
-Do not use this with Frigate! If the stream expires, Frigate will consume all available RAM on your machine within seconds. 
+**Important.** The Nest API only allows you to get a link to a stream for 5 minutes.
+Do not use this with Frigate! If the stream expires, Frigate will consume all available RAM on your machine within seconds.
 It's recommended to use [Nest source](../nest/README.md) - it supports extending the stream.
 
 ```yaml

--- a/internal/homekit/README.md
+++ b/internal/homekit/README.md
@@ -83,7 +83,7 @@ homekit:
 
 **Proxy HomeKit camera**
 
-- Video stream from HomeKit camera to Apple device (iPhone, AppleTV) will be transmitted directly
+- Video stream from HomeKit camera to Apple device (iPhone, Apple TV) will be transmitted directly
 - Video stream from HomeKit camera to RTSP/WebRTC/MP4/etc. will be transmitted via go2rtc
 
 ```yaml

--- a/internal/multitrans/README.md
+++ b/internal/multitrans/README.md
@@ -9,9 +9,9 @@ Two-way audio support for Chinese version of [TP-Link](https://www.tp-link.com.c
 ```yaml
 streams:
   tplink_cam:
-    # video use standard RTSP
+    # video uses standard RTSP
     - rtsp://admin:admin@192.168.1.202:554/stream1
-    # two-way audio use MULTITRANS schema
+    # two-way audio uses MULTITRANS schema
     - multitrans://admin:admin@192.168.1.202:554
 ```
 

--- a/internal/onvif/README.md
+++ b/internal/onvif/README.md
@@ -6,7 +6,7 @@
 
 The source is not very useful if you already know RTSP and snapshot links for your camera. But it can be useful if you don't.
 
-**WebUI > Add** webpage support ONVIF autodiscovery. Your server must be on the same subnet as the camera. If you use Docker, you must use "network host".
+**WebUI > Add** webpage supports ONVIF autodiscovery. Your server must be on the same subnet as the camera. If you use Docker, you must use "network host".
 
 ```yaml
 streams:
@@ -30,7 +30,7 @@ Go2rtc works as ONVIF server:
 - Onvier (android)
 - ONVIF Device Manager (windows)
 
-PS. Support only TCP transport for RTSP protocol. UDP and HTTP transports - unsupported yet.
+PS. Supports only TCP transport for RTSP protocol. UDP and HTTP transports - unsupported yet.
 
 ## Tested cameras
 

--- a/internal/pinggy/README.md
+++ b/internal/pinggy/README.md
@@ -47,7 +47,7 @@ In go2rtc logs you will get similar output:
 16:17:43.167 INF [pinggy] proxy url=tcp://abcde-123-123-123-123.a.free.pinggy.link:12345
 ```
 
-Now you have working stream:
+Now you have a working stream:
 
 ```
 rtsp://admin:password@abcde-123-123-123-123.a.free.pinggy.link:12345/cam/realmonitor?channel=1&subtype=0

--- a/internal/rtmp/README.md
+++ b/internal/rtmp/README.md
@@ -56,7 +56,7 @@ Streaming ingest in `flv` format.
 ffmpeg -re -i BigBuckBunny.mp4 -c copy -f flv http://localhost:1984/api/stream.flv?dst=camera1
 ```
 
-## Tested client
+## Tested clients
 
 | From   | To                              | Comment |
 |--------|---------------------------------|---------|

--- a/internal/webrtc/README.md
+++ b/internal/webrtc/README.md
@@ -98,7 +98,7 @@ If an external connection via STUN is used:
   - https://habr.com/ru/companies/flashphoner/articles/480006/
   - https://www.youtube.com/watch?v=FXVg2ckuKfs
 
-### Confiration suggestions
+### Configuration suggestions
 
 - by default, WebRTC uses both TCP and UDP on port 8555 for connections
 - you can use this port for external access

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -7,10 +7,10 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 
 - The initiator of the connection can be go2rtc - **Source protocols**
 - The initiator of the connection can be an external program - **Ingress protocols**
-- Codecs can be incoming - **Recevers codecs**
-- Codecs can be outgoing (two way audio) - **Senders codecs**
+- Codecs can be incoming - **Receiver codecs**
+- Codecs can be outgoing (two way audio) - **Sender codecs**
 
-| Group      | Format       | Protocols       | Ingress | Recevers codecs                 | Senders codecs      | Example       |
+| Group      | Format       | Protocols       | Ingress | Receiver codecs                 | Sender codecs      | Example       |
 |------------|--------------|-----------------|---------|---------------------------------|---------------------|---------------|
 | Devices    | alsa         | pipe            |         |                                 | pcm                 | `alsa:`       |
 | Devices    | v4l2         | pipe            |         |                                 |                     | `v4l2:`       |
@@ -93,7 +93,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 
 - `pkg/{format}/producer.go` - producer for this format (also if support backchannel)
 - `pkg/{format}/consumer.go` - consumer for this format
-- `pkg/{format}/backchanel.go` - producer with only backchannel func
+- `pkg/{format}/backchannel.go` - producer with only backchannel func
 
 **Mentioning modules:**
 

--- a/pkg/h264/README.md
+++ b/pkg/h264/README.md
@@ -1,6 +1,6 @@
 # H264
 
-Payloader code taken from [pion](https://github.com/pion/rtp) library. And changed to AVC packets support.
+Payloader code taken from [pion](https://github.com/pion/rtp) library and changed to AVC packets support.
 
 ## Useful Links
 

--- a/pkg/h265/README.md
+++ b/pkg/h265/README.md
@@ -1,6 +1,6 @@
 # H265
 
-Payloader code taken from [pion](https://github.com/pion/rtp) library branch [h265](https://github.com/pion/rtp/tree/h265). Because it's still not in release. Thanks to [@kevmo314](https://github.com/kevmo314).
+Payloader code taken from [pion](https://github.com/pion/rtp) library branch [h265](https://github.com/pion/rtp/tree/h265), because it's still not in release. Thanks to [@kevmo314](https://github.com/kevmo314).
 
 ## Useful links
 


### PR DESCRIPTION
Summary
- clarify Docker README wording and various README.md grammar issues throughout docs
- describe credential loading behavior more precisely and tidy localized descriptions, including pkg docs and internal guides