### PR TITLE
Allow `/api/exit` to stop all producers before terminating

### DIFF
--- a/internal/alsa/alsa_linux.go
+++ b/internal/alsa/alsa_linux.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/alsa"
 	"github.com/AlexxIT/go2rtc/pkg/alsa/device"

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -192,8 +192,6 @@ func Response(w http.ResponseWriter, body any, contentType string) {
 	}
 }
 
-const StreamNotFound = "stream not found"
-
 var allowPaths []string
 var basePath string
 var log zerolog.Logger

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -1,235 +1,30 @@
 package api
 
 import (
-	"crypto/tls"
-	"encoding/json"
-	"fmt"
-	"net"
 	"net/http"
 	"os"
-	"slices"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
-	"time"
 
+	"github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/rs/zerolog"
 )
 
 func Init() {
-	var cfg struct {
-		Mod struct {
-			Listen     string `yaml:"listen"`
-			Username   string `yaml:"username"`
-			Password   string `yaml:"password"`
-			LocalAuth  bool   `yaml:"local_auth"`
-			BasePath   string `yaml:"base_path"`
-			StaticDir  string `yaml:"static_dir"`
-			Origin     string `yaml:"origin"`
-			TLSListen  string `yaml:"tls_listen"`
-			TLSCert    string `yaml:"tls_cert"`
-			TLSKey     string `yaml:"tls_key"`
-			UnixListen string `yaml:"unix_listen"`
-
-			AllowPaths []string `yaml:"allow_paths"`
-		} `yaml:"api"`
-	}
-
-	// default config
-	cfg.Mod.Listen = ":1984"
-
-	// load config from YAML
-	app.LoadConfig(&cfg)
-
-	if cfg.Mod.Listen == "" && cfg.Mod.UnixListen == "" && cfg.Mod.TLSListen == "" {
-		return
-	}
-
-	allowPaths = cfg.Mod.AllowPaths
-	basePath = cfg.Mod.BasePath
+	server.Init()
 	log = app.GetLogger("api")
 
-	initStatic(cfg.Mod.StaticDir)
-
-	HandleFunc("api", apiHandler)
-	HandleFunc("api/config", configHandler)
-	HandleFunc("api/exit", exitHandler)
-	HandleFunc("api/restart", restartHandler)
-	HandleFunc("api/log", logHandler)
-
-	Handler = http.DefaultServeMux // 4th
-
-	if cfg.Mod.Origin == "*" {
-		Handler = middlewareCORS(Handler) // 3rd
-	}
-
-	if cfg.Mod.Username != "" {
-		Handler = middlewareAuth(cfg.Mod.Username, cfg.Mod.Password, cfg.Mod.LocalAuth, Handler) // 2nd
-	}
-
-	if log.Trace().Enabled() {
-		Handler = middlewareLog(Handler) // 1st
-	}
-
-	if cfg.Mod.Listen != "" {
-		_, port, _ := net.SplitHostPort(cfg.Mod.Listen)
-		Port, _ = strconv.Atoi(port)
-		go listen("tcp", cfg.Mod.Listen)
-	}
-
-	if cfg.Mod.UnixListen != "" {
-		_ = syscall.Unlink(cfg.Mod.UnixListen)
-		go listen("unix", cfg.Mod.UnixListen)
-	}
-
-	// Initialize the HTTPS server
-	if cfg.Mod.TLSListen != "" && cfg.Mod.TLSCert != "" && cfg.Mod.TLSKey != "" {
-		go tlsListen("tcp", cfg.Mod.TLSListen, cfg.Mod.TLSCert, cfg.Mod.TLSKey)
-	}
+	server.HandleFunc("api", apiHandler)
+	server.HandleFunc("api/config", configHandler)
+	server.HandleFunc("api/exit", exitHandler)
+	server.HandleFunc("api/restart", restartHandler)
+	server.HandleFunc("api/log", logHandler)
 }
 
