### PR TITLE
Fix: Instead of 'src = ''' use removeAttribute('src') (video-rtc.js)

### DIFF
--- a/www/video-rtc.js
+++ b/www/video-rtc.js
@@ -338,7 +338,7 @@ export class VideoRTC extends HTMLElement {
             this.pc = null;
         }
 
-        this.video.src = '';
+        this.video.removeAttribute('src');
         this.video.srcObject = null;
     }
 


### PR DESCRIPTION
An empty SRC is invalid for the VIDEO tag and will cause problems. For example, when executing `"this.video.play(),"` we'll get a minor error like 

> "DOMException: The element has no supported sources." 

But this will trigger catch(), resulting in `"this.video.muted = true,"` even though the problem is something completely different, not "muted."