### PR TITLE
api: add GET /api/ready readiness endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,5 +121,8 @@ func main() {
 		}
 	}
 
+	// Signal that all modules have finished initializing and all schemes are registered.
+	api.SetReady()
+
 	shell.RunUntilSignal()
 }


### PR DESCRIPTION
Closes #2088

## Summary

The HTTP server starts listening inside `api.Init()`, which is the first module initialized. All other modules register their schemes afterward. Any client querying `/api/schemes` between `api.Init()` and the completion of the module init loop receives an incomplete list.

This PR adds a `GET /api/ready` endpoint that returns:
- `503 Service Unavailable` (body: `starting`) while modules are still initializing
- `200 OK` once all modules have completed their `Init()` calls

`SetReady()` is called from `main.go` after the module init loop completes.

## Changes

- `internal/api/api.go`: add `ready atomic.Bool`, exported `SetReady()`, `readyHandler`, and register `api/ready`
- `main.go`: call `api.SetReady()` after the module init loop