-func listen(network, address string) {
-	ln, err := net.Listen(network, address)
-	if err != nil {
-		log.Error().Err(err).Msg("[api] listen")
-		return
-	}
-
-	log.Info().Str("addr", address).Msg("[api] listen")
-
-	server := http.Server{
-		Handler:           Handler,
-		ReadHeaderTimeout: 5 * time.Second, // Example: Set to 5 seconds
-	}
-	if err = server.Serve(ln); err != nil {
-		log.Fatal().Err(err).Msg("[api] serve")
-	}
-}
-
-func tlsListen(network, address, certFile, keyFile string) {
-	var cert tls.Certificate
-	var err error
-	if strings.IndexByte(certFile, '\n') < 0 && strings.IndexByte(keyFile, '\n') < 0 {
-		// check if file path
-		cert, err = tls.LoadX509KeyPair(certFile, keyFile)
-	} else {
-		// if text file content
-		cert, err = tls.X509KeyPair([]byte(certFile), []byte(keyFile))
-	}
-	if err != nil {
-		log.Error().Err(err).Caller().Send()
-		return
-	}
-
-	ln, err := net.Listen(network, address)
-	if err != nil {
-		log.Error().Err(err).Msg("[api] tls listen")
-		return
-	}
-
-	log.Info().Str("addr", address).Msg("[api] tls listen")
-
-	server := &http.Server{
-		Handler:           Handler,
-		TLSConfig:         &tls.Config{Certificates: []tls.Certificate{cert}},
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-	if err = server.ServeTLS(ln, "", ""); err != nil {
-		log.Fatal().Err(err).Msg("[api] tls serve")
-	}
-}
-
-var Port int
-
-const (
-	MimeJSON = "application/json"
-	MimeText = "text/plain"
-)
-
-var Handler http.Handler
-
-// HandleFunc handle pattern with relative path:
-// - "api/streams" => "{basepath}/api/streams"
-// - "/streams"    => "/streams"
-func HandleFunc(pattern string, handler http.HandlerFunc) {
-	if len(pattern) == 0 || pattern[0] != '/' {
-		pattern = basePath + "/" + pattern
-	}
-	if allowPaths != nil && !slices.Contains(allowPaths, pattern) {
-		log.Trace().Str("path", pattern).Msg("[api] ignore path not in allow_paths")
-		return
-	}
-	log.Trace().Str("path", pattern).Msg("[api] register path")
-	http.HandleFunc(pattern, handler)
-}
-
-// ResponseJSON important always add Content-Type
-// so go won't need to call http.DetectContentType
-func ResponseJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", MimeJSON)
-	_ = json.NewEncoder(w).Encode(v)
-}
-
-func ResponsePrettyJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", MimeJSON)
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(v)
-}
-
-func Response(w http.ResponseWriter, body any, contentType string) {
-	w.Header().Set("Content-Type", contentType)
-
-	switch v := body.(type) {
-	case []byte:
-		_, _ = w.Write(v)
-	case string:
-		_, _ = w.Write([]byte(v))
-	default:
-		_, _ = fmt.Fprint(w, body)
-	}
-}
-
-var allowPaths []string
-var basePath string
 var log zerolog.Logger
