### PR TITLE
Fix: Avoiding problems with "muted" & added an "onplay" event triggered when playback begins

### DIFF
--- a/www/video-rtc.js
+++ b/www/video-rtc.js
@@ -164,7 +164,10 @@ export class VideoRTC extends HTMLElement {
      * https://developer.chrome.com/blog/autoplay/
      */
     play() {
-        this.video.play().catch(er => {
+        this.video.play().then(_ => {
+            this.onplay();
+        })
+        .catch(er => {
             if (er.name === 'NotAllowedError' && !this.video.muted) {
                 this.video.muted = true;
                 this.play();
@@ -172,6 +175,10 @@ export class VideoRTC extends HTMLElement {
                 console.warn(er);
             }
         });
+    }
+
+    onplay() {
+
     }
 
     /**


### PR DESCRIPTION
Similar to #2090, but cleaner code.
In addition to #2102

Adding the "onplay" event will allow users to more flexibly handle the playback start event.