### PR TITLE
feat: add AV1 codec support for MSE, WebRTC and MP4 streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,13 +358,13 @@ Some examples:
 
 ### Codecs madness
 
-`AVC/H.264` video can be played almost anywhere. But `HEVC/H.265` has many limitations in supporting different devices and browsers.
+`AVC/H.264` video can be played almost anywhere. But `HEVC/H.265` and `AV1` have many limitations in supporting different devices and browsers.
 
 | Device                                                             | WebRTC                                  | MSE                                     | HTTP*                                        | HLS                         |
 |--------------------------------------------------------------------|-----------------------------------------|-----------------------------------------|----------------------------------------------|-----------------------------|
 | *latency*                                                          | best                                    | medium                                  | bad                                          | bad                         |
-| Desktop Chrome 136+ <br/> Desktop Edge <br/> Android Chrome 136+   | H264, H265* <br/> PCMU, PCMA <br/> OPUS | H264, H265* <br/> AAC, FLAC* <br/> OPUS | H264, H265* <br/> AAC, FLAC* <br/> OPUS, MP3 | no                          |
-| Desktop Firefox                                                    | H264 <br/> PCMU, PCMA <br/> OPUS        | H264 <br/> AAC, FLAC* <br/> OPUS        | H264 <br/> AAC, FLAC* <br/> OPUS             | no                          |
+| Desktop Chrome 136+ <br/> Desktop Edge <br/> Android Chrome 136+   | H264, H265*, AV1* <br/> PCMU, PCMA <br/> OPUS | H264, H265*, AV1* <br/> AAC, FLAC* <br/> OPUS | H264, H265*, AV1* <br/> AAC, FLAC* <br/> OPUS, MP3 | no |
+| Desktop Firefox                                                    | H264, AV1* <br/> PCMU, PCMA <br/> OPUS | H264, AV1* <br/> AAC, FLAC* <br/> OPUS | H264, AV1* <br/> AAC, FLAC* <br/> OPUS | no |
 | Desktop Safari 14+ <br/> iPad Safari 14+ <br/> iPhone Safari 17.1+ | H264, H265* <br/> PCMU, PCMA <br/> OPUS | H264, H265 <br/> AAC, FLAC*             | **no!**                                      | H264, H265 <br/> AAC, FLAC* |
 | iPhone Safari 14+                                                  | H264, H265* <br/> PCMU, PCMA <br/> OPUS | **no!**                                 | **no!**                                      | H264, H265 <br/> AAC, FLAC* |
 | macOS [Hass App][1]                                                | no                                      | no                                      | no                                           | H264, H265 <br/> AAC, FLAC* |
