### PR TITLE
api: block /api/schemes and /api until initialization is complete

### DIFF
--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -177,5 +177,9 @@ func apiPreload(w http.ResponseWriter, r *http.Request) {
 }
 
 func apiSchemes(w http.ResponseWriter, r *http.Request) {
+	if err := api.WaitReady(r.Context()); err != nil {
+		http.Error(w, "starting", http.StatusServiceUnavailable)
+		return
+	}
 	api.ResponseJSON(w, SupportedSchemes())
 }

--- a/main.go
+++ b/main.go
@@ -121,7 +121,9 @@ func main() {
 		}
 	}
 
-	// Signal that all modules have finished initializing and all schemes are registered.
+	// Unblock any API requests that were waiting for full initialization
+	// (e.g. /api/schemes, /api). Callers that arrived early will now get
+	// the complete response rather than partial or stale data.
 	api.SetReady()
 
 	shell.RunUntilSignal()


### PR DESCRIPTION
Fixes #2088.

Closes #2089 (supersedes the previous `/api/ready` approach).

## What this does

Replaces the `atomic.Bool` ready flag with a channel that is closed once all modules have finished initializing (`SetReady()` in `main.go`, unchanged position).

`/api/schemes` and `/api` now block on that channel instead of returning partial data. When `SetReady()` fires, all concurrent waiters unblock at once (closing a channel broadcasts to all receivers). Context cancellation is respected so disconnecting clients do not leak goroutines.

After startup completes, receives from a closed channel return immediately — existing callers are unaffected.

## Why this approach

As suggested by @AlexxIT in #2089: rather than a dedicated readiness endpoint, delay the response of `/api/schemes` (and `/api`) until startup is complete.