### PR TITLE
feat(rtmp): add SOCKS5 proxy support for RTMP streams

### DIFF
--- a/internal/streams/README.md
+++ b/internal/streams/README.md
@@ -62,6 +62,24 @@ streams:
 - **Telegram Desktop App** > Any public or private channel or group (where you admin) > Live stream > Start with... > Start streaming.
 - **YouTube** > Create > Go live > Stream latency: Ultra low-latency > Copy: Stream URL + Stream key.
 
+### Publish via SOCKS5 proxy
+
+If the streaming service is blocked in your country (e.g. Telegram), you can route the RTMP connection through a SOCKS5 proxy by appending the `socks5` query parameter to the destination URL:
+
+```yaml
+publish:
+  # publish to Telegram via SOCKS5 proxy (no auth)
+  my_stream: rtmps://dc4-1.rtmp.t.me/s/YOUR_KEY#proxy=socks5://proxy.example.com:1080
+
+  # publish to Telegram via SOCKS5 proxy with authentication
+  my_stream2: rtmps://dc4-1.rtmp.t.me/s/YOUR_KEY#proxy=socks5://user:pass@proxy.example.com:1080
+
+  # combine with RTMP query parameters
+  my_stream3: rtmp://xxx.rtmp.youtube.com/live2/KEY?token=abc#proxy=socks5://proxy.example.com:1080
+```
+
+The `socks5` parameter is stripped before the URL is sent to the RTMP server, so it will not affect authentication or stream keys.
+
 ## Preload stream
 
 [`new in v1.9.11`](https://github.com/AlexxIT/go2rtc/releases/tag/v1.9.11)

--- a/pkg/rtmp/client_test.go
+++ b/pkg/rtmp/client_test.go
@@ -1,0 +1,109 @@
+package rtmp
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// parseAppStream replicates the App/Stream assignment from NewClient
+// so it can be tested without a real network connection.
+func parseAppStream(u *url.URL) (app, stream string) {
+	if args := strings.Split(u.Path, "/"); len(args) >= 2 {
+		app = args[1]
+		if len(args) >= 3 {
+			stream = args[2]
+			if u.RawQuery != "" {
+				stream += "?" + u.RawQuery
+			}
+		}
+	}
+	return
+}
+
+func TestStreamNameParsing(t *testing.T) {
+	tests := []struct {
+		name       string
+		rawURL     string
+		wantApp    string
+		wantStream string
+	}{
+		{
+			name:       "plain rtmp",
+			rawURL:     "rtmp://192.168.1.1/live/camera1",
+			wantApp:    "live",
+			wantStream: "camera1",
+		},
+		{
+			name:       "rtmp with query params",
+			rawURL:     "rtmp://host/bcs/channel0.bcs?channel=0&stream=0&user=admin&password=pass",
+			wantApp:    "bcs",
+			wantStream: "channel0.bcs?channel=0&stream=0&user=admin&password=pass",
+		},
+		{
+			name:       "proxy fragment does not leak into stream name",
+			rawURL:     "rtmps://dc4-1.rtmp.t.me/s/MY_KEY#proxy=socks5://proxy.example.com:1080",
+			wantApp:    "s",
+			wantStream: "MY_KEY",
+		},
+		{
+			name:       "proxy with auth does not leak into stream name",
+			rawURL:     "rtmps://dc4-1.rtmp.t.me/s/MY_KEY#proxy=socks5://user:pass@proxy:1080",
+			wantApp:    "s",
+			wantStream: "MY_KEY",
+		},
+		{
+			name:       "query params preserved, proxy fragment excluded",
+			rawURL:     "rtmp://host/live/KEY?token=abc123#proxy=socks5://proxy:1080",
+			wantApp:    "live",
+			wantStream: "KEY?token=abc123",
+		},
+		{
+			name:       "rtmps telegram format",
+			rawURL:     "rtmps://xxx-x.rtmp.t.me/s/xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx",
+			wantApp:    "s",
+			wantStream: "xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx",
+		},
+		{
+			name:       "youtube rtmp format",
+			rawURL:     "rtmp://xxx.rtmp.youtube.com/live2/xxxx-xxxx-xxxx-xxxx-xxxx",
+			wantApp:    "live2",
+			wantStream: "xxxx-xxxx-xxxx-xxxx-xxxx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse(%q) error: %v", tt.rawURL, err)
+			}
+			gotApp, gotStream := parseAppStream(u)
+			if gotApp != tt.wantApp {
+				t.Errorf("App = %q, want %q", gotApp, tt.wantApp)
+			}
+			if gotStream != tt.wantStream {
+				t.Errorf("Stream = %q, want %q", gotStream, tt.wantStream)
+			}
+		})
+	}
+}
+
+// TestFragmentNotInURL verifies that url.Parse correctly places
+// the #proxy=... part into Fragment, not RawQuery or Path.
+func TestFragmentNotInURL(t *testing.T) {
+	u, err := url.Parse("rtmps://dc4-1.rtmp.t.me/s/KEY#proxy=socks5://proxy:1080")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if u.RawQuery != "" {
+		t.Errorf("RawQuery should be empty, got %q", u.RawQuery)
+	}
+	if u.Fragment == "" {
+		t.Errorf("Fragment should not be empty")
+	}
+	if !strings.HasPrefix(u.Fragment, "proxy=") {
+		t.Errorf("Fragment = %q, should start with proxy=", u.Fragment)
+	}
+}

