### PR TITLE
fix: improve ONVIF/RTSP compatibility with Hikvision ISC and NVR platforms

### DIFF
--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -167,6 +167,14 @@ func tcpHandler(conn *rtsp.Conn) {
 				return
 			}
 
+			// Clean up previous consumer on re-DESCRIBE (e.g. ONVIF clients)
+			if closer != nil {
+				closer()
+				closer = nil
+			}
+			conn.Senders = nil
+			conn.Receivers = nil
+
 			name = conn.URL.Path[1:]
 
 			stream := streams.Get(name)

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -66,7 +66,7 @@ func GetCapabilitiesResponse(host string) []byte {
 			<tt:XAddr>http://%s/onvif/media_service</tt:XAddr>
 			<tt:StreamingCapabilities>
 				<tt:RTPMulticast>false</tt:RTPMulticast>
-				<tt:RTP_TCP>false</tt:RTP_TCP>
+				<tt:RTP_TCP>true</tt:RTP_TCP>
 				<tt:RTP_RTSP_TCP>true</tt:RTP_RTSP_TCP>
 			</tt:StreamingCapabilities>
 		</tt:Media>
@@ -261,7 +261,7 @@ func StaticResponse(operation string) []byte {
 var responses = map[string]string{
 	ServiceGetServiceCapabilities: `<trt:GetServiceCapabilitiesResponse>
 	<trt:Capabilities SnapshotUri="true" Rotation="false" VideoSourceMode="false" OSD="false" TemporaryOSDText="false" EXICompression="false">
-		<trt:StreamingCapabilities RTPMulticast="false" RTP_TCP="false" RTP_RTSP_TCP="true" NonAggregateControl="false" NoRTSPStreaming="false" />
+		<trt:StreamingCapabilities RTPMulticast="false" RTP_TCP="true" RTP_RTSP_TCP="true" NonAggregateControl="false" NoRTSPStreaming="false" />
 	</trt:Capabilities>
 </trt:GetServiceCapabilitiesResponse>`,
 

--- a/pkg/rtsp/server.go
+++ b/pkg/rtsp/server.go
@@ -163,9 +163,11 @@ func (c *Conn) Accept() error {
 				Request: req,
 			}
 
-			// Test if client requests TCP transport, otherwise return 461 Transport not supported
-			// This allows smart clients who initially requested UDP to fall back on TCP transport
-			if tr := req.Header.Get("Transport"); strings.HasPrefix(tr, "RTP/AVP/TCP") {
+			tr := req.Header.Get("Transport")
+
+			// Accept both TCP and UDP transport requests
+			// For UDP requests, force TCP interleaved transport in response
+			if strings.HasPrefix(tr, "RTP/AVP/TCP") || strings.HasPrefix(tr, "RTP/AVP") {
 				c.session = core.RandString(8, 10)
 				c.state = StateSetup
 


### PR DESCRIPTION
## Problem

When using go2rtc as an ONVIF server with Hikvision ISC (iSecure Center) and similar NVR platforms, ONVIF clients frequently fail to get streams (~80-90% failure rate).

### Root Cause Analysis

Through trace-level logging analysis, three issues were identified:

**1. Duplicate SDP tracks on re-DESCRIBE (Bug)**

Some ONVIF clients (e.g. Hikvision ISC) send multiple DESCRIBE requests on the same RTSP TCP connection. The RTSP server's `tcpHandler` calls `AddConsumer` on each DESCRIBE without cleaning up the previous consumer, causing `Senders` to accumulate. The second DESCRIBE response contains 4 tracks (duplicated video + audio) instead of 2, which confuses the client.

**2. ONVIF capabilities declare RTP_TCP=false (Compatibility)**

The ONVIF `GetCapabilities` and `GetServiceCapabilities` responses declare `RTP_TCP=false`. Hikvision ISC checks this capability and decides TCP streaming is not available, so it gives up after DESCRIBE without even attempting SETUP. The client never tries the `RTP_RTSP_TCP` (interleaved) capability.

**3. RTSP server rejects UDP SETUP with 461 (Compatibility)**

Even if an NVR client does attempt SETUP with UDP transport (`RTP/AVP;unicast;client_port=...`), the server responds with `461 Unsupported transport`. Many NVR clients do not fall back to TCP after receiving 461.

## Changes

### 1. `internal/rtsp/rtsp.go` - Fix re-DESCRIBE handling
- Clean up previous consumer (`closer()`) before processing a new DESCRIBE on the same connection
- Reset `Senders` and `Receivers` to prevent track accumulation

### 2. `pkg/onvif/server.go` - Update ONVIF capabilities
- Change `RTP_TCP` from `false` to `true` in both `GetCapabilities` and `GetServiceCapabilities` responses
- This tells NVR platforms that TCP streaming is available

### 3. `pkg/rtsp/server.go` - Accept UDP SETUP requests
- Accept any `RTP/AVP` prefixed transport (including UDP requests)
- Always respond with TCP interleaved transport (`RTP/AVP/TCP;unicast;interleaved=...`)
- This forces clients to use TCP interleaved mode regardless of their initial transport preference

## Testing

Tested with:
- Hikvision ISC (iSecure Center) as ONVIF client
- go2rtc v1.9.14 on Windows Server
- Hikvision camera as RTSP source

Before fix: ~10-20% stream success rate
After fix: stable streaming, all ONVIF client connections succeed