-
-func middlewareLog(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Trace().Msgf("[api] %s %s %s", r.Method, r.URL, r.RemoteAddr)
-		next.ServeHTTP(w, r)
-	})
-}
-
-func isLoopback(remoteAddr string) bool {
-	return strings.HasPrefix(remoteAddr, "127.") || strings.HasPrefix(remoteAddr, "[::1]") || remoteAddr == "@"
-}
-
-func middlewareAuth(username, password string, localAuth bool, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if localAuth || !isLoopback(r.RemoteAddr) {
-			user, pass, ok := r.BasicAuth()
-			if !ok || user != username || pass != password {
-				w.Header().Set("Www-Authenticate", `Basic realm="go2rtc"`)
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
-
-func middlewareCORS(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-		next.ServeHTTP(w, r)
-	})
-}
 
 var mu sync.Mutex
 
@@ -238,7 +33,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 	app.Info["host"] = r.Host
 	mu.Unlock()
 
-	ResponseJSON(w, app.Info)
+	server.ResponseJSON(w, app.Info)
 }
 
 func exitHandler(w http.ResponseWriter, r *http.Request) {
@@ -284,36 +79,8 @@ func logHandler(w http.ResponseWriter, r *http.Request) {
 		_, _ = app.MemoryLog.WriteTo(w)
 	case "DELETE":
 		app.MemoryLog.Reset()
-		Response(w, "OK", "text/plain")
+		server.Response(w, "OK", "text/plain")
 	default:
 		http.Error(w, "Method not allowed", http.StatusBadRequest)
 	}
-}
-
-type Source struct {
-	ID       string `json:"id,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Info     string `json:"info,omitempty"`
-	URL      string `json:"url,omitempty"`
-	Location string `json:"location,omitempty"`
-}
-
-func ResponseSources(w http.ResponseWriter, sources []*Source) {
-	if len(sources) == 0 {
-		http.Error(w, "no sources", http.StatusNotFound)
-		return
-	}
-
-	var response = struct {
-		Sources []*Source `json:"sources"`
-	}{
-		Sources: sources,
-	}
-	ResponseJSON(w, response)
-}
-
-func Error(w http.ResponseWriter, err error) {
-	log.Error().Err(err).Caller(1).Send()
-
-	http.Error(w, err.Error(), http.StatusInsufficientStorage)
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -51,6 +51,9 @@ func exitHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Stop all streams before exiting.
+	streams.StopAll()
+
 	os.Exit(code)
 }
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"gopkg.in/yaml.v3"
 )
@@ -23,7 +24,7 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-00.html
-		Response(w, data, "application/yaml")
+		server.Response(w, data, "application/yaml")
 
 	case "POST", "PATCH":
 		data, err := io.ReadAll(r.Body)

--- a/internal/api/server/handle.go
+++ b/internal/api/server/handle.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"net/http"
+	"slices"
+)
+
+// HandleFunc handle pattern with relative path:
+// - "api/streams" => "{basepath}/api/streams"
+// - "/streams"    => "/streams"
+func HandleFunc(pattern string, handler http.HandlerFunc) {
+	if len(pattern) == 0 || pattern[0] != '/' {
+		pattern = basePath + "/" + pattern
+	}
+	if allowPaths != nil && !slices.Contains(allowPaths, pattern) {
+		log.Trace().Str("path", pattern).Msg("[api] ignore path not in allow_paths")
+		return
+	}
+	log.Trace().Str("path", pattern).Msg("[api] register path")
+	http.HandleFunc(pattern, handler)
+}

--- a/internal/api/server/response.go
+++ b/internal/api/server/response.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ResponseJSON important always add Content-Type
+// so go won't need to call http.DetectContentType
+func ResponseJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", MimeJSON)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func ResponsePrettyJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", MimeJSON)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+func Response(w http.ResponseWriter, body any, contentType string) {
+	w.Header().Set("Content-Type", contentType)
+
+	switch v := body.(type) {
+	case []byte:
+		_, _ = w.Write(v)
+	case string:
+		_, _ = w.Write([]byte(v))
+	default:
+		_, _ = fmt.Fprint(w, body)
+	}
+}
+
+func ResponseSources(w http.ResponseWriter, sources []*Source) {
+	if len(sources) == 0 {
+		http.Error(w, "no sources", http.StatusNotFound)
+		return
+	}
+
+	var response = struct {
+		Sources []*Source `json:"sources"`
+	}{
+		Sources: sources,
+	}
+	ResponseJSON(w, response)
+}
+
+func Error(w http.ResponseWriter, err error) {
+	log.Error().Err(err).Caller(1).Send()
+
+	http.Error(w, err.Error(), http.StatusInsufficientStorage)
+}

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/rs/zerolog"
+)
+
+func Init() {
+	var cfg struct {
+		Mod struct {
+			Listen     string `yaml:"listen"`
+			Username   string `yaml:"username"`
+			Password   string `yaml:"password"`
+			LocalAuth  bool   `yaml:"local_auth"`
+			BasePath   string `yaml:"base_path"`
+			StaticDir  string `yaml:"static_dir"`
+			Origin     string `yaml:"origin"`
+			TLSListen  string `yaml:"tls_listen"`
+			TLSCert    string `yaml:"tls_cert"`
+			TLSKey     string `yaml:"tls_key"`
+			UnixListen string `yaml:"unix_listen"`
+
+			AllowPaths []string `yaml:"allow_paths"`
+		} `yaml:"api"`
+	}
+
+	// default config
+	cfg.Mod.Listen = ":1984"
+
+	// load config from YAML
+	app.LoadConfig(&cfg)
+
+	if cfg.Mod.Listen == "" && cfg.Mod.UnixListen == "" && cfg.Mod.TLSListen == "" {
+		return
+	}
+
+	allowPaths = cfg.Mod.AllowPaths
+	basePath = cfg.Mod.BasePath
+	log = app.GetLogger("api")
+
+	initStatic(cfg.Mod.StaticDir)
+
+	Handler = http.DefaultServeMux // 4th
+
+	if cfg.Mod.Origin == "*" {
+		Handler = middlewareCORS(Handler) // 3rd
+	}
+
+	if cfg.Mod.Username != "" {
+		Handler = middlewareAuth(cfg.Mod.Username, cfg.Mod.Password, cfg.Mod.LocalAuth, Handler) // 2nd
+	}
+
+	if log.Trace().Enabled() {
+		Handler = middlewareLog(Handler) // 1st
+	}
+
+	if cfg.Mod.Listen != "" {
+		_, port, _ := net.SplitHostPort(cfg.Mod.Listen)
+		Port, _ = strconv.Atoi(port)
+		go listen("tcp", cfg.Mod.Listen)
+	}
+
+	if cfg.Mod.UnixListen != "" {
+		_ = syscall.Unlink(cfg.Mod.UnixListen)
+		go listen("unix", cfg.Mod.UnixListen)
+	}
+
+	// Initialize the HTTPS server
+	if cfg.Mod.TLSListen != "" && cfg.Mod.TLSCert != "" && cfg.Mod.TLSKey != "" {
+		go tlsListen("tcp", cfg.Mod.TLSListen, cfg.Mod.TLSCert, cfg.Mod.TLSKey)
+	}
+}
+
+var Port int
+
+var Handler http.Handler
+
+const (
+	MimeJSON = "application/json"
+	MimeText = "text/plain"
+)
+
+var allowPaths []string
+var basePath string
+var log zerolog.Logger
+
+func listen(network, address string) {
+	ln, err := net.Listen(network, address)
+	if err != nil {
+		log.Error().Err(err).Msg("[api] listen")
+		return
+	}
+
+	log.Info().Str("addr", address).Msg("[api] listen")
+
+	server := http.Server{
+		Handler:           Handler,
+		ReadHeaderTimeout: 5 * time.Second, // Example: Set to 5 seconds
+	}
+	if err = server.Serve(ln); err != nil {
+		log.Fatal().Err(err).Msg("[api] serve")
+	}
+}
+
+func tlsListen(network, address, certFile, keyFile string) {
+	var cert tls.Certificate
+	var err error
+	if strings.IndexByte(certFile, '\n') < 0 && strings.IndexByte(keyFile, '\n') < 0 {
+		// check if file path
+		cert, err = tls.LoadX509KeyPair(certFile, keyFile)
+	} else {
+		// if text file content
+		cert, err = tls.X509KeyPair([]byte(certFile), []byte(keyFile))
+	}
+	if err != nil {
+		log.Error().Err(err).Caller().Send()
+		return
+	}
+
+	ln, err := net.Listen(network, address)
+	if err != nil {
+		log.Error().Err(err).Msg("[api] tls listen")
+		return
+	}
+
+	log.Info().Str("addr", address).Msg("[api] tls listen")
+
+	server := &http.Server{
+		Handler:           Handler,
+		TLSConfig:         &tls.Config{Certificates: []tls.Certificate{cert}},
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err = server.ServeTLS(ln, "", ""); err != nil {
+		log.Fatal().Err(err).Msg("[api] tls serve")
+	}
+}
+
+func middlewareLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Trace().Msgf("[api] %s %s %s", r.Method, r.URL, r.RemoteAddr)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func isLoopback(remoteAddr string) bool {
+	return strings.HasPrefix(remoteAddr, "127.") || strings.HasPrefix(remoteAddr, "[::1]") || remoteAddr == "@"
+}
+
+func middlewareAuth(username, password string, localAuth bool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if localAuth || !isLoopback(r.RemoteAddr) {
+			user, pass, ok := r.BasicAuth()
+			if !ok || user != username || pass != password {
+				w.Header().Set("Www-Authenticate", `Basic realm="go2rtc"`)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func middlewareCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/server/source.go
+++ b/internal/api/server/source.go
@@ -1,0 +1,9 @@
+package server
+
+type Source struct {
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Info     string `json:"info,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Location string `json:"location,omitempty"`
+}

