### PR TITLE
Fix ONVIF NVR compatibility for RTSP streaming

### DIFF
--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -167,6 +167,14 @@ func tcpHandler(conn *rtsp.Conn) {
 				return
 			}
 
+			// Clean up previous consumer on re-DESCRIBE (e.g. ONVIF clients)
+			if closer != nil {
+				closer()
+				closer = nil
+			}
+			conn.Senders = nil
+			conn.Receivers = nil
+
 			name = conn.URL.Path[1:]
 
 			stream := streams.Get(name)

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -66,7 +66,7 @@ func GetCapabilitiesResponse(host string) []byte {
 			<tt:XAddr>http://%s/onvif/media_service</tt:XAddr>
 			<tt:StreamingCapabilities>
 				<tt:RTPMulticast>false</tt:RTPMulticast>
-				<tt:RTP_TCP>false</tt:RTP_TCP>
+				<tt:RTP_TCP>true</tt:RTP_TCP>
 				<tt:RTP_RTSP_TCP>true</tt:RTP_RTSP_TCP>
 			</tt:StreamingCapabilities>
 		</tt:Media>
@@ -261,7 +261,7 @@ func StaticResponse(operation string) []byte {
 var responses = map[string]string{
 	ServiceGetServiceCapabilities: `<trt:GetServiceCapabilitiesResponse>
 	<trt:Capabilities SnapshotUri="true" Rotation="false" VideoSourceMode="false" OSD="false" TemporaryOSDText="false" EXICompression="false">
-		<trt:StreamingCapabilities RTPMulticast="false" RTP_TCP="false" RTP_RTSP_TCP="true" NonAggregateControl="false" NoRTSPStreaming="false" />
+		<trt:StreamingCapabilities RTPMulticast="false" RTP_TCP="true" RTP_RTSP_TCP="true" NonAggregateControl="false" NoRTSPStreaming="false" />
 	</trt:Capabilities>
 </trt:GetServiceCapabilitiesResponse>`,
 

--- a/pkg/rtsp/server.go
+++ b/pkg/rtsp/server.go
@@ -163,9 +163,11 @@ func (c *Conn) Accept() error {
 				Request: req,
 			}
 
-			// Test if client requests TCP transport, otherwise return 461 Transport not supported
-			// This allows smart clients who initially requested UDP to fall back on TCP transport
-			if tr := req.Header.Get("Transport"); strings.HasPrefix(tr, "RTP/AVP/TCP") {
+			tr := req.Header.Get("Transport")
+
+			// Accept both TCP and UDP transport requests
+			// For UDP requests, force TCP interleaved transport in response
+			if strings.HasPrefix(tr, "RTP/AVP/TCP") || strings.HasPrefix(tr, "RTP/AVP") {
 				c.session = core.RandString(8, 10)
 				c.state = StateSetup
 


### PR DESCRIPTION
## Summary

This PR fixes three issues that cause ONVIF clients (e.g. Hikvision ISC/iSecure Center) to fail when connecting to go2rtc's ONVIF server for RTSP streaming. The failure rate was approximately 80-90%.

### Root Causes

1. **ONVIF capabilities declare RTP_TCP as false** — ONVIF clients check `GetCapabilities` and `GetServiceCapabilities` before attempting RTSP SETUP. When `RTP_TCP=false`, clients like Hikvision ISC skip the SETUP entirely, resulting in silent stream failure.

2. **RTSP server rejects UDP transport requests** — When an ONVIF client sends `SETUP` with `RTP/AVP` (UDP), the server returns `461 Unsupported transport`. Since go2rtc only supports TCP interleaved, the server should accept the request but respond with TCP interleaved transport parameters.

3. **SDP track accumulation on re-DESCRIBE** — Some ONVIF clients reuse the same RTSP connection to send multiple DESCRIBE requests (e.g. when switching profiles). The `Senders` and `Receivers` slices were never reset, causing duplicate tracks to accumulate and break playback.

### Changes

- **pkg/onvif/server.go**: Set `RTP_TCP` to `true` in both `GetCapabilities` and `GetServiceCapabilities` responses
- **pkg/rtsp/server.go**: Accept `RTP/AVP` (UDP) SETUP requests and respond with TCP interleaved transport
- **internal/rtsp/rtsp.go**: Clean up previous consumer and reset Senders/Receivers on re-DESCRIBE

### Testing

Tested with Hikvision ISC (iSecure Center) NVR platform connecting to go2rtc v1.9.14 ONVIF server. After the fix, streams connect reliably (previously ~80-90% failure rate).