--- a/pkg/tcp/dial_test.go
+++ b/pkg/tcp/dial_test.go
@@ -1,0 +1,72 @@
+package tcp
+
+import (
+	"testing"
+)
+
+func TestFragmentParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		fragment string
+		key      string
+		want     string
+	}{
+		{
+			name:     "empty fragment",
+			fragment: "",
+			key:      "proxy",
+			want:     "",
+		},
+		{
+			name:     "proxy without auth",
+			fragment: "proxy=socks5://proxy.example.com:1080",
+			key:      "proxy",
+			want:     "socks5://proxy.example.com:1080",
+		},
+		{
+			name:     "proxy with auth",
+			fragment: "proxy=socks5://user:pass@proxy.example.com:1080",
+			key:      "proxy",
+			want:     "socks5://user:pass@proxy.example.com:1080",
+		},
+		{
+			name:     "proxy among other params",
+			fragment: "video=h264#proxy=socks5://proxy:1080#audio=aac",
+			key:      "proxy",
+			want:     "socks5://proxy:1080",
+		},
+		{
+			name:     "proxy as last param",
+			fragment: "video=h264#proxy=socks5://proxy:1080",
+			key:      "proxy",
+			want:     "socks5://proxy:1080",
+		},
+		{
+			name:     "no matching key",
+			fragment: "video=h264#audio=aac",
+			key:      "proxy",
+			want:     "",
+		},
+		{
+			name:     "partial key match",
+			fragment: "proxy2=socks5://proxy:1080",
+			key:      "proxy",
+			want:     "",
+		},
+		{
+			name:     "other key lookup",
+			fragment: "proxy=socks5://proxy:1080#video=h264",
+			key:      "video",
+			want:     "h264",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fragmentParam(tt.fragment, tt.key)
+			if got != tt.want {
+				t.Errorf("fragmentParam(%q, %q) = %q, want %q", tt.fragment, tt.key, got, tt.want)
+			}
+		})
+	}
+}

--- a/www/schema.json
+++ b/www/schema.json
@@ -500,7 +500,9 @@
             "type": "string",
             "examples": [
               "rtmp://xxx.rtmp.youtube.com/live2/xxxx-xxxx-xxxx-xxxx-xxxx",
-              "rtmps://xxx-x.rtmp.t.me/s/xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx"
+              "rtmps://xxx-x.rtmp.t.me/s/xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx",
+              "rtmps://dc4-1.rtmp.t.me/s/xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx#proxy=socks5://proxy.example.com:1080",
+              "rtmps://dc4-1.rtmp.t.me/s/xxxxxxxxxx:xxxxxxxxxxxxxxxxxxxxxx#proxy=socks5://user:pass@proxy.example.com:1080"
             ]
           },
           {


### PR DESCRIPTION
**This PR needs external testing: I couldn't check it on real services. Only the actual direction of traffic through socks5 is checked**


- implement SOCKS5 proxy handling for RTMP connections
- update streamsConsumerHandle to parse proxy from URL fragment
- add fragmentParam function to extract parameters from URL fragment
- enhance README with SOCKS5 proxy usage examples
- add unit tests for fragmentParam and stream name parsing