--- a/internal/api/server/static.go
+++ b/internal/api/server/static.go
@@ -1,4 +1,4 @@
-package api
+package server
 
 import (
 	"net/http"

--- a/internal/api/ws/ws.go
+++ b/internal/api/ws/ws.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/pkg/creds"
 	"github.com/gorilla/websocket"

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,7 +1,7 @@
 package debug
 
 import (
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 )
 
 func Init() {

--- a/internal/debug/stack.go
+++ b/internal/debug/stack.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 )
 
 var stackSkip = [][]byte{

--- a/internal/dvrip/dvrip.go
+++ b/internal/dvrip/dvrip.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/dvrip"
 )

--- a/internal/exec/README.md
+++ b/internal/exec/README.md
@@ -20,6 +20,7 @@ Pipe commands support parameters (format: `exec:{command}#{param1}#{param2}`):
 
 - `killsignal` - signal which will be sent to stop the process (numeric form)
 - `killtimeout` - time in seconds for forced termination with sigkill
+- `quitstdin` - string to pass on stdin for graceful termination
 - `backchannel` - enable backchannel for two-way audio
 - `starttimeout` - time in seconds for waiting first byte from RTSP
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
@@ -102,6 +103,12 @@ func execHandle(rawURL string) (prod core.Producer, err error) {
 
 	if s := query.Get("killtimeout"); s != "" {
 		cmd.WaitDelay = time.Duration(core.Atoi(s)) * time.Second
+	}
+
+	if s := query.Get("quitstdin"); s != "" {
+		buffer := bytes.Buffer{}
+		buffer.Write([]byte(s + "\n"))
+		cmd.Stdin = &buffer
 	}
 
 	if query.Get("backchannel") == "1" {

--- a/internal/ffmpeg/device/device_bsd.go
+++ b/internal/ffmpeg/device/device_bsd.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 

--- a/internal/ffmpeg/device/device_darwin.go
+++ b/internal/ffmpeg/device/device_darwin.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 

--- a/internal/ffmpeg/device/device_unix.go
+++ b/internal/ffmpeg/device/device_unix.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 

--- a/internal/ffmpeg/device/device_windows.go
+++ b/internal/ffmpeg/device/device_windows.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"regexp"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 

--- a/internal/ffmpeg/device/devices.go
+++ b/internal/ffmpeg/device/devices.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 )
 
 func Init(bin string) {

--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/ffmpeg/device"
 	"github.com/AlexxIT/go2rtc/internal/ffmpeg/hardware"

--- a/internal/ffmpeg/hardware/hardware.go
+++ b/internal/ffmpeg/hardware/hardware.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/pkg/ffmpeg"
 )
 

--- a/internal/ffmpeg/hardware/hardware_bsd.go
+++ b/internal/ffmpeg/hardware/hardware_bsd.go
@@ -5,7 +5,7 @@ package hardware
 import (
 	"runtime"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 )
 
 const (

--- a/internal/ffmpeg/hardware/hardware_darwin.go
+++ b/internal/ffmpeg/hardware/hardware_darwin.go
@@ -3,7 +3,7 @@
 package hardware
 
 import (
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 )
 
 const ProbeVideoToolboxH264 = "-f lavfi -i testsrc2=size=svga -t 1 -c h264_videotoolbox -f null -"

--- a/internal/ffmpeg/hardware/hardware_unix.go
+++ b/internal/ffmpeg/hardware/hardware_unix.go
@@ -5,7 +5,7 @@ package hardware
 import (
 	"runtime"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 )
 
 const (

--- a/internal/ffmpeg/hardware/hardware_windows.go
+++ b/internal/ffmpeg/hardware/hardware_windows.go
@@ -2,7 +2,7 @@
 
 package hardware
 
-import "github.com/AlexxIT/go2rtc/internal/api"
+import api "github.com/AlexxIT/go2rtc/internal/api/server"
 
 const ProbeDXVA2H264 = "-init_hw_device dxva2 -f lavfi -i testsrc2 -t 1 -c h264_qsv -f null -"
 const ProbeDXVA2H265 = "-init_hw_device dxva2 -f lavfi -i testsrc2 -t 1 -c hevc_qsv -f null -"

--- a/internal/ffmpeg/producer.go
+++ b/internal/ffmpeg/producer.go
@@ -31,6 +31,10 @@ func NewProducer(url string) (core.Producer, error) {
 		return nil, errors.New("ffmpeg: unsupported params: " + url[i:])
 	}
 
+	// Append quitstdin param to ensure ffmpeg process is terminated when the producer is stopped.
+	// This is necessary as it lets ffmpeg exit gracefully.
+	p.query.Add("quitstdin", "q")
+
 	p.ID = core.NewID()
 	p.FormatName = "ffmpeg"
 	p.Medias = []*core.Media{

--- a/internal/gopro/gopro.go
+++ b/internal/gopro/gopro.go
@@ -3,7 +3,7 @@ package gopro
 import (
 	"net/http"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/gopro"

--- a/internal/hass/api.go
+++ b/internal/hass/api.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/internal/webrtc"
 )

--- a/internal/hass/api.go
+++ b/internal/hass/api.go
@@ -47,7 +47,7 @@ func apiStream(w http.ResponseWriter, r *http.Request) {
 		name := r.RequestURI[8 : 8+i]
 		stream := streams.Get(name)
 		if stream == nil {
-			http.Error(w, api.StreamNotFound, http.StatusNotFound)
+			http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 			return
 		}
 

--- a/internal/hass/hass.go
+++ b/internal/hass/hass.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/roborock"
 	"github.com/AlexxIT/go2rtc/internal/streams"

--- a/internal/hls/hls.go
+++ b/internal/hls/hls.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"

--- a/internal/hls/hls.go
+++ b/internal/hls/hls.go
@@ -52,7 +52,7 @@ func handlerStream(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/hls/ws.go
+++ b/internal/hls/ws.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/mp4"
@@ -13,7 +12,7 @@ import (
 func handlerWSHLS(tr *ws.Transport, msg *ws.Message) error {
 	stream, _ := streams.GetOrPatch(tr.Request.URL.Query())
 	if stream == nil {
-		return errors.New(api.StreamNotFound)
+		return errors.New(streams.StreamNotFound)
 	}
 
 	codecs := msg.String()

--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/hap"

--- a/internal/homekit/api.go
+++ b/internal/homekit/api.go
@@ -151,7 +151,7 @@ func apiPair(id, url string) error {
 func apiUnpair(id string) error {
 	stream := streams.Get(id)
 	if stream == nil {
-		return errors.New(api.StreamNotFound)
+		return errors.New(streams.StreamNotFound)
 	}
 
 	rawURL := findHomeKitURL(stream.Sources())

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/srtp"
 	"github.com/AlexxIT/go2rtc/internal/streams"

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/hls"

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -114,7 +114,7 @@ func apiStream(w http.ResponseWriter, r *http.Request) {
 	dst := r.URL.Query().Get("dst")
 	stream := streams.Get(dst)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/mjpeg/mjpeg.go
+++ b/internal/mjpeg/mjpeg.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/ffmpeg"

--- a/internal/mjpeg/mjpeg.go
+++ b/internal/mjpeg/mjpeg.go
@@ -40,7 +40,7 @@ func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	stream, _ := streams.GetOrPatch(query)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -139,7 +139,7 @@ func outputMjpeg(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -174,7 +174,7 @@ func inputMjpeg(w http.ResponseWriter, r *http.Request) {
 	dst := r.URL.Query().Get("dst")
 	stream := streams.Get(dst)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -193,7 +193,7 @@ func inputMjpeg(w http.ResponseWriter, r *http.Request) {
 func handlerWS(tr *ws.Transport, _ *ws.Message) error {
 	stream, _ := streams.GetOrPatch(tr.Request.URL.Query())
 	if stream == nil {
-		return errors.New(api.StreamNotFound)
+		return errors.New(streams.StreamNotFound)
 	}
 
 	cons := mjpeg.NewConsumer()
@@ -219,7 +219,7 @@ func apiStreamY4M(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/mp4/mp4.go
+++ b/internal/mp4/mp4.go
@@ -43,7 +43,7 @@ func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
 	src := query.Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -93,7 +93,7 @@ func handlerMP4(w http.ResponseWriter, r *http.Request) {
 
 	stream, _ := streams.GetOrPatch(query)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/mp4/mp4.go
+++ b/internal/mp4/mp4.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"

--- a/internal/mp4/ws.go
+++ b/internal/mp4/ws.go
@@ -3,7 +3,6 @@ package mp4
 import (
 	"errors"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -13,7 +12,7 @@ import (
 func handlerWSMSE(tr *ws.Transport, msg *ws.Message) error {
 	stream, _ := streams.GetOrPatch(tr.Request.URL.Query())
 	if stream == nil {
-		return errors.New(api.StreamNotFound)
+		return errors.New(streams.StreamNotFound)
 	}
 
 	var medias []*core.Media
@@ -45,7 +44,7 @@ func handlerWSMSE(tr *ws.Transport, msg *ws.Message) error {
 func handlerWSMP4(tr *ws.Transport, msg *ws.Message) error {
 	stream, _ := streams.GetOrPatch(tr.Request.URL.Query())
 	if stream == nil {
-		return errors.New(api.StreamNotFound)
+		return errors.New(streams.StreamNotFound)
 	}
 
 	var medias []*core.Media

--- a/internal/mpeg/mpeg.go
+++ b/internal/mpeg/mpeg.go
@@ -3,7 +3,7 @@ package mpeg
 import (
 	"net/http"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/aac"
 	"github.com/AlexxIT/go2rtc/pkg/mpegts"

--- a/internal/mpeg/mpeg.go
+++ b/internal/mpeg/mpeg.go
@@ -26,7 +26,7 @@ func outputMpegTS(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -49,7 +49,7 @@ func inputMpegTS(w http.ResponseWriter, r *http.Request) {
 	dst := r.URL.Query().Get("dst")
 	stream := streams.Get(dst)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -72,7 +72,7 @@ func apiStreamAAC(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/nest/init.go
+++ b/internal/nest/init.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/nest"

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/rtsp"
 	"github.com/AlexxIT/go2rtc/internal/streams"

--- a/internal/ring/ring.go
+++ b/internal/ring/ring.go
@@ -6,7 +6,7 @@ import (
 
 	"fmt"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/ring"

--- a/internal/roborock/roborock.go
+++ b/internal/roborock/roborock.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/roborock"

--- a/internal/rtmp/rtmp.go
+++ b/internal/rtmp/rtmp.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"

--- a/internal/rtmp/rtmp.go
+++ b/internal/rtmp/rtmp.go
@@ -155,7 +155,7 @@ func outputFLV(w http.ResponseWriter, r *http.Request) {
 	src := r.URL.Query().Get("src")
 	stream := streams.Get(src)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -179,7 +179,7 @@ func inputFLV(w http.ResponseWriter, r *http.Request) {
 	dst := r.URL.Query().Get("dst")
 	stream := streams.Get(dst)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/streams/add_consumer.go
+++ b/internal/streams/add_consumer.go
@@ -95,7 +95,7 @@ func (s *Stream) AddConsumer(cons core.Consumer) (err error) {
 
 	// stop producers if they don't have readers
 	if s.pending.Add(-1) == 0 {
-		s.stopProducers()
+		s.StopProducers()
 	}
 
 	if len(prodStarts) == 0 {

--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -3,7 +3,7 @@ package streams
 import (
 	"net/http"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/creds"

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -8,6 +8,8 @@ import (
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 
+const StreamNotFound = "stream not found"
+
 type Stream struct {
 	producers []*Producer
 	consumers []core.Consumer

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -75,7 +75,7 @@ func (s *Stream) RemoveConsumer(cons core.Consumer) {
 	}
 	s.mu.Unlock()
 
-	s.stopProducers()
+	s.StopProducers()
 }
 
 func (s *Stream) AddProducer(prod core.Producer) {
@@ -96,7 +96,12 @@ func (s *Stream) RemoveProducer(prod core.Producer) {
 	s.mu.Unlock()
 }
 
-func (s *Stream) stopProducers() {
+func (s *Stream) StopProducers(force ...bool) {
+	// Default force=false, only stop producers without active tracks
+	// If force=true, stop all producers regardless of active tracks
+	if len(force) == 0 {
+		force = append(force, false)
+	}
 	if s.pending.Load() > 0 {
 		log.Trace().Msg("[streams] skip stop pending producer")
 		return
@@ -105,14 +110,16 @@ func (s *Stream) stopProducers() {
 	s.mu.Lock()
 producers:
 	for _, producer := range s.producers {
-		for _, track := range producer.receivers {
-			if len(track.Senders()) > 0 {
-				continue producers
+		if !force[0] {
+			for _, track := range producer.receivers {
+				if len(track.Senders()) > 0 {
+					continue producers
+				}
 			}
-		}
-		for _, track := range producer.senders {
-			if len(track.Senders()) > 0 {
-				continue producers
+			for _, track := range producer.senders {
+				if len(track.Senders()) > 0 {
+					continue producers
+				}
 			}
 		}
 		producer.stop()

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -174,3 +174,11 @@ func GetAllSources() map[string][]string {
 	streamsMu.Unlock()
 	return sources
 }
+
+func StopAll() {
+	streamsMu.Lock()
+	for _, stream := range streams {
+		stream.StopProducers(true)
+	}
+	streamsMu.Unlock()
+}

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/rs/zerolog"
 )

--- a/internal/tuya/tuya.go
+++ b/internal/tuya/tuya.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/tuya"

--- a/internal/v4l2/v4l2_linux.go
+++ b/internal/v4l2/v4l2_linux.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/v4l2"

--- a/internal/webrtc/server.go
+++ b/internal/webrtc/server.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/webrtc"
@@ -66,7 +65,7 @@ func outputWebRTC(w http.ResponseWriter, r *http.Request) {
 	u := r.URL.Query().Get("src")
 	stream := streams.Get(u)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 
@@ -167,7 +166,7 @@ func inputWebRTC(w http.ResponseWriter, r *http.Request) {
 	dst := r.URL.Query().Get("dst")
 	stream := streams.Get(dst)
 	if stream == nil {
-		http.Error(w, api.StreamNotFound, http.StatusNotFound)
+		http.Error(w, streams.StreamNotFound, http.StatusNotFound)
 		return
 	}
 

--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"

--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -130,7 +130,7 @@ func asyncHandler(tr *ws.Transport, msg *ws.Message) (err error) {
 	}
 
 	if stream == nil {
-		return errors.New(api.StreamNotFound)
+		return errors.New(streams.StreamNotFound)
 	}
 
 	var offer struct {

--- a/internal/webtorrent/init.go
+++ b/internal/webtorrent/init.go
@@ -45,7 +45,7 @@ func Init() {
 		Exchange: func(src, offer string) (answer string, err error) {
 			stream := streams.Get(src)
 			if stream == nil {
-				return "", errors.New(api.StreamNotFound)
+				return "", errors.New(streams.StreamNotFound)
 			}
 			return webrtc.ExchangeSDP(stream, offer, "webtorrent", "")
 		},

--- a/internal/webtorrent/init.go
+++ b/internal/webtorrent/init.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/internal/webrtc"

--- a/internal/wyze/wyze.go
+++ b/internal/wyze/wyze.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"

--- a/internal/xiaomi/xiaomi.go
+++ b/internal/xiaomi/xiaomi.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/AlexxIT/go2rtc/internal/api"
+	api "github.com/AlexxIT/go2rtc/internal/api/server"
 	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"


### PR DESCRIPTION
This patch refactors some code to make it possible for the `api` package to refer to the `streams` package so that the `/api/exit` endpoint can call a new `streams` API: `StopAll`.   The method stops all producers of any kind.  In the case of `rtsp` sources, this results in a `TEARDOWN` message being sent to the device, allowing it to free any onboard resources that were dedicated to `go2rtc` having configured that source/stream.

Fixes #2104 

Testing (RTSP):

1. Start `go2rtc`.
2. Configure an `rtsp` source
3. Access the configured source's manufacturer UI/configuration app to observe the access log. I'm using an Axis camera for this.
4. Access the `go2rtc` 1984 application page and create a tab from the configured source's `stream` link.
5. Observe on (2) that a stream is now active; my Axis shows this:
    ```
    2021-03-28T14:14:32.700-05:00 axis-accc8eac4517 [ NOTICE  ] monolith: RTSP UNKNOWN session U3xyCnUGHI_kLa0j created from 192.168.1.224
    ```
6. POST to the `/api/exit` endpoint.
7. Observe that the application has exited.
8. Observe in (2) that the stream is no longer active.  For Axis, it shows `terminated`; if you observe this on Wireshark, you will see a `TEARDOWN` event over port 554.
    ```
    2021-03-28T14:21:40.004-05:00 axis-accc8eac4517 [ NOTICE  ] monolith: RTSP video/x-h264 session rSQoJw8.xdc-cnh3 terminated from 192.168.1.224
    ```