@@ -373,6 +373,8 @@ Some examples:
 
 - `HTTP*` - HTTP Progressive Streaming, not related to [progressive download](https://en.wikipedia.org/wiki/Progressive_download), because the file has no size and no end
 - `WebRTC H265` - supported in [Chrome 136+](https://developer.chrome.com/release-notes/136), supported in [Safari 18+](https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes)
+- `AV1` - supported in [Chrome 111+](https://developer.chrome.com/blog/av1), [Firefox 136+](https://www.firefox.com/en-US/firefox/136.0/releasenotes/) and Edge 121+, in Safari only with a hardware decoder (M3/A17 Pro or newer)
+- `HLS AV1` - go2rtc serves it to a client that asks for it, but most HLS clients have no AV1 decoder
 - `MSE iPhone` - supported in [iOS 17.1+](https://webkit.org/blog/14735/webkit-features-in-safari-17-1/)
 
 **Audio**

--- a/internal/hls/session.go
+++ b/internal/hls/session.go
@@ -73,6 +73,11 @@ func (s *Session) Main() []byte {
 		Codecs() []*core.Codec
 	}
 
+	// AV1 codec params only arrive with the first keyframe
+	if cons, ok := s.cons.(*mp4.Consumer); ok {
+		cons.WaitInit(time.Second * 3)
+	}
+
 	codecs := mp4.MimeCodecs(s.cons.(withCodecs).Codecs())
 	codecs = strings.Replace(codecs, mp4.MimeFlac, "fLaC", 1)
 

--- a/internal/mp4/mp4.go
+++ b/internal/mp4/mp4.go
@@ -123,6 +123,12 @@ func handlerMP4(w http.ResponseWriter, r *http.Request) {
 	header := w.Header()
 	header.Set("Content-Type", mp4.ContentType(cons.Codecs()))
 
+	// AV1 codec params are only known once the first keyframe has arrived,
+	// still before the first write, so the header can be corrected here
+	cons.OnInit = func(contentType string) {
+		header.Set("Content-Type", contentType)
+	}
+
 	if filename := query.Get("filename"); filename != "" {
 		header.Set("Content-Disposition", `attachment; filename="`+filename+`"`)
 	}

--- a/internal/mp4/ws.go
+++ b/internal/mp4/ws.go
@@ -31,7 +31,11 @@ func handlerWSMSE(tr *ws.Transport, msg *ws.Message) error {
 		return err
 	}
 
-	tr.Write(&ws.Message{Type: "mse", Value: mp4.ContentType(cons.Codecs())})
+	// sent from WriteTo right before the init segment, because an AV1 content
+	// type is only complete once the first keyframe has been seen
+	cons.OnInit = func(contentType string) {
+		tr.Write(&ws.Message{Type: "mse", Value: contentType})
+	}
 
 	go cons.WriteTo(tr.Writer())
 

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -15,7 +15,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | Devices    | alsa         | pipe            |         |                                 | pcm                 | `alsa:`       |
 | Devices    | v4l2         | pipe            |         |                                 |                     | `v4l2:`       |
 | Files      | adts         | http, tcp, pipe | http    | aac                             |                     | `http:`       |
-| Files      | flv          | http, tcp, pipe | http    | h264, aac                       |                     | `http:`       |
+| Files      | flv          | http, tcp, pipe | http    | h264, hevc, av1, aac            |                     | `http:`       |
 | Files      | h264         | http, tcp, pipe | http    | h264                            |                     | `http:`       |
 | Files      | hevc         | http, tcp, pipe | http    | hevc                            |                     | `http:`       |
 | Files      | hls          | http            |         | h264, h265, aac, opus           |                     | `http:`       |
@@ -25,7 +25,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | Net (pub)  | mpjpeg       | http, tcp, pipe | http    | mjpeg                           |                     | `http:`       |
 | Net (pub)  | onvif        | rtsp            |         |                                 |                     | `onvif:`      |
 | Net (pub)  | rtmp         | rtmp            | rtmp    | h264, aac                       |                     | `rtmp:`       |
-| Net (pub)  | rtsp         | rtsp, ws        | rtsp    | h264, hevc, aac, pcm*, opus     | pcm*, opus          | `rtsp:`       |
+| Net (pub)  | rtsp         | rtsp, ws        | rtsp    | h264, hevc, av1, aac, pcm*, opus | pcm*, opus         | `rtsp:`       |
 | Net (pub)  | webrtc*      | webrtc          | webrtc  | h264, pcm_alaw, pcm_mulaw, opus | pcm_alaw, pcm_mulaw | `webrtc:`     |
 | Net (pub)  | yuv4mpegpipe | http, tcp, pipe | http    | rawvideo                        |                     | `http:`       |
 | Net (priv) | bubble       | http            |         | h264, hevc, pcm_alaw            |                     | `bubble:`     |
@@ -70,12 +70,12 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | homekit      | hap      | h264, opus                      |                           | Apple HomeKit app                     |
 | mjpeg        | ws       | mjpeg                           |                           | `{"type":"mjpeg"}` -> `/api/ws`       |
 | mpjpeg       | http     | mjpeg                           |                           | `GET /api/stream.mjpeg`               |
-| mp4          | http     | h264, hevc, aac, pcm*, opus     |                           | `GET /api/stream.mp4`                 |
-| mse/fmp4     | ws       | h264, hevc, aac, pcm*, opus     |                           | `{"type":"mse"}` -> `/api/ws`         |
+| mp4          | http     | h264, hevc, av1, aac, pcm*, opus |                           | `GET /api/stream.mp4`                 |
+| mse/fmp4     | ws       | h264, hevc, av1, aac, pcm*, opus |                           | `{"type":"mse"}` -> `/api/ws`         |
 | mpegts       | http     | h264, hevc, aac                 |                           | `GET /api/stream.ts`                  |
 | rtmp         | rtmp     | h264, aac                       |                           | `rtmp://localhost:1935/{stream_name}` |
 | rtsp         | rtsp     | h264, hevc, aac, pcm*, opus     |                           | `rtsp://localhost:8554/{stream_name}` |
-| webrtc       | webrtc   | h264, pcm_alaw, pcm_mulaw, opus | pcm_alaw, pcm_mulaw, opus | `{"type":"webrtc"}` -> `/api/ws`      |
+| webrtc       | webrtc   | h264, av1, pcm_alaw, pcm_mulaw, opus | pcm_alaw, pcm_mulaw, opus | `{"type":"webrtc"}` -> `/api/ws`      |
 | yuv4mpegpipe | http     | rawvideo                        |                           | `GET /api/stream.y4m`                 |
 
 - **pcm** - pcm_alaw pcm_mulaw pcm_s16be pcm_s16le

--- a/pkg/av1/README.md
+++ b/pkg/av1/README.md
@@ -1,0 +1,14 @@
+# AV1
+
+AV1 carries its codec parameters in a sequence header OBU inside the bitstream, not in the SDP. Encoders repeat that OBU in front of every keyframe, so consumers that need an `av1C` record (MP4, MSE, HLS) have to wait for one before they can build an init segment.
+
+Depayloading uses pion's `AV1Depacketizer`. It rewrites `obu_size` while reassembling, so a temporal unit spliced together across a packet loss still parses as a valid keyframe. `RTPDepay` therefore drops such a unit and resumes at the next marker instead of mid unit.
+
+## Useful Links
+
+- [AV1 Bitstream & Decoding Process Specification](https://aomediacodec.github.io/av1-spec/)
+- [RTP Payload Format For AV1 (RFC 9583)](https://www.rfc-editor.org/rfc/rfc9583)
+- [AV1 Codec ISO Media File Format Binding](https://aomediacodec.github.io/av1-isobmff/)
+- [AV1 levels](https://aomediacodec.github.io/av1-spec/#levels)
+- [Codecs parameter for AV1 (MDN)](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/codecs_parameter#av1)
+- [Enhanced RTMP v2](https://github.com/veovera/enhanced-rtmp/blob/main/docs/enhanced/enhanced-rtmp-v2.md)

--- a/pkg/av1/av1.go
+++ b/pkg/av1/av1.go
@@ -1,0 +1,222 @@
+// Package av1 implements AV1 OBU parsing, keyframe detection, and RTP depayloading.
+//
+// References:
+//   - AV1 Bitstream & Decoding Process: https://aomediacodec.github.io/av1-spec/
+//   - AV1 RTP Payload Format (RFC 9583): https://www.rfc-editor.org/rfc/rfc9583
+//   - AV1 Codec ISO Media File Format Binding: https://aomediacodec.github.io/av1-isobmff/
+package av1
+
+// OBU types from AV1 spec Section 6.2.2
+const (
+	OBUTypeSequenceHeader    = 1
+	OBUTypeTemporalDelimiter = 2
+	OBUTypeFrameHeader       = 3
+	OBUTypeTileGroup         = 4
+	OBUTypeFrame             = 6
+)
+
+// Frame type from AV1 spec Section 6.8.2
+const FrameTypeKey = 0
+
+// OBUType returns the OBU type from the first byte of an OBU header.
+func OBUType(header byte) byte {
+	return (header >> 3) & 0x0F
+}
+
+// OBUHasExtension returns true if the extension flag is set.
+func OBUHasExtension(header byte) bool {
+	return header&0x04 != 0
+}
+
+// OBUHasSize returns true if the has_size_field flag is set.
+func OBUHasSize(header byte) bool {
+	return header&0x02 != 0
+}
+
+// MaxSequenceHeaderSize bounds what SequenceHeader will hand on. Real ones are
+// 13 to 20 bytes; the cap only keeps a padded OBU out of the fmtp line.
+const MaxSequenceHeaderSize = 256
+
+// ReadLEB128 reads a LEB128 (Little Endian Base 128) encoded unsigned integer.
+// Returns the value and the number of bytes consumed, or n = 0 if the encoding
+// is not terminated or does not fit in 32 bits, so callers can reject it.
+func ReadLEB128(data []byte) (value uint32, n int) {
+	for i := 0; i < len(data) && i < 8; i++ {
+		b := data[i]
+		// the 5th byte carries only 4 usable bits, the rest would overflow
+		if i == 4 && b&0x7F > 0x0F {
+			return 0, 0 // more than 32 bits
+		}
+		if i >= 5 && b&0x7F != 0 {
+			return 0, 0 // more than 32 bits
+		}
+		value |= uint32(b&0x7F) << (i * 7)
+		if b&0x80 == 0 {
+			return value, i + 1
+		}
+	}
+	return 0, 0 // no terminating byte
+}
+
+// WriteLEB128 encodes a value as LEB128 and returns the bytes.
+func WriteLEB128(value uint32) []byte {
+	if value == 0 {
+		return []byte{0}
+	}
+	var buf []byte
+	for value > 0 {
+		b := byte(value & 0x7F)
+		value >>= 7
+		if value > 0 {
+			b |= 0x80
+		}
+		buf = append(buf, b)
+	}
+	return buf
+}
+
+// OBUHeaderSize returns the total header size (1 for basic, 2 with extension).
+func OBUHeaderSize(header byte) int {
+	if OBUHasExtension(header) {
+		return 2
+	}
+	return 1
+}
+
+// obuPayload returns the OBU payload without the OBU header and the optional
+// size field. Returns nil if the OBU is truncated.
+func obuPayload(obu []byte) []byte {
+	if len(obu) == 0 {
+		return nil
+	}
+
+	n := OBUHeaderSize(obu[0])
+	if len(obu) < n {
+		return nil
+	}
+
+	if !OBUHasSize(obu[0]) {
+		// the last OBU of a temporal unit may omit the size field
+		return obu[n:]
+	}
+
+	size, sizeLen := ReadLEB128(obu[n:])
+	if sizeLen == 0 || size > uint32(len(obu)) || len(obu) < n+sizeLen+int(size) {
+		return nil
+	}
+
+	return obu[n+sizeLen : n+sizeLen+int(size)]
+}
+
+// ParseOBUs iterates over OBUs in an AV1 bitstream (with size fields).
+// Calls fn with (obuType, obuData including header) for each OBU.
+// Returns false from fn to stop iteration.
+func ParseOBUs(data []byte, fn func(obuType byte, obu []byte) bool) {
+	for len(data) > 0 {
+		header := data[0]
+		obuType := OBUType(header)
+		hdrSize := OBUHeaderSize(header)
+
+		if len(data) < hdrSize {
+			return
+		}
+
+		if !OBUHasSize(header) {
+			// OBU without size field - rest of data is this OBU
+			if !fn(obuType, data) {
+				return
+			}
+			return
+		}
+
+		// read size after header
+		if len(data) < hdrSize+1 {
+			return
+		}
+
+		size, sizeLen := ReadLEB128(data[hdrSize:])
+		if sizeLen == 0 {
+			return // invalid size field, the rest can't be trusted
+		}
+
+		// compared before the conversion, because int is 32 bits on the 386,
+		// arm and mips builds, where a large size would go negative
+		if uint64(hdrSize)+uint64(sizeLen)+uint64(size) > uint64(len(data)) {
+			return
+		}
+
+		totalSize := hdrSize + sizeLen + int(size)
+
+		if !fn(obuType, data[:totalSize]) {
+			return
+		}
+
+		data = data[totalSize:]
+	}
+}
+
+// IsKeyframe checks if the AV1 temporal unit (sequence of OBUs in MP4 low
+// overhead format) contains a keyframe, indicated by frame_type == KEY_FRAME in
+// the uncompressed header. Decided by the first frame header in the unit.
+func IsKeyframe(payload []byte) bool {
+	var keyframe, reducedStill bool
+
+	ParseOBUs(payload, func(obuType byte, obu []byte) bool {
+		switch obuType {
+		case OBUTypeSequenceHeader:
+			// with reduced_still_picture_header every frame is a keyframe and
+			// the uncompressed header carries no frame_type bits
+			if data := obuPayload(obu); len(data) > 0 {
+				reducedStill = data[0]&0x08 != 0 // after seq_profile(3) + still_picture(1)
+			}
+
+		case OBUTypeFrame, OBUTypeFrameHeader:
+			if reducedStill {
+				keyframe = true
+				return false
+			}
+
+			data := obuPayload(obu)
+			if len(data) == 0 {
+				return true
+			}
+			if data[0]&0x80 != 0 {
+				return true // show_existing_frame, this OBU has no frame_type
+			}
+
+			keyframe = (data[0]>>5)&0x03 == FrameTypeKey
+			return false // the first real frame header decides
+		}
+
+		return true
+	})
+
+	return keyframe
+}
+
+// SequenceHeader extracts the raw sequence header OBU bytes from a payload.
+// Returns nil if no sequence header is found.
+func SequenceHeader(payload []byte) []byte {
+	var seqHdr []byte
+	ParseOBUs(payload, func(obuType byte, obu []byte) bool {
+		if obuType != OBUTypeSequenceHeader {
+			return true
+		}
+		// Without a size field the OBU runs to the end of the temporal unit,
+		// which would put the whole keyframe into the av1C box and the fmtp
+		// line. The sequence header is never the last OBU of a unit.
+		if !OBUHasSize(obu[0]) {
+			return false
+		}
+		// The OBU is copied into the fmtp line, the av1C box of every init
+		// segment and every RTSP SDP answer, so a padded one would be served
+		// back over and over. A real sequence header is a few dozen bytes.
+		if len(obu) > MaxSequenceHeaderSize {
+			return false
+		}
+		seqHdr = make([]byte, len(obu))
+		copy(seqHdr, obu)
+		return false
+	})
+	return seqHdr
+}

--- a/pkg/av1/av1_test.go
+++ b/pkg/av1/av1_test.go
@@ -1,0 +1,914 @@
+package av1
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+// --- test helpers ---
+
+type bitWriter struct {
+	data []byte
+	n    int
+}
+
+func (w *bitWriter) put(val uint32, bits int) {
+	for i := bits - 1; i >= 0; i-- {
+		if w.n%8 == 0 {
+			w.data = append(w.data, 0)
+		}
+		w.data[w.n/8] |= byte((val>>uint(i))&1) << uint(7-w.n%8)
+		w.n++
+	}
+}
+
+func (w *bitWriter) flag(b bool) {
+	if b {
+		w.put(1, 1)
+	} else {
+		w.put(0, 1)
+	}
+}
+
+func wrapOBU(obuType byte, payload []byte) []byte {
+	obu := []byte{obuType<<3 | 0x02} // has_size_field=1
+	obu = append(obu, WriteLEB128(uint32(len(payload)))...)
+	return append(obu, payload...)
+}
+
+// seqHdr builds a Sequence Header OBU bit by bit, following
+// sequence_header_obu() from AV1 spec Section 5.5.1. The optional fields have
+// their own switches so tests can cover what real encoders actually emit.
+type seqHdr struct {
+	profile       byte
+	level         byte
+	tier          byte
+	width, height uint32
+	opCount       uint32
+
+	timingInfo   bool // timing_info_present_flag + decoder_model_info
+	displayDelay bool // initial_display_delay_present_flag
+	reducedStill bool // reduced_still_picture_header
+
+	highBitdepth bool
+	twelveBit    bool
+	monochrome   bool
+	subX, subY   byte // only written for profile 2 at 12-bit
+}
+
+func (s seqHdr) build() []byte {
+	if s.opCount == 0 {
+		s.opCount = 1
+	}
+	if s.width == 0 {
+		s.width, s.height = 1920, 1080
+	}
+
+	w := &bitWriter{}
+	w.put(uint32(s.profile), 3)
+	w.flag(false) // still_picture
+	w.flag(s.reducedStill)
+
+	if s.reducedStill {
+		w.put(uint32(s.level), 5)
+	} else {
+		w.flag(s.timingInfo)
+		if s.timingInfo {
+			w.put(0, 32)  // num_units_in_display_tick
+			w.put(0, 32)  // time_scale
+			w.flag(false) // equal_picture_interval
+			w.flag(true)  // decoder_model_info_present_flag
+			w.put(15, 5)  // buffer_delay_length_minus_1, 16 bits per delay
+			w.put(0, 32)  // num_units_in_decoding_tick
+			w.put(0, 5)   // buffer_removal_time_length_minus_1
+			w.put(0, 5)   // frame_presentation_time_length_minus_1
+		}
+
+		w.flag(s.displayDelay)
+
+		w.put(s.opCount-1, 5)
+		for i := uint32(0); i < s.opCount; i++ {
+			w.put(0, 12) // operating_point_idc
+			w.put(uint32(s.level), 5)
+			if s.level > 7 {
+				w.put(uint32(s.tier), 1)
+			}
+			if s.timingInfo {
+				w.flag(true) // decoder_model_present_for_this_op
+				w.put(0, 16) // decoder_buffer_delay
+				w.put(0, 16) // encoder_buffer_delay
+				w.flag(false)
+			}
+			if s.displayDelay {
+				w.flag(true) // initial_display_delay_present_for_this_op
+				w.put(0, 4)  // initial_display_delay_minus_1
+			}
+		}
+	}
+
+	w.put(15, 4) // frame_width_bits_minus_1
+	w.put(15, 4) // frame_height_bits_minus_1
+	w.put(s.width-1, 16)
+	w.put(s.height-1, 16)
+
+	if !s.reducedStill {
+		w.flag(false) // frame_id_numbers_present_flag
+	}
+
+	w.flag(false) // use_128x128_superblock
+	w.flag(false) // enable_filter_intra
+	w.flag(false) // enable_intra_edge_filter
+
+	if !s.reducedStill {
+		w.flag(false) // enable_interintra_compound
+		w.flag(false) // enable_masked_compound
+		w.flag(false) // enable_warped_motion
+		w.flag(false) // enable_dual_filter
+		w.flag(false) // enable_order_hint
+		w.flag(true)  // seq_choose_screen_content_tools
+		w.flag(true)  // seq_choose_integer_mv
+	}
+
+	w.flag(false) // enable_superres
+	w.flag(false) // enable_cdef
+	w.flag(false) // enable_restoration
+
+	// color_config()
+	w.flag(s.highBitdepth)
+	if s.profile == 2 && s.highBitdepth {
+		w.flag(s.twelveBit)
+	}
+	if s.profile != 1 {
+		w.flag(s.monochrome)
+	}
+	w.flag(false) // color_description_present_flag
+	w.put(0, 1)   // color_range
+
+	if !s.monochrome {
+		if s.profile == 2 && s.highBitdepth && s.twelveBit {
+			w.put(uint32(s.subX), 1)
+			if s.subX == 1 {
+				w.put(uint32(s.subY), 1)
+			}
+		}
+		subX, subY := s.subX, s.subY
+		switch {
+		case s.profile == 0:
+			subX, subY = 1, 1
+		case s.profile == 1:
+			subX, subY = 0, 0
+		case !(s.highBitdepth && s.twelveBit):
+			subX, subY = 1, 0
+		}
+		if subX == 1 && subY == 1 {
+			w.put(0, 2) // chroma_sample_position
+		}
+		w.flag(false) // separate_uv_delta_q
+	}
+
+	w.flag(false) // film_grain_params_present
+
+	return wrapOBU(OBUTypeSequenceHeader, w.data)
+}
+
+var testSeqHdr = seqHdr{level: 13, width: 3840, height: 2160}.build()
+
+func keyframeOBU() []byte   { return wrapOBU(OBUTypeFrame, []byte{0x00}) }
+func interframeOBU() []byte { return wrapOBU(OBUTypeFrame, []byte{0x20}) }
+
+var testKeyframePayload = append(append([]byte{}, testSeqHdr...), keyframeOBU()...)
+
+// --- LEB128 ---
+
+func TestReadLEB128(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		value uint32
+		n     int
+	}{
+		{"zero", []byte{0x00}, 0, 1},
+		{"one byte", []byte{0x7F}, 127, 1},
+		{"two bytes", []byte{0x80, 0x01}, 128, 2},
+		{"three bytes", []byte{0xE5, 0x8E, 0x26}, 624485, 3},
+		{"empty", nil, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, n := ReadLEB128(tt.input)
+			require.Equal(t, tt.value, value, "ReadLEB128(%v) value", tt.input)
+			require.Equal(t, tt.n, n, "ReadLEB128(%v) bytes consumed", tt.input)
+		})
+	}
+}
+
+func TestLEB128Roundtrip(t *testing.T) {
+	for _, v := range []uint32{0, 1, 127, 128, 255, 256, 16383, 16384, 624485, 1 << 28} {
+		got, n := ReadLEB128(WriteLEB128(v))
+		require.Equal(t, v, got, "LEB128 round trip for %d", v)
+		require.NotZero(t, n, "LEB128 round trip for %d consumed nothing", v)
+	}
+}
+
+// --- OBU helpers ---
+
+func TestOBUHeader(t *testing.T) {
+	tests := []struct {
+		header  byte
+		obuType byte
+		hasSize bool
+		hasExt  bool
+		hdrSize int
+	}{
+		{0x0A, OBUTypeSequenceHeader, true, false, 1},
+		{0x08, OBUTypeSequenceHeader, false, false, 1},
+		{0x0E, OBUTypeSequenceHeader, true, true, 2},
+		{0x12, OBUTypeTemporalDelimiter, true, false, 1},
+		{0x1A, OBUTypeFrameHeader, true, false, 1},
+		{0x32, OBUTypeFrame, true, false, 1},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.obuType, OBUType(tt.header), "OBUType(0x%02X)", tt.header)
+		require.Equal(t, tt.hasSize, OBUHasSize(tt.header), "OBUHasSize(0x%02X)", tt.header)
+		require.Equal(t, tt.hasExt, OBUHasExtension(tt.header), "OBUHasExtension(0x%02X)", tt.header)
+		require.Equal(t, tt.hdrSize, OBUHeaderSize(tt.header), "OBUHeaderSize(0x%02X)", tt.header)
+	}
+}
+
+// --- ParseOBUs ---
+
+func TestParseOBUs(t *testing.T) {
+	var types []byte
+	ParseOBUs(testKeyframePayload, func(obuType byte, obu []byte) bool {
+		types = append(types, obuType)
+		return true
+	})
+
+	want := []byte{OBUTypeSequenceHeader, OBUTypeFrame}
+	require.Equal(t, want, types, "ParseOBUs found %v, want %v", types, want)
+}
+
+func TestParseOBUsEarlyStop(t *testing.T) {
+	count := 0
+	ParseOBUs(testKeyframePayload, func(obuType byte, obu []byte) bool {
+		count++
+		return false
+	})
+	require.Equal(t, 1, count, "ParseOBUs with early stop: called %d times, want 1", count)
+}
+
+func TestParseOBUsTruncated(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want int // how many OBUs must be reported
+	}{
+		// size field promises more data than the buffer holds
+		{"far past the end", []byte{0x0A, 0x40, 0x00, 0x00}, 0},
+		// one byte short, the boundary a loose bounds check would let through
+		{"over-runs by one", []byte{0x32, 0x03, 0x00, 0x00}, 0},
+		// exactly fits, must be reported
+		{"exact fit", []byte{0x32, 0x02, 0x00, 0x00}, 1},
+		// size field itself is not a valid LEB128
+		{"unterminated size", []byte{0x32, 0x80, 0x80, 0x80, 0x80, 0x80}, 0},
+		// 5th byte carries bits above 32
+		{"size over 32 bits", []byte{0x32, 0x80, 0x80, 0x80, 0x80, 0x10}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var n int
+			ParseOBUs(tt.data, func(obuType byte, obu []byte) bool {
+				n++
+				return true
+			})
+			require.Equal(t, tt.want, n, "reported %d OBUs, want %d", n, tt.want)
+		})
+	}
+}
+
+// --- IsKeyframe ---
+
+func TestIsKeyframe(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    bool
+	}{
+		{"keyframe", testKeyframePayload, true},
+		{"interframe", interframeOBU(), false},
+		{"frame only, no seq header", keyframeOBU(), true},
+		{
+			"temporal delimiter first",
+			append(wrapOBU(OBUTypeTemporalDelimiter, nil), testKeyframePayload...),
+			true,
+		},
+		{
+			// the last OBU of a temporal unit may omit the size field
+			"no size field",
+			[]byte{OBUTypeFrame<<3 | 0x00, 0x00},
+			true,
+		},
+		{
+			"frame header plus tile group",
+			append(wrapOBU(OBUTypeFrameHeader, []byte{0x00}), wrapOBU(OBUTypeTileGroup, []byte{0x00})...),
+			true,
+		},
+		{
+			// show_existing_frame carries no frame_type, must not count as key
+			"show existing frame",
+			wrapOBU(OBUTypeFrame, []byte{0x80}),
+			false,
+		},
+		{
+			// a whole sample written by ffmpeg/libsvtav1, a frame header that
+			// only shows an already decoded frame
+			"show existing frame, ffmpeg sample",
+			[]byte{0x1A, 0x01, 0x88},
+			false,
+		},
+		{
+			// reduced_still_picture_header implies KEY_FRAME for every frame
+			"reduced still picture",
+			append(seqHdr{reducedStill: true, level: 8}.build(), interframeOBU()...),
+			true,
+		},
+		{
+			// a sequence header alone is not a frame
+			"sequence header only",
+			testSeqHdr,
+			false,
+		},
+		{
+			// INTRA_ONLY is not a keyframe, and it is the only frame type that
+			// tells a correct frame_type read from a shifted one
+			"intra only frame",
+			wrapOBU(OBUTypeFrame, []byte{0x40}),
+			false,
+		},
+		{
+			"switch frame",
+			wrapOBU(OBUTypeFrame, []byte{0x60}),
+			false,
+		},
+		{
+			// the first frame header of a unit decides, not the last
+			"keyframe followed by inter frame",
+			append(wrapOBU(OBUTypeFrame, []byte{0x00}), wrapOBU(OBUTypeFrame, []byte{0x20})...),
+			true,
+		},
+		{
+			"inter frame followed by keyframe",
+			append(wrapOBU(OBUTypeFrame, []byte{0x20}), wrapOBU(OBUTypeFrame, []byte{0x00})...),
+			false,
+		},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsKeyframe(tt.payload))
+		})
+	}
+}
+
+// --- SequenceHeader ---
+
+func TestSequenceHeader(t *testing.T) {
+	require.Equal(t, testSeqHdr, SequenceHeader(testKeyframePayload))
+	require.Nil(t, SequenceHeader(interframeOBU()), "an inter frame carries no sequence header")
+}
+
+// --- ParseSequenceHeaderInfo ---
+
+func TestParseSequenceHeaderInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		hdr  seqHdr
+		want SequenceHeaderInfo
+		mime string
+	}{
+		{
+			name: "1080p main",
+			hdr:  seqHdr{level: 8},
+			want: SequenceHeaderInfo{Level: 8, BitDepth: 8, Width: 1920, Height: 1080,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.08M.08",
+		},
+		{
+			name: "4k high tier",
+			hdr:  seqHdr{level: 13, tier: 1, width: 3840, height: 2160},
+			want: SequenceHeaderInfo{Level: 13, Tier: 1, BitDepth: 8, Width: 3840, Height: 2160,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.13H.08",
+		},
+		{
+			// the two per operating point flags below are what ffmpeg and
+			// several cameras emit, and skipping them shifts everything after
+			name: "initial_display_delay",
+			hdr:  seqHdr{level: 8, displayDelay: true},
+			want: SequenceHeaderInfo{Level: 8, BitDepth: 8, Width: 1920, Height: 1080,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.08M.08",
+		},
+		{
+			name: "decoder_model_info",
+			hdr:  seqHdr{level: 8, timingInfo: true},
+			want: SequenceHeaderInfo{Level: 8, BitDepth: 8, Width: 1920, Height: 1080,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.08M.08",
+		},
+		{
+			name: "both, three operating points",
+			hdr:  seqHdr{level: 13, width: 3840, height: 2160, opCount: 3, timingInfo: true, displayDelay: true},
+			want: SequenceHeaderInfo{Level: 13, BitDepth: 8, Width: 3840, Height: 2160,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.13M.08",
+		},
+		{
+			name: "reduced still picture",
+			hdr:  seqHdr{level: 8, reducedStill: true, width: 1280, height: 720},
+			want: SequenceHeaderInfo{Level: 8, BitDepth: 8, Width: 1280, Height: 720,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.08M.08",
+		},
+		{
+			name: "10 bit",
+			hdr:  seqHdr{level: 13, width: 3840, height: 2160, highBitdepth: true},
+			want: SequenceHeaderInfo{Level: 13, BitDepth: 10, Width: 3840, Height: 2160,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1, highBitdepth: 1},
+			mime: "av01.0.13M.10",
+		},
+		{
+			name: "profile 2, 12 bit 4:2:0",
+			hdr:  seqHdr{profile: 2, level: 8, highBitdepth: true, twelveBit: true, subX: 1, subY: 1},
+			want: SequenceHeaderInfo{Profile: 2, Level: 8, BitDepth: 12, Width: 1920, Height: 1080,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1, highBitdepth: 1, twelveBit: 1},
+			mime: "av01.2.08M.12",
+		},
+		{
+			name: "profile 2, 12 bit 4:4:4",
+			hdr:  seqHdr{profile: 2, level: 8, highBitdepth: true, twelveBit: true},
+			want: SequenceHeaderInfo{Profile: 2, Level: 8, BitDepth: 12, Width: 1920, Height: 1080,
+				highBitdepth: 1, twelveBit: 1},
+			mime: "av01.2.08M.12",
+		},
+		{
+			// spec keeps subsampling at 1,1 for monochrome
+			name: "monochrome",
+			hdr:  seqHdr{level: 8, monochrome: true},
+			want: SequenceHeaderInfo{Level: 8, BitDepth: 8, Width: 1920, Height: 1080, Monochrome: true,
+				ChromaSubsamplingX: 1, ChromaSubsamplingY: 1},
+			mime: "av01.0.08M.08",
+		},
+		{
+			name: "profile 1 is 4:4:4",
+			hdr:  seqHdr{profile: 1, level: 8},
+			want: SequenceHeaderInfo{Profile: 1, Level: 8, BitDepth: 8, Width: 1920, Height: 1080},
+			mime: "av01.1.08M.08",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := tt.hdr.build()
+
+			info := ParseSequenceHeaderInfo(raw)
+			require.NotNil(t, info, "ParseSequenceHeaderInfo returned nil")
+			require.Equal(t, tt.want, *info)
+
+			require.Equal(t, tt.mime, MimeCodecString(raw))
+
+			// the av1C packing has a field per parsed value, check them all
+			var mono byte
+			if tt.want.Monochrome {
+				mono = 1
+			}
+			conf := EncodeConfig(raw)
+			wantSeq := tt.want.Profile<<5 | tt.want.Level&0x1F
+			wantColor := tt.want.Tier<<7 | tt.want.highBitdepth<<6 | tt.want.twelveBit<<5 | mono<<4 |
+				tt.want.ChromaSubsamplingX<<3 | tt.want.ChromaSubsamplingY<<2 | tt.want.ChromaSamplePos&0x03
+			require.Equal(t, wantSeq, conf[1], "av1C seq_profile/seq_level_idx byte")
+			require.Equal(t, wantColor, conf[2], "av1C colour byte")
+
+			w, h := DecodeSequenceHeader(raw)
+			require.Equal(t, tt.want.Width, w, "width")
+			require.Equal(t, tt.want.Height, h, "height")
+		})
+	}
+}
+
+func TestParseSequenceHeaderInfoInvalid(t *testing.T) {
+	require.Nil(t, ParseSequenceHeaderInfo(nil), "nil input should not parse")
+	require.Equal(t, "", MimeCodecString(nil), "MimeCodecString(nil) should be empty")
+
+	// reserved profile
+	require.Nil(t, ParseSequenceHeaderInfo(seqHdr{profile: 5, level: 8}.build()), "a reserved profile must not parse")
+
+	// every truncation must be rejected rather than parsed into garbage
+	full := testSeqHdr
+	for i := 0; i < len(full); i++ {
+		if info := ParseSequenceHeaderInfo(full[:i]); info != nil {
+			t.Errorf("truncated to %d/%d bytes parsed as %+v", i, len(full), *info)
+		}
+	}
+
+	// size field is honest but the payload ends mid header
+	payload := full[2:]
+	for i := 1; i < len(payload); i++ {
+		if info := ParseSequenceHeaderInfo(wrapOBU(OBUTypeSequenceHeader, payload[:i])); info != nil {
+			t.Errorf("payload cut to %d/%d bytes parsed as %+v", i, len(payload), *info)
+		}
+	}
+}
+
+// --- EncodeConfig ---
+
+func TestEncodeConfig(t *testing.T) {
+	conf := EncodeConfig(testSeqHdr)
+
+	require.Equal(t, 4+len(testSeqHdr), len(conf), "av1C is a 4 byte record plus the configOBUs")
+	require.Equal(t, byte(0x81), conf[0], "marker=1, version=1")
+	// profile(3)=0 | seq_level_idx_0(5)=13
+	require.Equal(t, byte(13), conf[1], "conf[1] = 0x%02X, want 0x0D (profile=0, level=13)", conf[1])
+	// tier|high_bitdepth|twelve_bit|monochrome|chroma_x|chroma_y|chroma_pos(2)
+	require.Equal(t, byte(1<<3|1<<2), conf[2], "conf[2] = 0x%02X, want 0x0C (4:2:0, 8-bit)", conf[2])
+	require.Equal(t, byte(0x00), conf[3], "conf[3] = 0x%02X, want 0x00", conf[3])
+	require.Equal(t, testSeqHdr, conf[4:], "configOBUs should be the sequence header OBU")
+}
+
+func TestEncodeConfigDefaults(t *testing.T) {
+	conf := EncodeConfig(nil)
+	require.Equal(t, 4, len(conf), "av1C without configOBUs is 4 bytes")
+	require.Equal(t, byte(0x81), conf[0], "marker=1, version=1")
+	require.Equal(t, byte(8), conf[1]&0x1F, "default level is 4.0")
+	require.Equal(t, byte(1<<3|1<<2), conf[2], "conf[2] = 0x%02X, want 0x0C (4:2:0)", conf[2])
+}
+
+// --- FmtpLine ---
+
+func TestFmtpLine(t *testing.T) {
+	require.Equal(t, testSeqHdr, GetSequenceHeader(EncodeFmtpLine(testSeqHdr)), "fmtp line round trip")
+	require.Nil(t, GetSequenceHeader(""), "an empty fmtp line has no sequence header")
+	for _, fmtp := range []string{
+		"packetization-mode=1",
+		fmtpSeqHeader,
+		fmtpSeqHeader + ";profile=0",
+		fmtpSeqHeader + "not base64!;",
+	} {
+		require.Nil(t, GetSequenceHeader(fmtp), "GetSequenceHeader(%q)", fmtp)
+	}
+
+	// no trailing semicolon
+	require.Equal(t, testSeqHdr, GetSequenceHeader(EncodeFmtpLine(testSeqHdr)+";x=1"), "trailing fmtp params")
+}
+
+// --- real world fixtures ---
+
+// av1C records taken from files written by ffmpeg/libsvtav1. Re-encoding them
+// must reproduce the original bytes, which checks the parser and the encoder
+// against a reference implementation rather than against our own builder.
+func TestEncodeConfigAgainstFFmpeg(t *testing.T) {
+	tests := []struct {
+		name string
+		av1c string
+		mime string
+		w, h uint16
+	}{
+		{"640x480 8-bit 4:2:0", "81040c000a0b00000024c4ffdf00be0010", "av01.0.04M.08", 640, 480},
+		{"1920x1080 8-bit 4:2:0", "81080c000a0b00000042abbfc3700be001", "av01.0.08M.08", 1920, 1080},
+		{"1280x720 8-bit 4:2:0", "81050c000a0b0000002d4cffb3c02f8004", "av01.0.05M.08", 1280, 720},
+		{"3840x2160 10-bit 4:2:0", "810c4c000a0c00000062efbfe1bc02f84040", "av01.0.12M.10", 3840, 2160},
+		// color_description_present_flag = 1, which no other fixture exercises
+		{"1920x1080 BT.709 tagged", "81080c000a0e00000042abbfc3700be040808041", "av01.0.08M.08", 1920, 1080},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, err := hex.DecodeString(tt.av1c)
+			require.NoError(t, err, err)
+			seqHdr := want[4:] // configOBUs
+
+			require.Equal(t, want, EncodeConfig(seqHdr), "av1C record")
+			require.Equal(t, tt.mime, MimeCodecString(seqHdr))
+			if w, h := DecodeSequenceHeader(seqHdr); w != tt.w || h != tt.h {
+				t.Errorf("DecodeSequenceHeader() = (%d, %d), want (%d, %d)", w, h, tt.w, tt.h)
+			}
+		})
+	}
+}
+
+// A sequence header without a size field runs to the end of the temporal unit.
+// Returning it would put the whole keyframe into av1C and into the fmtp line.
+func TestSequenceHeaderWithoutSizeField(t *testing.T) {
+	hdr := seqHdr{level: 8}.build()
+	sizeless := append([]byte{hdr[0] &^ 0x02}, hdr[2:]...)
+	unit := append(sizeless, wrapOBU(OBUTypeFrame, make([]byte, 4096))...)
+
+	require.Nil(t, SequenceHeader(unit), "a sizeless sequence header must be refused")
+}
+
+// LEB128 that is truncated or wider than 32 bits must be rejected, not read as 0.
+func TestReadLEB128Invalid(t *testing.T) {
+	for _, b := range [][]byte{
+		{0x80},                               // no terminating byte
+		{0x80, 0x80},                         // still continuing
+		{0x80, 0x80, 0x80, 0x80, 0x80, 0x01}, // 2^35
+		{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, // never terminates
+	} {
+		if v, n := ReadLEB128(b); n != 0 {
+			t.Errorf("ReadLEB128(% x) = (%d, %d), want n = 0", b, v, n)
+		}
+	}
+}
+
+// uvlc() counts zeros up to the terminating one bit and only then checks the
+// range. Stopping at 32 leaves the reader a few bits behind for the rest of
+// the header, which yields a plausible but wrong resolution.
+func TestReadUVLC(t *testing.T) {
+	tests := []struct {
+		name string
+		bits []uint32 // value, width pairs written in order
+		want uint32
+	}{
+		{"zero", []uint32{1, 1}, 0},
+		{"one", []uint32{0, 1, 1, 1, 0, 1}, 1},
+		{"two", []uint32{0, 1, 1, 1, 1, 1}, 2},
+		{"255", []uint32{0, 8, 1, 1, 0, 8}, 255},  // (1<<8 - 1) + 0
+		{"300", []uint32{0, 8, 1, 1, 45, 8}, 300}, // (1<<8 - 1) + 45
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bitWriter{}
+			for i := 0; i < len(tt.bits); i += 2 {
+				w.put(tt.bits[i], int(tt.bits[i+1]))
+			}
+			r := &bitReader{data: w.data}
+			require.Equal(t, tt.want, r.readUVLC())
+		})
+	}
+
+	// 33 leading zeros is out of range, and the terminator still has to be
+	// consumed so the caller can reject the header instead of misreading it
+	w := &bitWriter{}
+	w.put(0, 33)
+	w.put(1, 1)
+	w.put(0x2A, 8)
+	r := &bitReader{data: w.data}
+	require.Equal(t, uint32(0xFFFFFFFF), r.readUVLC(), "32 leading zeros")
+	require.Equal(t, uint32(0x2A), r.readBits(8), "reader is out of sync after an oversized uvlc")
+}
+
+// The guard exists for exactly this value.
+func TestClampDimension(t *testing.T) {
+	for _, tt := range []struct {
+		minusOne uint32
+		want     uint16
+	}{{0, 1}, {1919, 1920}, {0xFFFE, 0xFFFF}, {0xFFFF, 0xFFFF}, {0x1FFFF, 0xFFFF}} {
+		require.Equal(t, tt.want, clampDimension(tt.minusOne), "clampDimension(%d)", tt.minusOne)
+	}
+}
+
+// A header that ends exactly on its last bit is valid and must be accepted.
+func TestBitReaderExactFit(t *testing.T) {
+	r := &bitReader{data: []byte{0xFF, 0xFF}}
+	require.Equal(t, uint32(0xFFFF), r.readBits(16), "an exact fit must read")
+	require.False(t, r.eof, "an exact fit must not set eof")
+
+	r.readBits(1)
+	require.True(t, r.eof, "reading past the end must set eof")
+
+	r = &bitReader{data: []byte{0xFF}}
+	r.skipBits(8)
+	if r.eof {
+		t.Error("skipping exactly to the end should not set eof")
+	}
+	r.skipBits(1)
+	require.True(t, r.eof, "skipping past the end should set eof")
+}
+
+// --- RTP ---
+
+func TestRTPRoundTrip(t *testing.T) {
+	// a temporal unit big enough to need fragmenting at every MTU below
+	unit := append(append([]byte{}, testSeqHdr...),
+		wrapOBU(OBUTypeFrame, append([]byte{0x00}, bytes.Repeat([]byte{0xA5}, 4000)...))...)
+
+	for _, mtu := range []uint16{1472, 1200, 300, 64, 20} {
+		t.Run(fmt.Sprint(mtu), func(t *testing.T) {
+			var got [][]byte
+			var out *rtp.Packet
+			sink := RTPDepay(func(p *rtp.Packet) {
+				got = append(got, append([]byte{}, p.Payload...))
+				out = p
+			})
+
+			var last bool
+			var maxPayload int
+			pay := RTPPay(mtu, func(p *rtp.Packet) {
+				last = p.Marker
+				if len(p.Payload) > maxPayload {
+					maxPayload = len(p.Payload)
+				}
+				sink(p)
+			})
+			pay(&rtp.Packet{
+				Header:  rtp.Header{Version: RTPPacketVersionAV1, Timestamp: 90000},
+				Payload: unit,
+			})
+
+			require.True(t, last, "the last packet has no marker")
+			require.Equal(t, 1, len(got), "temporal units")
+			require.Equal(t, unit, got[0], "round trip changed the unit: %d bytes in, %d out", len(unit), len(got[0]))
+			require.True(t, IsKeyframe(got[0]), "the reassembled unit is no longer a keyframe")
+
+			// RTPPay keys off the version to tell depayed units apart
+			require.Equal(t, uint8(RTPPacketVersionAV1), out.Version, "RTPPay keys off the version")
+			// AV1 has no B-frames, a composition time offset would desync the muxer
+			require.Equal(t, uint16(0), out.ExtensionProfile, "AV1 has no B-frames, so no composition time offset")
+			// the payloader has to leave room for the 12 byte RTP header
+			if maxPayload+12 > int(mtu) {
+				t.Errorf("largest packet is %d+12 bytes, over the %d byte MTU", maxPayload, mtu)
+			}
+		})
+	}
+}
+
+// A lost packet splices OBUs from two units together, and pion rewrites
+// obu_size to match, so the result still parses as a valid keyframe.
+func TestRTPDepayDropsGaps(t *testing.T) {
+	unit := append(append([]byte{}, testSeqHdr...),
+		wrapOBU(OBUTypeFrame, append([]byte{0x00}, bytes.Repeat([]byte{0xA5}, 4000)...))...)
+
+	var packets []*rtp.Packet
+	seq := uint16(1000)
+	RTPPay(300, func(p *rtp.Packet) {
+		p.SequenceNumber = seq
+		seq++
+		packets = append(packets, p)
+	})(&rtp.Packet{Header: rtp.Header{Version: RTPPacketVersionAV1}, Payload: unit})
+
+	if len(packets) < 4 {
+		t.Fatalf("expected a fragmented unit, got %d packets", len(packets))
+	}
+
+	// a hole anywhere in the unit must drop it, not emit a shortened one:
+	// pion rewrites obu_size on reassembly, so the remains still parse
+	for drop := range packets {
+		var got [][]byte
+		h := RTPDepay(func(p *rtp.Packet) { got = append(got, append([]byte{}, p.Payload...)) })
+		for i, p := range packets {
+			if i == drop {
+				continue
+			}
+			h(p)
+		}
+
+		for _, u := range got {
+			if !bytes.Equal(u, unit) {
+				t.Errorf("dropping packet %d/%d emitted %d bytes, want %d or nothing",
+					drop, len(packets), len(u), len(unit))
+			}
+		}
+	}
+}
+
+// TestRTPDepayResyncsOnUnitBoundary - after a hole the depayloader must not
+// resume mid unit, or the tail of the broken unit is spliced onto the next one.
+func TestRTPDepayResyncsOnUnitBoundary(t *testing.T) {
+	unitA := append(append([]byte{}, testSeqHdr...),
+		wrapOBU(OBUTypeFrame, append([]byte{0x00}, bytes.Repeat([]byte{0xA5}, 2000)...))...)
+	unitB := wrapOBU(OBUTypeFrame, append([]byte{0x30}, bytes.Repeat([]byte{0x5A}, 2000)...))
+
+	var packets []*rtp.Packet
+	seq := uint16(1000)
+	pay := RTPPay(300, func(p *rtp.Packet) {
+		p.SequenceNumber = seq
+		seq++
+		packets = append(packets, p)
+	})
+	pay(&rtp.Packet{Header: rtp.Header{Version: RTPPacketVersionAV1}, Payload: unitA})
+	pay(&rtp.Packet{Header: rtp.Header{Version: RTPPacketVersionAV1}, Payload: unitB})
+
+	for drop := range packets {
+		var got [][]byte
+		h := RTPDepay(func(p *rtp.Packet) { got = append(got, append([]byte{}, p.Payload...)) })
+		for i, p := range packets {
+			if i == drop {
+				continue
+			}
+			h(p)
+		}
+
+		for _, u := range got {
+			if !bytes.Equal(u, unitA) && !bytes.Equal(u, unitB) {
+				t.Errorf("dropping packet %d/%d emitted a %d byte unit that is neither source unit",
+					drop, len(packets), len(u))
+			}
+		}
+	}
+}
+
+// The depacketizer buffers fragments of an unfinished OBU itself, so a stream
+// of continuation fragments that never completes one must not grow without end.
+func TestRTPDepayBoundsUnfinishedUnit(t *testing.T) {
+	var emitted int
+	depay := RTPDepay(func(p *rtp.Packet) { emitted++ })
+
+	seq := uint16(1)
+	depay(&rtp.Packet{Header: rtp.Header{SequenceNumber: seq}, Payload: []byte{0x50, 0x30, 0x00}})
+
+	frag := make([]byte, 1200)
+	frag[0] = 0xD0 // Z=1 Y=1 W=1, a continuation that never ends
+
+	// well past maxUnitBytes: without a bound this is quadratic and keeps
+	// every byte, so it would take tens of seconds instead of well under one
+	start := time.Now()
+	for i := 0; i < 32000; i++ {
+		seq++
+		depay(&rtp.Packet{Header: rtp.Header{SequenceNumber: seq}, Payload: frag})
+	}
+	elapsed := time.Since(start)
+
+	require.Equal(t, 0, emitted, "emitted %d units from fragments that never complete an OBU", emitted)
+	if elapsed > 5*time.Second {
+		t.Errorf("38 MB of continuation fragments took %v, the buffer is not bounded", elapsed)
+	}
+}
+
+// A large but legal temporal unit still has to survive the round trip.
+func TestRTPRoundTripLargeUnit(t *testing.T) {
+	unit := append(append([]byte{}, testSeqHdr...),
+		wrapOBU(OBUTypeFrame, append([]byte{0x00}, bytes.Repeat([]byte{0x5A}, 1<<20)...))...)
+
+	var got [][]byte
+	sink := RTPDepay(func(p *rtp.Packet) { got = append(got, append([]byte{}, p.Payload...)) })
+	RTPPay(1200, sink)(&rtp.Packet{
+		Header:  rtp.Header{Version: RTPPacketVersionAV1, Timestamp: 90000},
+		Payload: unit,
+	})
+
+	if len(got) != 1 || !bytes.Equal(got[0], unit) {
+		t.Fatalf("a 1 MB unit did not survive the round trip: %d units back", len(got))
+	}
+}
+
+// A sequence header is copied into the fmtp line, into the av1C box of every
+// init segment and into every RTSP SDP answer, so a padded one must be refused.
+func TestSequenceHeaderSizeCap(t *testing.T) {
+	for _, n := range []int{16, MaxSequenceHeaderSize - 4, MaxSequenceHeaderSize + 1, 1 << 20} {
+		body := make([]byte, n)
+		obu := append([]byte{0x0A}, WriteLEB128(uint32(n))...)
+		obu = append(obu, body...)
+
+		got := SequenceHeader(obu)
+		if n <= MaxSequenceHeaderSize-4 && got == nil {
+			t.Errorf("a %d byte sequence header was refused", n)
+		}
+		if n > MaxSequenceHeaderSize && got != nil {
+			t.Errorf("a %d byte sequence header was accepted, %d bytes came back", n, len(got))
+		}
+	}
+}
+
+// int is 32 bits on the 386, arm and mips builds, where a size this large goes
+// negative and the slice bounds check is passed with a negative length.
+func TestParseOBUsHugeSizeField(t *testing.T) {
+	data := []byte{0x0A, 0x80, 0x80, 0x80, 0x80, 0x08} // obu_size = 0x80000000
+
+	var n int
+	ParseOBUs(data, func(obuType byte, obu []byte) bool { n++; return true })
+	require.Equal(t, 0, n, "reported %d OBUs for a size field of 2 GiB", n)
+
+	IsKeyframe(data)
+	SequenceHeader(data)
+}
+
+// pion's payloader marks every packet after the first as a continuation, but a
+// foreign packetizer may start a fresh OBU in the middle of a temporal unit.
+// Resuming there would emit a unit missing everything before the gap.
+func TestRTPDepayForeignPacketizerMidUnit(t *testing.T) {
+	obu := func(b byte) []byte { return []byte{0x32, 0x02, b, b} }
+	// aggregation header: Z=0 (starts an OBU), W=1 element
+	pkt := func(seq uint16, marker bool, b byte) *rtp.Packet {
+		return &rtp.Packet{
+			Header:  rtp.Header{SequenceNumber: seq, Marker: marker},
+			Payload: append([]byte{0x10}, obu(b)...),
+		}
+	}
+
+	var got [][]byte
+	h := RTPDepay(func(p *rtp.Packet) { got = append(got, append([]byte{}, p.Payload...)) })
+
+	h(pkt(100, false, 0xAA)) // starts the unit
+	// sequence 101 is lost
+	h(pkt(102, false, 0xCC)) // fresh OBU, but still mid unit
+	h(pkt(103, true, 0xDD))  // ends the unit
+
+	require.Empty(t, got, "a unit missing everything before the gap was emitted")
+}

--- a/pkg/av1/config.go
+++ b/pkg/av1/config.go
@@ -1,0 +1,396 @@
+package av1
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+// Color description values from AV1 spec Section 6.4.2.
+const (
+	cpBT709    = 1
+	tcSRGB     = 13
+	mcIdentity = 0
+)
+
+// SequenceHeaderInfo holds parsed fields from an AV1 Sequence Header OBU.
+// Used for av1C box generation, MIME codec strings, and resolution detection.
+type SequenceHeaderInfo struct {
+	Profile    byte
+	Level      byte // seq_level_idx[0]
+	Tier       byte // 0=Main, 1=High
+	BitDepth   byte // 8, 10, or 12
+	Monochrome bool
+	Width      uint16
+	Height     uint16
+
+	// Chroma subsampling (for av1C box)
+	ChromaSubsamplingX byte
+	ChromaSubsamplingY byte
+	ChromaSamplePos    byte
+
+	// Raw flags for av1C encoding
+	highBitdepth byte
+	twelveBit    byte
+}
+
+// ParseSequenceHeaderInfo parses a raw Sequence Header OBU (with OBU header and
+// optional size field). Returns nil if the OBU is truncated or invalid.
+//
+// Follows sequence_header_obu() from AV1 spec Section 5.5.1.
+func ParseSequenceHeaderInfo(obu []byte) *SequenceHeaderInfo {
+	data := obuPayload(obu)
+	if data == nil {
+		return nil
+	}
+
+	r := &bitReader{data: data}
+	info := &SequenceHeaderInfo{}
+
+	info.Profile = byte(r.readBits(3))
+	if info.Profile > 2 {
+		return nil // reserved profile, rest of the header can't be trusted
+	}
+
+	r.skipBits(1) // still_picture
+	reducedStill := r.readFlag()
+
+	// flags that gate the per operating point fields below
+	var decoderModelInfo, initialDisplayDelay bool
+	var bufferDelayLength uint32
+
+	if reducedStill {
+		info.Level = byte(r.readBits(5))
+	} else {
+		if r.readFlag() { // timing_info_present_flag
+			// timing_info()
+			r.skipBits(32)    // num_units_in_display_tick
+			r.skipBits(32)    // time_scale
+			if r.readFlag() { // equal_picture_interval
+				r.readUVLC() // num_ticks_per_picture_minus_1
+			}
+
+			if decoderModelInfo = r.readFlag(); decoderModelInfo {
+				// decoder_model_info()
+				bufferDelayLength = r.readBits(5) + 1
+				r.skipBits(32) // num_units_in_decoding_tick
+				r.skipBits(5)  // buffer_removal_time_length_minus_1
+				r.skipBits(5)  // frame_presentation_time_length_minus_1
+			}
+		}
+
+		initialDisplayDelay = r.readFlag()
+
+		opCount := r.readBits(5) + 1
+		for i := uint32(0); i < opCount; i++ {
+			r.skipBits(12) // operating_point_idc
+
+			level := byte(r.readBits(5))
+			var tier byte
+			if level > 7 {
+				tier = byte(r.readBits(1))
+			}
+			if i == 0 {
+				info.Level, info.Tier = level, tier
+			}
+
+			if decoderModelInfo && r.readFlag() { // decoder_model_present_for_this_op
+				// operating_parameters_info()
+				r.skipBits(bufferDelayLength) // decoder_buffer_delay
+				r.skipBits(bufferDelayLength) // encoder_buffer_delay
+				r.skipBits(1)                 // low_delay_mode_flag
+			}
+
+			if initialDisplayDelay && r.readFlag() { // initial_display_delay_present_for_this_op
+				r.skipBits(4) // initial_display_delay_minus_1
+			}
+
+			if r.eof {
+				return nil
+			}
+		}
+	}
+
+	// frame dimensions, present for reduced_still_picture_header too
+	widthBits := r.readBits(4) + 1
+	heightBits := r.readBits(4) + 1
+	info.Width = clampDimension(r.readBits(widthBits))
+	info.Height = clampDimension(r.readBits(heightBits))
+
+	if !reducedStill && r.readFlag() { // frame_id_numbers_present_flag
+		r.skipBits(4) // delta_frame_id_length_minus_2
+		r.skipBits(3) // additional_frame_id_length_minus_1
+	}
+
+	r.skipBits(1) // use_128x128_superblock
+	r.skipBits(1) // enable_filter_intra
+	r.skipBits(1) // enable_intra_edge_filter
+
+	if !reducedStill {
+		r.skipBits(1) // enable_interintra_compound
+		r.skipBits(1) // enable_masked_compound
+		r.skipBits(1) // enable_warped_motion
+		r.skipBits(1) // enable_dual_filter
+
+		enableOrderHint := r.readFlag()
+		if enableOrderHint {
+			r.skipBits(1) // enable_jnt_comp
+			r.skipBits(1) // enable_ref_frame_mvs
+		}
+
+		// SELECT_SCREEN_CONTENT_TOOLS when seq_choose_screen_content_tools is set
+		forceScreenContent := uint32(2)
+		if !r.readFlag() { // seq_choose_screen_content_tools
+			forceScreenContent = r.readBits(1)
+		}
+		if forceScreenContent > 0 {
+			if !r.readFlag() { // seq_choose_integer_mv
+				r.skipBits(1) // seq_force_integer_mv
+			}
+		}
+
+		if enableOrderHint {
+			r.skipBits(3) // order_hint_bits_minus_1
+		}
+	}
+
+	r.skipBits(1) // enable_superres
+	r.skipBits(1) // enable_cdef
+	r.skipBits(1) // enable_restoration
+
+	parseColorConfig(r, info)
+
+	if r.eof {
+		return nil
+	}
+
+	return info
+}
+
+// parseColorConfig follows color_config() from AV1 spec Section 5.5.2.
+func parseColorConfig(r *bitReader, info *SequenceHeaderInfo) {
+	info.highBitdepth = byte(r.readBits(1))
+
+	info.BitDepth = 8
+	switch {
+	case info.Profile == 2 && info.highBitdepth == 1:
+		info.twelveBit = byte(r.readBits(1))
+		if info.twelveBit == 1 {
+			info.BitDepth = 12
+		} else {
+			info.BitDepth = 10
+		}
+	case info.highBitdepth == 1:
+		info.BitDepth = 10
+	}
+
+	if info.Profile != 1 {
+		info.Monochrome = r.readFlag()
+	}
+
+	// CP_UNSPECIFIED, TC_UNSPECIFIED, MC_UNSPECIFIED
+	colorPrimaries, transfer, matrix := uint32(2), uint32(2), uint32(2)
+	if r.readFlag() { // color_description_present_flag
+		colorPrimaries = r.readBits(8)
+		transfer = r.readBits(8)
+		matrix = r.readBits(8)
+	}
+
+	if info.Monochrome {
+		r.skipBits(1) // color_range
+		info.ChromaSubsamplingX = 1
+		info.ChromaSubsamplingY = 1
+		return
+	}
+
+	if colorPrimaries == cpBT709 && transfer == tcSRGB && matrix == mcIdentity {
+		// implicit full range 4:4:4, no color_range bit
+		r.skipBits(1) // separate_uv_delta_q
+		return
+	}
+
+	r.skipBits(1) // color_range
+
+	switch {
+	case info.Profile == 0:
+		info.ChromaSubsamplingX = 1
+		info.ChromaSubsamplingY = 1
+	case info.Profile == 1:
+		// 4:4:4, both stay 0
+	case info.BitDepth == 12:
+		info.ChromaSubsamplingX = byte(r.readBits(1))
+		if info.ChromaSubsamplingX == 1 {
+			info.ChromaSubsamplingY = byte(r.readBits(1))
+		}
+	default:
+		info.ChromaSubsamplingX = 1 // 4:2:2
+	}
+
+	if info.ChromaSubsamplingX == 1 && info.ChromaSubsamplingY == 1 {
+		info.ChromaSamplePos = byte(r.readBits(2))
+	}
+
+	r.skipBits(1) // separate_uv_delta_q
+}
+
+// MimeCodecString generates the av01 MIME codec string from a raw Sequence Header OBU.
+// Format: av01.<profile>.<levelIdx><tier>.<bitDepth>
+// See: https://aomediacodec.github.io/av1-isobmff/#codecsparam
+func MimeCodecString(seqHdr []byte) string {
+	info := ParseSequenceHeaderInfo(seqHdr)
+	if info == nil {
+		return ""
+	}
+
+	tier := 'M'
+	if info.Tier == 1 {
+		tier = 'H'
+	}
+
+	return fmt.Sprintf("av01.%d.%02d%c.%02d", info.Profile, info.Level, tier, info.BitDepth)
+}
+
+// EncodeConfig creates an AV1CodecConfigurationRecord for the av1C box in MP4.
+// See: https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationrecord
+//
+// The seqHdr should be a raw Sequence Header OBU (with OBU header and size).
+// If seqHdr can't be parsed, a default config (Main profile, level 4.0, 8-bit,
+// 4:2:0) is used, so the muxer still produces a playable init segment.
+func EncodeConfig(seqHdr []byte) []byte {
+	info := ParseSequenceHeaderInfo(seqHdr)
+	if info == nil {
+		info = &SequenceHeaderInfo{Level: 8, ChromaSubsamplingX: 1, ChromaSubsamplingY: 1}
+	}
+
+	var monochrome byte
+	if info.Monochrome {
+		monochrome = 1
+	}
+
+	conf := []byte{
+		0x81, // marker=1, version=1
+		(info.Profile << 5) | (info.Level & 0x1F),
+		(info.Tier << 7) | (info.highBitdepth << 6) | (info.twelveBit << 5) | (monochrome << 4) |
+			(info.ChromaSubsamplingX << 3) | (info.ChromaSubsamplingY << 2) | (info.ChromaSamplePos & 0x03),
+		0x00, // reserved(3)=0, initial_presentation_delay_present=0, reserved(4)=0
+	}
+
+	return append(conf, seqHdr...)
+}
+
+// ConfigToCodec parses an AV1CodecConfigurationRecord (av1C) into a core.Codec.
+// The record is carried in the enhanced-RTMP/FLV PacketTypeSequenceStart body
+// and in the ISOBMFF av1C box.
+func ConfigToCodec(conf []byte) *core.Codec {
+	codec := &core.Codec{
+		Name:        core.CodecAV1,
+		ClockRate:   90000,
+		PayloadType: core.PayloadTypeRAW,
+	}
+
+	// configOBUs, everything after the 4 byte record header
+	if len(conf) > 4 {
+		if seqHdr := SequenceHeader(conf[4:]); seqHdr != nil {
+			codec.FmtpLine = EncodeFmtpLine(seqHdr)
+		}
+	}
+
+	return codec
+}
+
+// DecodeSequenceHeader parses a Sequence Header OBU and returns width and height.
+// Convenience wrapper around ParseSequenceHeaderInfo.
+func DecodeSequenceHeader(obu []byte) (width, height uint16) {
+	if info := ParseSequenceHeaderInfo(obu); info != nil {
+		return info.Width, info.Height
+	}
+	return 0, 0
+}
+
+// AV1 has no fmtp parameter carrying the sequence header (RFC 9583), so go2rtc
+// uses its own, shaped like the H264/H265 sprop parameters.
+const fmtpSeqHeader = "sprop-seq-header="
+
+// EncodeFmtpLine stores a raw Sequence Header OBU in a codec FmtpLine.
+func EncodeFmtpLine(seqHdr []byte) string {
+	return fmtpSeqHeader + base64.StdEncoding.EncodeToString(seqHdr)
+}
+
+// GetSequenceHeader extracts the raw Sequence Header OBU from a codec FmtpLine.
+func GetSequenceHeader(fmtp string) []byte {
+	s := core.Between(fmtp, fmtpSeqHeader, ";")
+	if s == "" {
+		return nil
+	}
+	seqHdr, err := base64.StdEncoding.DecodeString(s)
+	if err != nil || len(seqHdr) == 0 {
+		return nil
+	}
+	return seqHdr
+}
+
+// clampDimension converts max_frame_*_minus_1 to a dimension. The spec allows up
+// to 16 bits, so the +1 can overflow the uint16 the MP4 track header uses.
+func clampDimension(minusOne uint32) uint16 {
+	if minusOne >= 0xFFFF {
+		return 0xFFFF
+	}
+	return uint16(minusOne + 1)
+}
+
+// bitReader is a simple bit-level reader. Once it runs past the end of the data
+// it sets eof and returns zeros, so callers can reject truncated headers instead
+// of acting on garbage.
+type bitReader struct {
+	data []byte
+	pos  int // bit offset
+	eof  bool
+}
+
+func (r *bitReader) readBits(n uint32) uint32 {
+	if r.eof || r.pos+int(n) > len(r.data)*8 {
+		r.eof = true
+		return 0
+	}
+
+	var val uint32
+	for i := uint32(0); i < n; i++ {
+		val = val<<1 | uint32(r.data[r.pos>>3]>>(7-r.pos&7)&1)
+		r.pos++
+	}
+	return val
+}
+
+func (r *bitReader) readFlag() bool {
+	return r.readBits(1) == 1
+}
+
+func (r *bitReader) skipBits(n uint32) {
+	if r.eof || r.pos+int(n) > len(r.data)*8 {
+		r.eof = true
+		return
+	}
+	r.pos += int(n)
+}
+
+// readUVLC follows uvlc() from AV1 spec Section 4.10.3: count zeros up to the
+// terminating one bit, and only then decide whether the value fits.
+func (r *bitReader) readUVLC() uint32 {
+	var leadingZeros uint32
+	for !r.readFlag() {
+		if r.eof {
+			return 0
+		}
+		leadingZeros++
+	}
+
+	if leadingZeros >= 32 {
+		return 0xFFFFFFFF
+	}
+	if leadingZeros == 0 {
+		return 0
+	}
+
+	return (1<<leadingZeros - 1) + r.readBits(leadingZeros)
+}

--- a/pkg/av1/rtp.go
+++ b/pkg/av1/rtp.go
@@ -1,0 +1,159 @@
+package av1
+
+import (
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+)
+
+const RTPPacketVersionAV1 = 0
+
+// maxUnitBytes bounds both the reassembled temporal unit and the fragments the
+// depacketizer is still holding, so a stream that never completes one cannot
+// grow either without end.
+const maxUnitBytes = 5 * 1024 * 1024
+
+// RTPDepay converts AV1 RTP packets (RFC 9583) into AV1 temporal units
+// in low overhead bitstream format (OBUs with obu_has_size_field=1),
+// suitable for MP4/fMP4 muxing.
+//
+// Uses pion's AV1Depacketizer for correct handling of OBU fragmentation,
+// aggregation headers, and size field conversion.
+func RTPDepay(handler core.HandlerFunc) core.HandlerFunc {
+	depack := &codecs.AV1Depacketizer{}
+	buf := make([]byte, 0, 512*1024)
+	var seqNum uint16
+	var fragBytes int
+	var hasSeq, resync, started bool
+
+	reset := func() {
+		if cap(buf) > 512*1024 {
+			buf = make([]byte, 0, 512*1024)
+		} else {
+			buf = buf[:0]
+		}
+		depack = &codecs.AV1Depacketizer{}
+		fragBytes = 0
+		started = false
+	}
+
+	return func(packet *rtp.Packet) {
+		// A gap splices OBUs from different units together, and pion's
+		// depacketizer rewrites obu_size to match, so the result still parses
+		// as a valid keyframe. Drop the unit instead.
+		gap := hasSeq && packet.SequenceNumber-seqNum != 1
+		seqNum = packet.SequenceNumber
+		hasSeq = true
+
+		if gap {
+			reset()
+			resync = true
+		}
+
+		// Resuming at the next packet would collect the tail of the broken unit
+		// and splice it onto the following one, so wait for a marker and start
+		// with the unit after it.
+		if resync {
+			if packet.Marker {
+				reset()
+				resync = false
+			}
+			return
+		}
+
+		// Z=1 means the first OBU continues one from the previous packet. Before
+		// we accepted anything it belongs to a unit we never saw, which happens
+		// when a stream is joined mid unit.
+		if !started && len(packet.Payload) > 0 && packet.Payload[0]&0x80 != 0 {
+			reset()
+			resync = true
+			return
+		}
+
+		// The depacketizer holds fragments of an unfinished OBU itself and
+		// returns nothing meanwhile, so buf below never sees them. Without a
+		// bound here a run of continuation fragments grows its buffer without
+		// end, and it recopies that buffer per packet.
+		if fragBytes+len(packet.Payload) > maxUnitBytes {
+			reset()
+			resync = true
+			return
+		}
+
+		payload, err := depack.Unmarshal(packet.Payload)
+		if err != nil {
+			// half a temporal unit would be left over otherwise
+			reset()
+			resync = true
+			return
+		}
+		fragBytes += len(packet.Payload)
+		started = true
+
+		if len(payload) == 0 {
+			return
+		}
+
+		// can happen if we miss a lot of packets with the marker
+		if len(buf)+len(payload) > maxUnitBytes {
+			reset()
+			resync = true
+			return
+		}
+
+		// Collect OBUs for the complete temporal unit
+		buf = append(buf, payload...)
+
+		if !packet.Marker {
+			return // wait for complete temporal unit
+		}
+
+		// Make a copy to avoid aliasing - buf is reused across calls
+		payload2 := make([]byte, len(buf))
+		copy(payload2, buf)
+		buf = buf[:0]
+		fragBytes = 0
+		started = false
+
+		clone := *packet
+		clone.Version = RTPPacketVersionAV1
+		clone.Payload = payload2
+		clone.ExtensionProfile = 0 // AV1 has no B-frames, CTS always equals DTS
+
+		handler(&clone)
+	}
+}
+
+// RTPPay packetizes AV1 OBUs into RTP packets with proper MTU fragmentation.
+// Input packets must have Version == RTPPacketVersionAV1 with reassembled OBUs.
+func RTPPay(mtu uint16, handler core.HandlerFunc) core.HandlerFunc {
+	if mtu == 0 {
+		mtu = 1472
+	}
+
+	payloader := &codecs.AV1Payloader{}
+	sequencer := rtp.NewRandomSequencer()
+	mtu -= 12 // rtp.Header size
+
+	return func(packet *rtp.Packet) {
+		if packet.Version != RTPPacketVersionAV1 {
+			handler(packet)
+			return
+		}
+
+		payloads := payloader.Payload(mtu, packet.Payload)
+		last := len(payloads) - 1
+		for i, payload := range payloads {
+			clone := rtp.Packet{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         i == last,
+					SequenceNumber: sequencer.NextSequenceNumber(),
+					Timestamp:      packet.Timestamp,
+				},
+				Payload: payload,
+			}
+			handler(&clone)
+		}
+	}
+}

--- a/pkg/flv/flv_test.go
+++ b/pkg/flv/flv_test.go
@@ -1,8 +1,13 @@
 package flv
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
+	"github.com/AlexxIT/go2rtc/pkg/av1"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,5 +22,84 @@ func TestTimeToRTP(t *testing.T) {
 		// 1000ms/(16000/1024) = 64ms
 		require.Equal(t, uint32(frameN*1024), TimeToRTP(uint32(frameN*64), 16000))
 		frameN *= 2
+	}
+}
+
+// av1SeqHdrOBU is a sequence header OBU captured from an ffmpeg av1_nvenc
+// 1920x1080 stream, as carried in the av1C configOBUs.
+var av1SeqHdrOBU = []byte{
+	0x0a, 0x0e, 0x00, 0x00, 0x00, 0x42, 0xab, 0xbf,
+	0xc3, 0x70, 0x08, 0x66, 0x40, 0x40, 0x40, 0x41,
+}
+
+func flvTag(tagType byte, payload []byte) []byte {
+	b := make([]byte, 4+11, 4+11+len(payload))
+	b[4] = tagType
+	b[5] = byte(len(payload) >> 16)
+	b[6] = byte(len(payload) >> 8)
+	b[7] = byte(len(payload))
+	return append(b, payload...)
+}
+
+// TestProducerAV1 feeds an enhanced-RTMP AV1 stream through the producer.
+// ffmpeg writes AV1 with fourCC av01, and enhanced-RTMP carries the 24-bit
+// composition time offset for HEVC only, so the OBUs of a PacketTypeCodedFrames
+// body start 5 bytes in, not 8.
+func TestProducerAV1(t *testing.T) {
+	b := []byte{'F', 'L', 'V', 1, 5, 0, 0, 0, 9}
+
+	// metadata without audiocodecid, so the probe doesn't wait for audio
+	b = append(b, flvTag(TagData, []byte("onMetaDatawidth"))...)
+
+	// PacketTypeSequenceStart, fourCC av01, av1C record
+	av1c := append([]byte{0x81, 0x08, 0x0c, 0x00}, av1SeqHdrOBU...)
+	b = append(b, flvTag(TagVideo, append([]byte{0x90, 'a', 'v', '0', '1'}, av1c...))...)
+
+	// PacketTypeCodedFrames, fourCC av01, temporal delimiter + frame OBU
+	obus := []byte{0x12, 0x00, 0x32, 0x01, 0x20}
+	b = append(b, flvTag(TagVideo, append([]byte{0x91, 'a', 'v', '0', '1'}, obus...))...)
+	b = append(b, 0, 0, 0, 0)
+
+	prod, err := Open(bytes.NewReader(b))
+	require.Nil(t, err)
+	require.Len(t, prod.Medias, 1)
+
+	codec := prod.Medias[0].Codecs[0]
+	require.Equal(t, core.CodecAV1, codec.Name)
+	require.Equal(t, av1SeqHdrOBU, av1.GetSequenceHeader(codec.FmtpLine))
+
+	receiver, err := prod.GetTrack(prod.Medias[0], codec)
+	require.Nil(t, err)
+
+	packets := make(chan []byte, 8)
+	sender := core.NewSender(prod.Medias[0], codec)
+	sender.Handler = func(packet *rtp.Packet) { packets <- packet.Payload }
+	sender.HandleRTP(receiver)
+	defer sender.Close()
+
+	_ = prod.Start()
+
+	select {
+	case payload := <-packets:
+		require.Equal(t, obus, payload)
+	case <-time.After(time.Second):
+		t.Fatal("no video packet")
+	}
+}
+
+// enhanced-RTMP carries the 24 bit composition time offset only for the codecs
+// that reorder frames. Getting this wrong shifts every frame by 3 bytes.
+func TestCodedFramesOffset(t *testing.T) {
+	for _, tt := range []struct {
+		fourCC string
+		want   int
+	}{
+		{FourCCAV1, 5},
+		{"vp09", 5},
+		{FourCCAVC, 8},
+		{FourCCHEVC, 8},
+		{FourCCVVC, 8},
+	} {
+		require.Equal(t, tt.want, codedFramesOffset(tt.fourCC), "codedFramesOffset(%q)", tt.fourCC)
 	}
 }

