### PR TITLE
feat(streams): add HasConsumer helper for idempotency

### DIFF
--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -76,6 +76,17 @@ func (s *Stream) RemoveConsumer(cons core.Consumer) {
 	s.stopProducers()
 }
 
+func (s *Stream) HasConsumer(cons core.Consumer) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, consumer := range s.consumers {
+		if consumer == cons {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Stream) AddProducer(prod core.Producer) {
 	producer := &Producer{conn: prod, state: stateExternal, url: "external"}
 	s.mu.Lock()


### PR DESCRIPTION
Stream lacks a way to check if a consumer is already attached.Adding Stream.HasConsumer(cons) allows upper modules to verify the attachment status during reconnection or recovery, preventing duplicate AddConsumer calls.