--- a/pkg/flv/producer.go
+++ b/pkg/flv/producer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/aac"
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/AlexxIT/go2rtc/pkg/h265"
@@ -47,6 +48,12 @@ const (
 
 	CodecH264 = 7
 	CodecHEVC = 12
+
+	// enhanced-RTMP video fourCC
+	FourCCAV1  = "av01"
+	FourCCAVC  = "avc1"
+	FourCCHEVC = "hvc1"
+	FourCCVVC  = "vvc1"
 )
 
 const (
@@ -72,6 +79,19 @@ func (c *Producer) GetTrack(media *core.Media, codec *core.Codec) (*core.Receive
 		c.audio = receiver
 	}
 	return receiver, nil
+}
+
+// codedFramesOffset returns where the coded data starts in an enhanced-RTMP
+// PacketTypeCodedFrames body. All of them carry a 4 bit frame type, a 4 bit
+// packet type and a 32 bit fourCC, and the codecs that reorder frames add a
+// 24 bit composition time offset on top. AV1 and VP9 never reorder.
+func codedFramesOffset(fourCC string) int {
+	switch fourCC {
+	case FourCCAVC, FourCCHEVC, FourCCVVC:
+		return 8
+	default:
+		return 5
+	}
 }
 
 func (c *Producer) Start() error {
@@ -101,8 +121,7 @@ func (c *Producer) Start() error {
 			if isExHeader(pkt.Payload) {
 				switch packetType := pkt.Payload[0] & 0b1111; packetType {
 				case PacketTypeCodedFrames:
-					// frame type 4b, packet type 4b, fourCC 32b, composition time 24b
-					pkt.Payload = pkt.Payload[8:]
+					pkt.Payload = pkt.Payload[codedFramesOffset(string(pkt.Payload[1:5])):]
 				case PacketTypeCodedFramesX:
 					// frame type 4b, packet type 4b, fourCC 32b
 					pkt.Payload = pkt.Payload[5:]
@@ -197,15 +216,18 @@ func (c *Producer) probe() error {
 			var codec *core.Codec
 
 			if isExHeader(pkt.Payload) {
-				if string(pkt.Payload[1:5]) != "hvc1" {
-					continue
-				}
-
 				if packetType := pkt.Payload[0] & 0b1111; packetType != PacketTypeSequenceStart {
 					continue
 				}
 
-				codec = h265.ConfigToCodec(pkt.Payload[5:])
+				switch string(pkt.Payload[1:5]) {
+				case FourCCHEVC:
+					codec = h265.ConfigToCodec(pkt.Payload[5:])
+				case FourCCAV1:
+					codec = av1.ConfigToCodec(pkt.Payload[5:])
+				default:
+					continue
+				}
 			} else {
 				_ = pkt.Payload[0] >> 4 // FrameType
 

--- a/pkg/iso/codecs.go
+++ b/pkg/iso/codecs.go
@@ -12,6 +12,8 @@ func (m *Movie) WriteVideo(codec string, width, height uint16, conf []byte) {
 		m.StartAtom("avc1")
 	case core.CodecH265:
 		m.StartAtom("hev1")
+	case core.CodecAV1:
+		m.StartAtom("av01")
 	default:
 		panic("unsupported iso video: " + codec)
 	}
@@ -37,6 +39,8 @@ func (m *Movie) WriteVideo(codec string, width, height uint16, conf []byte) {
 		m.StartAtom("avcC")
 	case core.CodecH265:
 		m.StartAtom("hvcC")
+	case core.CodecAV1:
+		m.StartAtom("av1C")
 	}
 	m.Write(conf)
 	m.EndAtom() // AVCC

--- a/pkg/mp4/consumer.go
+++ b/pkg/mp4/consumer.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/aac"
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/AlexxIT/go2rtc/pkg/h265"
@@ -19,6 +21,21 @@ type Consumer struct {
 	muxer *Muxer
 	mu    sync.Mutex
 	start bool
+
+	// AV1 carries its codec params in the sequence header, so the init
+	// segment can only be built once every AV1 track has seen one. pending
+	// counts them, initCh is closed when the last one arrives.
+	waitInit bool
+	pending  int
+	initCh   chan struct{}
+	initOnce sync.Once
+	stopCh   chan struct{}
+	stopOnce sync.Once
+
+	// OnInit is called from WriteTo after the init segment is generated,
+	// just before writing data. Use this to send the correct content-type
+	// to consumers (e.g. MSE) with actual codec parameters.
+	OnInit func(contentType string) `json:"-"`
 
 	Rotate int `json:"-"`
 	ScaleX int `json:"-"`
@@ -35,6 +52,7 @@ func NewConsumer(medias []*core.Media) *Consumer {
 				Codecs: []*core.Codec{
 					{Name: core.CodecH264},
 					{Name: core.CodecH265},
+					{Name: core.CodecAV1},
 				},
 			},
 			{
@@ -55,8 +73,10 @@ func NewConsumer(medias []*core.Media) *Consumer {
 			Medias:     medias,
 			Transport:  wr,
 		},
-		muxer: &Muxer{},
-		wr:    wr,
+		muxer:  &Muxer{},
+		wr:     wr,
+		initCh: make(chan struct{}),
+		stopCh: make(chan struct{}),
 	}
 }
 
@@ -115,6 +135,60 @@ func (c *Consumer) AddTrack(media *core.Media, _ *core.Codec, track *core.Receiv
 			handler.Handler = h265.RepairAVCC(track.Codec, handler.Handler)
 		}
 
+	case core.CodecAV1:
+		// AV1 has no codec params in the SDP. They come with the sequence
+		// header, which encoders repeat in front of every keyframe, so the
+		// init segment (av1C box) can only be built once one has arrived.
+		seqHdrOK := av1.GetSequenceHeader(codec.FmtpLine) != nil
+		if !seqHdrOK {
+			// under Mutex because an earlier track's handler may already be
+			// decrementing pending from its own goroutine
+			c.mu.Lock()
+			c.waitInit = true
+			c.pending++
+			c.mu.Unlock()
+		}
+
+		// own flag, because another video track may set c.start first
+		var started bool
+
+		handler.Handler = func(packet *rtp.Packet) {
+			if !started {
+				if !seqHdrOK {
+					if seqHdr := av1.SequenceHeader(packet.Payload); seqHdr != nil {
+						// under Mutex because Codecs reads it from other goroutines
+						c.mu.Lock()
+						codec.FmtpLine = av1.EncodeFmtpLine(seqHdr)
+						c.pending--
+						last := c.pending == 0
+						c.mu.Unlock()
+
+						seqHdrOK = true
+						if last {
+							c.initOnce.Do(func() { close(c.initCh) })
+						}
+					}
+				}
+				if !seqHdrOK || !av1.IsKeyframe(packet.Payload) {
+					return
+				}
+				started = true
+				c.start = true
+			}
+
+			// important to use Mutex because right fragment order
+			c.mu.Lock()
+			b := c.muxer.GetPayload(trackID, packet)
+			if n, err := c.wr.Write(b); err == nil {
+				c.Send += n
+			}
+			c.mu.Unlock()
+		}
+
+		if track.Codec.IsRTP() {
+			handler.Handler = av1.RTPDepay(handler.Handler)
+		}
+
 	default:
 		handler.Handler = func(packet *rtp.Packet) {
 			if !c.start {
@@ -164,9 +238,64 @@ func (c *Consumer) AddTrack(media *core.Media, _ *core.Codec, track *core.Receiv
 	return nil
 }
 
+// WaitInit blocks until the codec parameters for the init segment are known,
+// the consumer is stopped, or the timeout expires. A zero timeout waits
+// indefinitely. Returns false if the parameters are still unknown.
+func (c *Consumer) WaitInit(timeout time.Duration) bool {
+	if !c.waitInit {
+		return true
+	}
+
+	var expired <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		expired = timer.C
+	}
+
+	select {
+	case <-c.initCh:
+		// select picks at random when both are ready, and continuing after a
+		// Stop parks WriteTo in a write buffer nothing will release
+		select {
+		case <-c.stopCh:
+			return false
+		default:
+			return true
+		}
+	case <-c.stopCh:
+	case <-expired:
+	}
+
+	return false
+}
+
+func (c *Consumer) Stop() error {
+	c.stopOnce.Do(func() { close(c.stopCh) })
+	return c.Connection.Stop()
+}
+
+// Codecs returns a snapshot, because an AV1 track fills in its sequence header
+// from a track handler while the stream is already running.
+func (c *Consumer) Codecs() []*core.Codec {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	codecs := c.Connection.Codecs()
+	for i, codec := range codecs {
+		codecs[i] = codec.Clone()
+	}
+	return codecs
+}
+
 func (c *Consumer) WriteTo(wr io.Writer) (int64, error) {
 	if len(c.Senders) == 1 && c.Senders[0].Codec.IsAudio() {
 		c.start = true
+	}
+
+	// AV1 has no codec params in the SDP, they come with the first keyframe
+	if !c.WaitInit(0) {
+		return 0, nil
 	}
 
 	init, err := c.muxer.GetInit()
@@ -179,6 +308,11 @@ func (c *Consumer) WriteTo(wr io.Writer) (int64, error) {
 	}
 	if c.ScaleX != 0 && c.ScaleY != 0 {
 		PatchVideoScale(init, c.ScaleX, c.ScaleY)
+	}
+
+	// the caller can only know the final content type now
+	if c.OnInit != nil {
+		c.OnInit(ContentType(c.Codecs()))
 	}
 
 	if _, err = wr.Write(init); err != nil {

--- a/pkg/mp4/consumer_test.go
+++ b/pkg/mp4/consumer_test.go
@@ -1,0 +1,523 @@
+package mp4
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/av1"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/iso"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+// 3840x2160 Main profile level 5.0 10-bit, the configOBUs of an av1C record
+// written by ffmpeg. Deliberately not 1920x1080 Main 4.0 8-bit: those are the
+// placeholder values, so a test using them cannot tell a parsed sequence header
+// from no sequence header at all.
+var testSeqHdr = []byte{
+	0x0A, 0x0C, 0x00, 0x00, 0x00, 0x62, 0xEF, 0xBF, 0xE1, 0xBC, 0x02, 0xF8, 0x40,
+	0x40,
+}
+
+var (
+	testKeyframeOBU  = []byte{0x32, 0x01, 0x00}
+	testInterOBU     = []byte{0x32, 0x01, 0x20}
+	testKeyframeUnit = append(append([]byte{}, testSeqHdr...), testKeyframeOBU...)
+)
+
+// recWriter records every Write, so tests can tell "init segment sent" from
+// "WriteTo is still waiting" and can inspect what was actually muxed.
+type recWriter struct {
+	mu     sync.Mutex
+	writes [][]byte
+	signal chan struct{}
+}
+
+func newRecWriter() *recWriter {
+	return &recWriter{signal: make(chan struct{}, 1)}
+}
+
+func (w *recWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.writes = append(w.writes, append([]byte{}, p...))
+	w.mu.Unlock()
+
+	select {
+	case w.signal <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (w *recWriter) count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.writes)
+}
+
+func (w *recWriter) bytes() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var n int
+	for _, b := range w.writes {
+		n += len(b)
+	}
+	return n
+}
+
+func (w *recWriter) at(i int) []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if i >= len(w.writes) {
+		return nil
+	}
+	return w.writes[i]
+}
+
+func addTrack(t *testing.T, cons *Consumer, name string) *core.Receiver {
+	t.Helper()
+
+	media := &core.Media{Kind: core.KindVideo, Direction: core.DirectionSendonly}
+	codec := &core.Codec{Name: name, ClockRate: 90000, PayloadType: core.PayloadTypeRAW}
+	track := core.NewReceiver(media, codec)
+	if err := cons.AddTrack(media, nil, track); err != nil {
+		t.Fatal(err)
+	}
+	return track
+}
+
+func writeTo(t *testing.T, cons *Consumer) (*recWriter, chan struct{}) {
+	wr := newRecWriter()
+	done := make(chan struct{})
+	go func() {
+		_, _ = cons.WriteTo(wr)
+		close(done)
+	}()
+	return wr, done
+}
+
+func waitFor(t *testing.T, ch chan struct{}, why string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal(why)
+	}
+}
+
+func mustNot(t *testing.T, ch chan struct{}, why string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+		t.Fatal(why)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// H264 and H265 take their codec params from the SDP, so the init segment must
+// go out right away instead of waiting for the first keyframe.
+func TestInitNotDelayed(t *testing.T) {
+	cons := NewConsumer(nil)
+	addTrack(t, cons, core.CodecH264)
+
+	wr, _ := writeTo(t, cons)
+	waitFor(t, wr.signal, "init segment was not written before the first keyframe")
+}
+
+// A stream that never delivers a keyframe must not pin the WriteTo goroutine
+// once the consumer is stopped.
+func TestWriteToReturnsAfterStop(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	wr, done := writeTo(t, cons)
+
+	// inter frame only, no sequence header
+	track.WriteRTP(&rtp.Packet{Payload: testInterOBU})
+	mustNot(t, wr.signal, "AV1 init segment was written without a sequence header")
+
+	_ = cons.Stop()
+	waitFor(t, done, "WriteTo did not return after Stop, goroutine leaked")
+}
+
+// The av1C box and the MSE content type must come from the sequence header of
+// the first keyframe, not from the placeholder defaults.
+func TestAV1InitFromKeyframe(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	contentType := make(chan string, 1)
+	cons.OnInit = func(ct string) { contentType <- ct }
+
+	wr, _ := writeTo(t, cons)
+	mustNot(t, wr.signal, "AV1 init segment was written before the first keyframe")
+
+	if w, h := av1.DecodeSequenceHeader(testSeqHdr); w != 3840 || h != 2160 {
+		t.Fatalf("fixture parses as %dx%d, want 3840x2160", w, h)
+	}
+
+	track.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+
+	select {
+	case ct := <-contentType:
+		if want := `video/mp4; codecs="av01.0.12M.10"`; ct != want {
+			t.Errorf("content type = %q, want %q", ct, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnInit was not called after the first keyframe")
+	}
+
+	waitFor(t, wr.signal, "init segment was not written after the first keyframe")
+}
+
+// Codecs is read from the HTTP goroutine (internal/mp4) and from the HLS
+// session while a track handler may be filling in the AV1 sequence header.
+func TestCodecsRace(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	go func() {
+		time.Sleep(time.Millisecond)
+		track.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+	}()
+
+	for deadline := time.Now().Add(50 * time.Millisecond); time.Now().Before(deadline); {
+		_ = ContentType(cons.Codecs())
+	}
+
+	if got := ContentType(cons.Codecs()); got != `video/mp4; codecs="av01.0.12M.10"` {
+		t.Errorf("content type = %q", got)
+	}
+}
+
+// Some encoders send the sequence header in its own temporal unit instead of
+// repeating it in front of every keyframe.
+func TestAV1SequenceHeaderInEarlierUnit(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	contentType := make(chan string, 1)
+	cons.OnInit = func(ct string) { contentType <- ct }
+
+	wr, _ := writeTo(t, cons)
+	mustNot(t, wr.signal, "init segment was written before any codec params")
+
+	track.WriteRTP(&rtp.Packet{Payload: testSeqHdr}) // no frame
+
+	select {
+	case ct := <-contentType:
+		if want := `video/mp4; codecs="av01.0.12M.10"`; ct != want {
+			t.Errorf("content type = %q, want %q", ct, want)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnInit was not called after the sequence header")
+	}
+
+	waitFor(t, wr.signal, "init segment was not written after the sequence header")
+
+	// a keyframe with no sequence header of its own still has to be muxed
+	before := wr.count()
+	track.WriteRTP(&rtp.Packet{Payload: testKeyframeOBU})
+	waitFor(t, wr.signal, "keyframe was not muxed")
+	if wr.count() <= before {
+		t.Error("keyframe produced no fragment")
+	}
+}
+
+// A keyframe alone is not enough, the av1C box would carry placeholder values.
+func TestAV1WaitsForSequenceHeader(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	wr, done := writeTo(t, cons)
+
+	for i := 0; i < 5; i++ {
+		track.WriteRTP(&rtp.Packet{Payload: testKeyframeOBU})
+	}
+	mustNot(t, wr.signal, "init segment was written without a sequence header")
+
+	_ = cons.Stop()
+	waitFor(t, done, "WriteTo did not return after Stop")
+}
+
+// A stream is not a slideshow: everything after the first keyframe has to be
+// muxed too, not just the keyframes.
+func TestAV1InterFramesAreMuxed(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	wr, _ := writeTo(t, cons)
+	track.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+	waitFor(t, wr.signal, "init segment was not written")
+
+	// the write buffer switches to wr only once WriteTo reaches it, so poll
+	before := wr.bytes()
+	deadline := time.Now().Add(2 * time.Second)
+	for i := 0; ; i++ {
+		track.WriteRTP(&rtp.Packet{Payload: testInterOBU})
+		if wr.bytes() > before {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no inter frame was muxed after %d attempts", i+1)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The sync sample flag decides whether a browser can start or seek at all.
+func TestAV1SampleFlags(t *testing.T) {
+	m := &Muxer{}
+	m.AddTrack(&core.Codec{Name: core.CodecAV1, ClockRate: 90000})
+
+	key := m.GetPayload(0, &rtp.Packet{Payload: testKeyframeUnit})
+	inter := m.GetPayload(0, &rtp.Packet{Payload: testInterOBU})
+
+	var find func(atoms []any) *iso.AtomTfhd
+	find = func(atoms []any) *iso.AtomTfhd {
+		for _, atom := range atoms {
+			switch v := atom.(type) {
+			case []any:
+				if tfhd := find(v); tfhd != nil {
+					return tfhd
+				}
+			case *iso.AtomTfhd:
+				return v
+			}
+		}
+		return nil
+	}
+
+	flag := func(b []byte) uint32 {
+		atoms, err := iso.DecodeAtoms(b)
+		require.NoError(t, err, err)
+		tfhd := find(atoms)
+		require.NotNil(t, tfhd, "no tfhd box")
+		return tfhd.SampleFlags
+	}
+
+	require.Equal(t, uint32(iso.SampleVideoIFrame), flag(key), "keyframe sample flags")
+	require.Equal(t, uint32(iso.SampleVideoNonIFrame), flag(inter), "inter frame sample flags")
+}
+
+// The init segment has to describe the real track, not the placeholder.
+func TestAV1InitSegmentBytes(t *testing.T) {
+	m := &Muxer{}
+	m.AddTrack(&core.Codec{Name: core.CodecAV1, ClockRate: 90000,
+		FmtpLine: av1.EncodeFmtpLine(testSeqHdr)})
+
+	init, err := m.GetInit()
+	require.NoError(t, err, err)
+
+	require.True(t, bytes.Contains(init, []byte("av01")), "no av01 sample entry")
+	i := bytes.Index(init, []byte("av1C"))
+	if i < 0 {
+		t.Fatal("no av1C box")
+	}
+	require.True(t, bytes.HasPrefix(init[i+4:], av1.EncodeConfig(testSeqHdr)), "av1C box was not built from the sequence header")
+
+	// the placeholder track size must not survive into the init segment
+	placeholder := &Muxer{}
+	placeholder.AddTrack(&core.Codec{Name: core.CodecAV1, ClockRate: 90000})
+	if def, err := placeholder.GetInit(); err == nil && bytes.Equal(init, def) {
+		t.Error("init segment is identical to the one built without a sequence header")
+	}
+}
+
+// Two video tracks: the AV1 one must not be starved by the other one starting
+// first, or WriteTo never gets its codec params.
+func TestTwoVideoTracks(t *testing.T) {
+	cons := NewConsumer(nil)
+
+	// RTP payload type, so the packet goes through RTPDepay rather than
+	// RepairAVCC, which rewrites the payload in place
+	media := &core.Media{Kind: core.KindVideo, Direction: core.DirectionSendonly}
+	h264 := core.NewReceiver(media, &core.Codec{Name: core.CodecH264, ClockRate: 90000, PayloadType: 96})
+	if err := cons.AddTrack(media, nil, h264); err != nil {
+		t.Fatal(err)
+	}
+
+	av1t := addTrack(t, cons, core.CodecAV1)
+
+	wr, _ := writeTo(t, cons)
+
+	// single NAL unit packet holding an IDR slice
+	h264.WriteRTP(&rtp.Packet{Header: rtp.Header{Marker: true}, Payload: []byte{0x65, 0x88, 0x84, 0x00}})
+	mustNot(t, wr.signal, "init segment was written before the AV1 codec params")
+
+	av1t.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+	waitFor(t, wr.signal, "AV1 track was starved by the H264 track")
+}
+
+// A func field without a json tag makes encoding/json refuse the whole
+// consumer, which empties /api/streams for every user.
+func TestConsumerJSON(t *testing.T) {
+	if _, err := json.Marshal(NewConsumer(nil)); err != nil {
+		t.Errorf("json.Marshal: %v", err)
+	}
+}
+
+// frame.mp4 for AV1: the snapshot must be a complete MP4 and must not appear
+// before a keyframe with a sequence header.
+func TestKeyframeAV1(t *testing.T) {
+	media := &core.Media{Kind: core.KindVideo, Direction: core.DirectionSendonly}
+	codec := &core.Codec{Name: core.CodecAV1, ClockRate: 90000, PayloadType: core.PayloadTypeRAW}
+	track := core.NewReceiver(media, codec)
+
+	cons := NewKeyframe(nil)
+	if err := cons.AddTrack(media, nil, track); err != nil {
+		t.Fatal(err)
+	}
+
+	wr := newRecWriter()
+	go func() { _, _ = cons.WriteTo(wr) }()
+
+	track.WriteRTP(&rtp.Packet{Payload: testInterOBU})
+	mustNot(t, wr.signal, "snapshot was written for an inter frame")
+
+	track.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+	waitFor(t, wr.signal, "no snapshot after the keyframe")
+
+	b := wr.at(0)
+	if !bytes.Contains(b, []byte("ftyp")) || !bytes.Contains(b, []byte("moov")) {
+		t.Error("snapshot is missing the init segment")
+	}
+	// the box must carry the params of the sequence header, not the placeholder
+	require.True(t, bytes.Contains(b, av1.EncodeConfig(testSeqHdr)), "av1C box was not built from the sequence header")
+	if got := ContentType(cons.Codecs()); got != `video/mp4; codecs="av01.0.12M.10"` {
+		t.Errorf("content type = %q, want the params of the sequence header", got)
+	}
+}
+
+// The browser sends every AV1 profile it can decode, but go2rtc serves whatever
+// the stream has, so they have to collapse into a single AV1 codec.
+func TestParseCodecsAV1(t *testing.T) {
+	medias := ParseCodecs("avc1.640029,av01.0.08M.08,av01.0.12M.08,av01.0.13M.10,mp4a.40.2", true)
+
+	var video *core.Media
+	for _, media := range medias {
+		if media.Kind == core.KindVideo {
+			video = media
+		}
+	}
+	require.NotNil(t, video, "no video media")
+
+	var names []string
+	for _, codec := range video.Codecs {
+		names = append(names, codec.Name)
+	}
+	want := []string{core.CodecH264, core.CodecAV1}
+	require.Equal(t, len(want), len(names), "video codecs = %v, want %v", names, want)
+	for i := range want {
+		require.Equal(t, want[i], names[i], "video codecs = %v, want %v", names, want)
+	}
+}
+
+// The sequence header alone must not open the gate: muxing has to start on a
+// keyframe, or MSE gets handed a mid-GOP fragment first.
+func TestAV1StartsOnKeyframeOnly(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	wr, _ := writeTo(t, cons)
+
+	track.WriteRTP(&rtp.Packet{Payload: testSeqHdr}) // params, no frame
+	waitFor(t, wr.signal, "init segment was not written after the sequence header")
+
+	before := wr.count()
+	for i := 0; i < 5; i++ {
+		track.WriteRTP(&rtp.Packet{Payload: testInterOBU})
+	}
+	mustNot(t, wr.signal, "an inter frame was muxed before the first keyframe")
+	require.Equal(t, before, wr.count(), "fragments were written before the first keyframe")
+
+	track.WriteRTP(&rtp.Packet{Payload: testKeyframeOBU})
+	waitFor(t, wr.signal, "the keyframe was not muxed")
+}
+
+// The pending counter exists for consumers with more than one AV1 track: the
+// init segment may only be built once every track knows its params.
+func TestTwoAV1Tracks(t *testing.T) {
+	cons := NewConsumer(nil)
+	first := addTrack(t, cons, core.CodecAV1)
+	second := addTrack(t, cons, core.CodecAV1)
+
+	wr, _ := writeTo(t, cons)
+
+	first.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+	mustNot(t, wr.signal, "init segment was built while a track still had no sequence header")
+
+	second.WriteRTP(&rtp.Packet{Payload: testKeyframeUnit})
+	waitFor(t, wr.signal, "init segment was not written after both tracks had their params")
+}
+
+// WaitInit has to give up when the consumer is stopped, even if the init became
+// ready at the same moment.
+func TestWaitInitAfterStop(t *testing.T) {
+	cons := NewConsumer(nil)
+	track := addTrack(t, cons, core.CodecAV1)
+
+	track.WriteRTP(&rtp.Packet{Payload: testSeqHdr}) // closes initCh
+	_ = cons.Stop()
+
+	if cons.WaitInit(0) {
+		t.Error("WaitInit reported success after Stop")
+	}
+}
+
+// The HLS session cannot wait forever for a sequence header.
+func TestWaitInitTimeout(t *testing.T) {
+	cons := NewConsumer(nil)
+	addTrack(t, cons, core.CodecAV1)
+	t.Cleanup(func() { _ = cons.Stop() })
+
+	start := time.Now()
+	if cons.WaitInit(50 * time.Millisecond) {
+		t.Error("WaitInit reported success without a sequence header")
+	}
+	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
+		t.Errorf("WaitInit returned after %v, before the timeout", elapsed)
+	}
+}
+
+// frame.mp4 for H264 is the common case: its codec params come from the SDP, so
+// the init segment must be prepended to the snapshot without any waiting.
+func TestKeyframeH264(t *testing.T) {
+	media := &core.Media{Kind: core.KindVideo, Direction: core.DirectionSendonly}
+	// RTP payload type, so the packet goes through RTPDepay rather than
+	// RepairAVCC, which rewrites the payload in place
+	codec := &core.Codec{
+		Name: core.CodecH264, ClockRate: 90000, PayloadType: 96,
+		FmtpLine: "profile-level-id=640029;sprop-parameter-sets=Z2QAKaxWgHgCJ+WEAAADAAQAAAMAyDxQqSo=,aO48sA==",
+	}
+	track := core.NewReceiver(media, codec)
+
+	cons := NewKeyframe(nil)
+	if err := cons.AddTrack(media, nil, track); err != nil {
+		t.Fatal(err)
+	}
+
+	wr := newRecWriter()
+	go func() { _, _ = cons.WriteTo(wr) }()
+	t.Cleanup(func() { _ = cons.Stop() })
+
+	// single NAL unit packet holding a non-IDR slice
+	track.WriteRTP(&rtp.Packet{Header: rtp.Header{Marker: true}, Payload: []byte{0x41, 0x9A, 0x00, 0x00}})
+	mustNot(t, wr.signal, "snapshot was written for a non-keyframe")
+
+	// IDR slice
+	track.WriteRTP(&rtp.Packet{Header: rtp.Header{Marker: true}, Payload: []byte{0x65, 0x88, 0x84, 0x00}})
+	waitFor(t, wr.signal, "no snapshot after the keyframe")
+
+	b := wr.at(0)
+	if !bytes.Contains(b, []byte("ftyp")) || !bytes.Contains(b, []byte("moov")) {
+		t.Error("snapshot is missing the init segment")
+	}
+	require.True(t, bytes.Contains(b, []byte("avcC")), "snapshot has no avcC box")
+}

--- a/pkg/mp4/helpers.go
+++ b/pkg/mp4/helpers.go
@@ -18,6 +18,7 @@ func ParseQuery(query map[string][]string) []*core.Media {
 				Codecs: []*core.Codec{
 					{Name: core.CodecH264},
 					{Name: core.CodecH265},
+					{Name: core.CodecAV1},
 				},
 			},
 			{
@@ -59,13 +60,28 @@ func ParseCodecs(codecs string, parseAudio bool) (medias []*core.Media) {
 	var videos []*core.Codec
 	var audios []*core.Codec
 
+	var hasAV1 bool
+
 	for _, name := range strings.Split(codecs, ",") {
+		// browsers ask for several concrete AV1 profile/level/depth combos,
+		// and go2rtc serves whatever the stream has, so one codec is enough
+		if strings.HasPrefix(name, "av01.") {
+			if hasAV1 {
+				continue
+			}
+			hasAV1 = true
+			name = MimeAV1
+		}
+
 		switch name {
 		case MimeH264:
 			codec := &core.Codec{Name: core.CodecH264}
 			videos = append(videos, codec)
 		case MimeH265:
 			codec := &core.Codec{Name: core.CodecH265}
+			videos = append(videos, codec)
+		case MimeAV1:
+			codec := &core.Codec{Name: core.CodecAV1}
 			videos = append(videos, codec)
 		case MimeAAC:
 			codec := &core.Codec{Name: core.CodecAAC}

--- a/pkg/mp4/keyframe.go
+++ b/pkg/mp4/keyframe.go
@@ -3,6 +3,7 @@ package mp4
 import (
 	"io"
 
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/AlexxIT/go2rtc/pkg/h265"
@@ -25,6 +26,7 @@ func NewKeyframe(medias []*core.Media) *Keyframe {
 				Codecs: []*core.Codec{
 					{Name: core.CodecH264},
 					{Name: core.CodecH265},
+					{Name: core.CodecAV1},
 				},
 			},
 		}
@@ -45,13 +47,21 @@ func NewKeyframe(medias []*core.Media) *Keyframe {
 }
 
 func (c *Keyframe) AddTrack(media *core.Media, _ *core.Codec, track *core.Receiver) error {
-	c.muxer.AddTrack(track.Codec)
-	init, err := c.muxer.GetInit()
-	if err != nil {
-		return err
+	// clone because the AV1 branch fills FmtpLine from the first keyframe
+	codec := track.Codec.Clone()
+	c.muxer.AddTrack(codec)
+
+	// AV1 has no codec params in the SDP, its init segment is built below
+	var init []byte
+	if track.Codec.Name != core.CodecAV1 {
+		var err error
+		if init, err = c.muxer.GetInit(); err != nil {
+			return err
+		}
 	}
 
-	handler := core.NewSender(media, track.Codec)
+	// the clone, so Codecs reports the params the AV1 branch fills in below
+	handler := core.NewSender(media, codec)
 
 	switch track.Codec.Name {
 	case core.CodecH264:
@@ -90,6 +100,40 @@ func (c *Keyframe) AddTrack(media *core.Media, _ *core.Codec, track *core.Receiv
 
 		if track.Codec.IsRTP() {
 			handler.Handler = h265.RTPDepay(track.Codec, handler.Handler)
+		}
+
+	case core.CodecAV1:
+		seqHdrOK := av1.GetSequenceHeader(codec.FmtpLine) != nil
+
+		handler.Handler = func(packet *rtp.Packet) {
+			// the av1C box needs the sequence header, which encoders repeat in
+			// front of every keyframe
+			if !seqHdrOK {
+				seqHdr := av1.SequenceHeader(packet.Payload)
+				if seqHdr == nil {
+					return
+				}
+				codec.FmtpLine = av1.EncodeFmtpLine(seqHdr)
+				seqHdrOK = true
+			}
+
+			if !av1.IsKeyframe(packet.Payload) {
+				return
+			}
+
+			init, err := c.muxer.GetInit()
+			if err != nil {
+				return
+			}
+
+			b := append(init, c.muxer.GetPayload(0, packet)...)
+			if n, err := c.wr.Write(b); err == nil {
+				c.Send += n
+			}
+		}
+
+		if track.Codec.IsRTP() {
+			handler.Handler = av1.RTPDepay(handler.Handler)
 		}
 	}
 

--- a/pkg/mp4/mime.go
+++ b/pkg/mp4/mime.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 )
@@ -8,6 +9,7 @@ import (
 const (
 	MimeH264 = "avc1.640029"
 	MimeH265 = "hvc1.1.6.L153.B0"
+	MimeAV1  = "av01.0.08M.08"
 	MimeAAC  = "mp4a.40.2"
 	MimeFlac = "flac"
 	MimeOpus = "opus"
@@ -28,6 +30,13 @@ func MimeCodecs(codecs []*core.Codec) string {
 			// H.265 profile=main level=5.1
 			// hvc1 - supported in Safari, hev1 - doesn't, both supported in Chrome
 			s += MimeH265
+		case core.CodecAV1:
+			// AV1 Main 4.0 8-bit until the first keyframe brings the real params
+			if mime := av1.MimeCodecString(av1.GetSequenceHeader(codec.FmtpLine)); mime != "" {
+				s += mime
+			} else {
+				s += MimeAV1
+			}
 		case core.CodecAAC:
 			s += MimeAAC
 		case core.CodecOpus:

--- a/pkg/mp4/muxer.go
+++ b/pkg/mp4/muxer.go
@@ -3,6 +3,7 @@ package mp4
 import (
 	"encoding/hex"
 
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/AlexxIT/go2rtc/pkg/h265"
@@ -81,6 +82,20 @@ func (m *Muxer) GetInit() ([]byte, error) {
 				uint32(i+1), codec.Name, codec.ClockRate, width, height, h265.EncodeConfig(vps, sps, pps),
 			)
 
+		case core.CodecAV1:
+			// sequence header from the first keyframe, see Consumer.AddTrack
+			seqHdr := av1.GetSequenceHeader(codec.FmtpLine)
+
+			width, height := av1.DecodeSequenceHeader(seqHdr)
+			if width == 0 {
+				width = 1920
+				height = 1080
+			}
+
+			mv.WriteVideoTrack(
+				uint32(i+1), codec.Name, codec.ClockRate, width, height, av1.EncodeConfig(seqHdr),
+			)
+
 		case core.CodecAAC:
 			s := core.Between(codec.FmtpLine, "config=", ";")
 			b, err := hex.DecodeString(s)
@@ -138,6 +153,12 @@ func (m *Muxer) GetPayload(trackID byte, packet *rtp.Packet) []byte {
 		}
 	case core.CodecH265:
 		if h265.IsKeyframe(packet.Payload) {
+			flags = iso.SampleVideoIFrame
+		} else {
+			flags = iso.SampleVideoNonIFrame
+		}
+	case core.CodecAV1:
+		if av1.IsKeyframe(packet.Payload) {
 			flags = iso.SampleVideoIFrame
 		} else {
 			flags = iso.SampleVideoNonIFrame

--- a/pkg/webrtc/api.go
+++ b/pkg/webrtc/api.go
@@ -297,6 +297,15 @@ func RegisterDefaultCodecs(m *webrtc.MediaEngine) error {
 			},
 			PayloadType: 98, // Chrome v110 - PayloadType: 112
 		},
+		// Chrome 111, Firefox 136
+		{
+			RTPCodecCapability: webrtc.RTPCodecCapability{
+				MimeType:     webrtc.MimeTypeAV1,
+				ClockRate:    90000,
+				RTCPFeedback: videoRTCPFeedback,
+			},
+			PayloadType: 99,
+		},
 		// macOS Safari 15.1
 		{
 			RTPCodecCapability: webrtc.RTPCodecCapability{

--- a/pkg/webrtc/consumer.go
+++ b/pkg/webrtc/consumer.go
@@ -3,6 +3,7 @@ package webrtc
 import (
 	"errors"
 
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/AlexxIT/go2rtc/pkg/h265"
@@ -61,6 +62,12 @@ func (c *Conn) AddTrack(media *core.Media, codec *core.Codec, track *core.Receiv
 			sender.Handler = h265.RTPDepay(track.Codec, sender.Handler)
 		} else {
 			sender.Handler = h265.RepairAVCC(track.Codec, sender.Handler)
+		}
+
+	case core.CodecAV1:
+		sender.Handler = av1.RTPPay(1200, sender.Handler)
+		if track.Codec.IsRTP() {
+			sender.Handler = av1.RTPDepay(sender.Handler)
 		}
 
 	case core.CodecPCMA, core.CodecPCMU, core.CodecPCM, core.CodecPCML:

--- a/pkg/webrtc/server.go
+++ b/pkg/webrtc/server.go
@@ -47,11 +47,57 @@ func (c *Conn) SetOffer(offer string) (err error) {
 	return
 }
 
+// preferRecvCodecs moves AV1 to the end of the codec list for every video
+// transceiver we receive on. A remote publishes with the first codec of our
+// answer, so without this every browser that supports AV1 would switch away
+// from H264 as soon as go2rtc registered AV1.
+//
+// Must run after SetRemoteDescription, because only then does the media engine
+// hold the negotiated codecs, which carry the payload types and the rtcp-fb of
+// the offer.
+func preferRecvCodecs(tr *webrtc.RTPTransceiver) {
+	if tr.Kind() != webrtc.RTPCodecTypeVideo {
+		return
+	}
+
+	switch tr.Direction() {
+	case webrtc.RTPTransceiverDirectionSendrecv, webrtc.RTPTransceiverDirectionRecvonly:
+	default:
+		return // we don't receive on this transceiver
+	}
+
+	recv := tr.Receiver()
+	if recv == nil {
+		return
+	}
+
+	var codecs, av1 []webrtc.RTPCodecParameters
+	for _, codec := range recv.GetParameters().Codecs {
+		if codec.MimeType == webrtc.MimeTypeAV1 {
+			av1 = append(av1, codec)
+		} else {
+			codecs = append(codecs, codec)
+		}
+	}
+
+	if len(av1) == 0 || len(codecs) == 0 {
+		return // nothing to reorder
+	}
+
+	// pion rejects the whole list if one entry is unknown to the media engine,
+	// so this must only ever contain codecs it gave us
+	_ = tr.SetCodecPreferences(append(codecs, av1...))
+}
+
 func (c *Conn) GetAnswer() (answer string, err error) {
 	// we need to process remote offer after we create transeivers
 	desc := webrtc.SessionDescription{Type: webrtc.SDPTypeOffer, SDP: c.offer}
 	if err = c.pc.SetRemoteDescription(desc); err != nil {
 		return "", err
+	}
+
+	for _, tr := range c.pc.GetTransceivers() {
+		preferRecvCodecs(tr)
 	}
 
 	// disable transceivers if we don't have track, make direction=inactive

--- a/pkg/webrtc/server_test.go
+++ b/pkg/webrtc/server_test.go
@@ -1,0 +1,105 @@
+package webrtc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// browserOffer is the shape a browser sends for pc.addTrack(cameraTrack):
+// every codec it supports, each with an rtx twin, AV1 first.
+const browserOffer = `v=0
+o=- 1 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+m=video 9 UDP/TLS/RTP/SAVPF 45 46 96 97 98 99 102 103
+c=IN IP4 0.0.0.0
+a=ice-ufrag:aaaa
+a=ice-pwd:bbbbbbbbbbbbbbbbbbbbbbbb
+a=fingerprint:sha-256 00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF
+a=setup:actpass
+a=mid:0
+a=DIRECTION
+a=rtcp-mux
+a=rtpmap:45 AV1/90000
+a=rtcp-fb:45 nack
+a=rtcp-fb:45 nack pli
+a=rtpmap:46 rtx/90000
+a=fmtp:46 apt=45
+a=rtpmap:96 VP8/90000
+a=rtcp-fb:96 nack
+a=rtpmap:97 rtx/90000
+a=fmtp:97 apt=96
+a=rtpmap:98 VP9/90000
+a=rtpmap:99 rtx/90000
+a=fmtp:99 apt=98
+a=rtpmap:102 H264/90000
+a=rtcp-fb:102 nack
+a=rtcp-fb:102 nack pli
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
+a=rtpmap:103 rtx/90000
+a=fmtp:103 apt=102
+`
+
+func answerForDirection(t *testing.T, direction string) string {
+	t.Helper()
+
+	api, err := NewAPI()
+	require.Nil(t, err)
+
+	pc, err := api.NewPeerConnection(webrtc.Configuration{})
+	require.Nil(t, err)
+
+	conn := NewConn(pc)
+	offer := strings.ReplaceAll(strings.Replace(browserOffer, "DIRECTION", direction, 1), "\n", "\r\n")
+
+	// a sendrecv m-line used to panic here, because the codec list still held rtx
+	require.Nil(t, conn.SetOffer(offer))
+
+	answer, err := conn.GetAnswer()
+	require.Nil(t, err)
+
+	return answer
+}
+
+func mediaLine(t *testing.T, sdp string) string {
+	t.Helper()
+	for _, line := range strings.Split(sdp, "\r\n") {
+		if strings.HasPrefix(line, "m=video") {
+			return line
+		}
+	}
+	t.Fatal("no video media in answer")
+	return ""
+}
+
+// TestPreferRecvCodecs - a remote publishes with the first codec of our answer,
+// so AV1 must come last, without losing the payload types or the rtcp-fb of the
+// offer.
+func TestPreferRecvCodecs(t *testing.T) {
+	for _, direction := range []string{"sendrecv", "sendonly"} {
+		t.Run(direction, func(t *testing.T) {
+			answer := answerForDirection(t, direction)
+
+			// payload types of the offer, AV1 (45) behind H264 (102)
+			require.Equal(t, "m=video 9 UDP/TLS/RTP/SAVPF 102 45", mediaLine(t, answer))
+
+			// reordering must not drop the feedback attributes
+			require.Contains(t, answer, "a=rtcp-fb:102 nack pli")
+			require.Contains(t, answer, "a=rtcp-fb:45 nack pli")
+
+			// and not rewrite the H264 profile
+			require.Contains(t, answer, "profile-level-id=42001f")
+		})
+	}
+}
+
+// TestPreferRecvCodecsSendonly - we send on this transceiver, the remote only
+// receives, so its codec order is none of our business.
+func TestPreferRecvCodecsKeepsSendOrder(t *testing.T) {
+	answer := answerForDirection(t, "recvonly")
+	require.Equal(t, "m=video 9 UDP/TLS/RTP/SAVPF 45 102", mediaLine(t, answer))
+}

--- a/www/links.html
+++ b/www/links.html
@@ -31,7 +31,7 @@
 
         links.innerHTML = `
         <h2>Any codec in source</h2>
-        <li><a href="stream.html?src=${src}">stream.html</a> with auto-select mode / browsers: all / codecs: H264, H265*, MJPEG, JPEG, AAC, PCMU, PCMA, OPUS</li>
+        <li><a href="stream.html?src=${src}">stream.html</a> with auto-select mode / browsers: all / codecs: H264, H265*, AV1*, MJPEG, JPEG, AAC, PCMU, PCMA, OPUS</li>
         <li><a href="api/streams?src=${src}">info.json</a> page with active connections</li>
     `;
 
@@ -52,13 +52,13 @@
 
             <pre>ffplay -fflags nobuffer -flags low_delay -rtsp_transport tcp "rtsp://${rtsp}/${src}"</pre>
 
-            <h2>H264/H265 source</h2>
-            <li><a href="stream.html?src=${src}&mode=webrtc">stream.html</a> WebRTC stream / browsers: all / codecs: H264, PCMU, PCMA, OPUS / +H265 in Safari</li>
-            <li><a href="stream.html?src=${src}&mode=mse">stream.html</a> MSE stream / browsers: Chrome, Firefox, Safari Mac/iPad / codecs: H264, H265*, AAC, PCMA*, PCMU*, PCM* / +OPUS in Chrome and Firefox</li>
-            <li><a href="api/stream.mp4?src=${src}">stream.mp4</a> legacy MP4 stream with AAC audio / browsers: Chrome, Firefox / codecs: H264, H265*, AAC</li>
-            <li><a href="api/stream.mp4?src=${src}&mp4=flac">stream.mp4</a> modern MP4 stream with common audio / browsers: Chrome, Firefox / codecs: H264, H265*, AAC, FLAC (PCMA, PCMU, PCM)</li>
-            <li><a href="api/stream.mp4?src=${src}&mp4=all">stream.mp4</a> MP4 stream with any audio / browsers: Chrome / codecs: H264, H265*, AAC, OPUS, MP3, FLAC (PCMA, PCMU, PCM)</li>
-            <li><a href="api/frame.mp4?src=${src}">frame.mp4</a> snapshot in MP4-format / browsers: all / codecs: H264, H265*</li>
+            <h2>H264/H265/AV1 source</h2>
+            <li><a href="stream.html?src=${src}&mode=webrtc">stream.html</a> WebRTC stream / browsers: all / codecs: H264, PCMU, PCMA, OPUS / +H265 in Safari / +AV1 in Chrome and Firefox</li>
+            <li><a href="stream.html?src=${src}&mode=mse">stream.html</a> MSE stream / browsers: Chrome, Firefox, Safari Mac/iPad / codecs: H264, H265*, AV1*, AAC, PCMA*, PCMU*, PCM* / +OPUS in Chrome and Firefox</li>
+            <li><a href="api/stream.mp4?src=${src}">stream.mp4</a> legacy MP4 stream with AAC audio / browsers: Chrome, Firefox / codecs: H264, H265*, AV1*, AAC</li>
+            <li><a href="api/stream.mp4?src=${src}&mp4=flac">stream.mp4</a> modern MP4 stream with common audio / browsers: Chrome, Firefox / codecs: H264, H265*, AV1*, AAC, FLAC (PCMA, PCMU, PCM)</li>
+            <li><a href="api/stream.mp4?src=${src}&mp4=all">stream.mp4</a> MP4 stream with any audio / browsers: Chrome / codecs: H264, H265*, AV1*, AAC, OPUS, MP3, FLAC (PCMA, PCMU, PCM)</li>
+            <li><a href="api/frame.mp4?src=${src}">frame.mp4</a> snapshot in MP4-format / browsers: all / codecs: H264, H265*, AV1*</li>
             <li><a href="api/stream.m3u8?src=${src}">stream.m3u8</a> legacy HLS/TS / browsers: Safari all, Chrome Android / codecs: H264</li>
             <li><a href="api/stream.m3u8?src=${src}&mp4">stream.m3u8</a> legacy HLS/fMP4 / browsers: Safari all, Chrome Android / codecs: H264, H265*, AAC</li>
             <li><a href="api/stream.m3u8?src=${src}&mp4=flac">stream.m3u8</a> modern HLS/fMP4 / browsers: Safari all, Chrome Android / codecs: H264, H265*, AAC, FLAC (PCMA, PCMU, PCM)</li>

--- a/www/video-rtc.js
+++ b/www/video-rtc.js
@@ -26,6 +26,10 @@ export class VideoRTC extends HTMLElement {
             'avc1.64002A',      // H.264 high 4.2 (Chromecast 3rd Gen)
             'avc1.640033',      // H.264 high 5.1 (Chromecast with Google TV)
             'hvc1.1.6.L153.B0', // H.265 main 5.1 (Chromecast Ultra)
+            'av01.0.08M.08',    // AV1 Main 4.0 8-bit (up to 2048x1152)
+            'av01.0.12M.08',    // AV1 Main 5.0 8-bit (up to 4K 30fps)
+            'av01.0.13M.08',    // AV1 Main 5.1 8-bit (up to 4K 60fps)
+            'av01.0.13M.10',    // AV1 Main 5.1 10-bit (4K HDR)
             'mp4a.40.2',        // AAC LC
             'mp4a.40.5',        // AAC HE
             'flac',             // FLAC (PCM compatible)
@@ -185,7 +189,7 @@ export class VideoRTC extends HTMLElement {
     /** @param {Function} isSupported */
     codecs(isSupported) {
         return this.CODECS
-            .filter(codec => this.media.includes(codec.includes('vc1') ? 'video' : 'audio'))
+            .filter(codec => this.media.includes(codec.includes('vc1') || codec.startsWith('av01') ? 'video' : 'audio'))
             .filter(codec => isSupported(`video/mp4; codecs="${codec}"`)).join();
     }
 
@@ -451,8 +455,20 @@ export class VideoRTC extends HTMLElement {
 
             this.mseCodecs = msg.value;
 
-            const sb = ms.addSourceBuffer(msg.value);
+            // the server answers with the codec string of the stream, which for
+            // AV1 can be a profile or bit depth this browser can't decode
+            let sb;
+            try {
+                sb = ms.addSourceBuffer(msg.value);
+            } catch (e) {
+                console.warn(e);
+                // stop offering AV1, or every reconnect negotiates it again
+                this.CODECS = this.CODECS.filter(codec => !codec.startsWith('av01.'));
+                this.ws.close(); // reconnect without AV1, or fall to the next mode
+                return;
+            }
             sb.mode = 'segments'; // segments or sequence
+
             sb.addEventListener('updateend', () => {
                 if (!sb.updating && bufLen > 0) {
                     try {
@@ -602,6 +618,7 @@ export class VideoRTC extends HTMLElement {
             }
             if (stream.getAudioTracks().length > 0) rtcPriority += 0x102;
 
+            if (this.mseCodecs.includes('av01.')) msePriority += 0x220;
             if (this.mseCodecs.includes('hvc1.')) msePriority += 0x230;
             if (this.mseCodecs.includes('avc1.')) msePriority += 0x210;
             if (this.mseCodecs.includes('mp4a.')) msePriority += 0x101;


### PR DESCRIPTION
AV1 cameras are becoming common, most visibly the ARTPEC-9 based Axis models that ship with AV1 as the default codec. go2rtc could negotiate such a stream but had no way to serve it without transcoding first. Closes #2260.

Adds `pkg/av1` (OBU parsing, keyframe detection, sequence header, av1C record, RTP depay/pay) and wires AV1 into the MP4 muxer, MSE, HLS, WebRTC and the browser client. A second commit from @vertoforce adds the FLV producer path, which is how ffmpeg fed AV1 reaches go2rtc.

Two things worth a reviewer's attention:

- AV1 carries its codec parameters in the sequence header, not in the SDP, so the MP4 consumer waits for one before building the init segment. The wait is limited to AV1 tracks and ends on `Stop`, so H264 and H265 are unchanged.
- Registering AV1 changes every SDP answer, and an offerer sends with the first codec of the answer. Without a guard a browser publishing through `webrtc.html` or WHIP would silently switch from H264 to AV1, so transceivers the remote sends on keep AV1 last.

Verified against ffmpeg rather than against itself: the av1C records this produces are byte for byte identical to ffmpeg's for 640x480, 1280x720, 1920x1080, 4K 10-bit and a colour tagged stream, and keyframe detection agrees with ffmpeg's own flags over 120 real temporal units. End to end, AV1 over RTSP and over FLV both decode cleanly through `stream.mp4`, `frame.mp4`, HLS and WebRTC, and H264 output is byte identical to master.

`go test ./pkg/...` fails in exactly the same 14 packages as master, none of them touched here.
