### PR TITLE
Fix PCMA and PCMU handling in incoming streams

### DIFF
--- a/pkg/mpegts/producer.go
+++ b/pkg/mpegts/producer.go
@@ -175,6 +175,8 @@ func StreamType(codec *core.Codec) uint8 {
 		return StreamTypeAAC
 	case core.CodecPCMA:
 		return StreamTypePCMATapo
+	case core.CodecPCMU:
+		return StreamTypePCMUTapo
 	case core.CodecOpus:
 		return StreamTypePrivateOPUS
 	}

--- a/pkg/mpegts/producer.go
+++ b/pkg/mpegts/producer.go
@@ -91,7 +91,7 @@ func (c *Producer) probe() error {
 		case StreamTypeMetadata:
 			for _, streamType := range pkt.Payload {
 				switch streamType {
-				case StreamTypeH264, StreamTypeH265, StreamTypeAAC, StreamTypePrivateOPUS, StreamTypePCMATapo, StreamTypePCMUTapo:
+				case StreamTypeH264, StreamTypeH265, StreamTypeAAC, StreamTypePrivateOPUS, StreamTypePCMATapo:
 					waitType = append(waitType, streamType)
 				}
 			}
@@ -147,18 +147,6 @@ func (c *Producer) probe() error {
 				Codecs:    []*core.Codec{codec},
 			}
 			c.Medias = append(c.Medias, media)
-
-		case StreamTypePCMUTapo:
-			codec := &core.Codec{
-				Name:      core.CodecPCMU,
-				ClockRate: 8000,
-			}
-			media := &core.Media{
-				Kind:      core.KindAudio,
-				Direction: core.DirectionRecvonly,
-				Codecs:    []*core.Codec{codec},
-			}
-			c.Medias = append(c.Medias, media)
 		}
 	}
 
@@ -175,8 +163,6 @@ func StreamType(codec *core.Codec) uint8 {
 		return StreamTypeAAC
 	case core.CodecPCMA:
 		return StreamTypePCMATapo
-	case core.CodecPCMU:
-		return StreamTypePCMUTapo
 	case core.CodecOpus:
 		return StreamTypePrivateOPUS
 	}

--- a/pkg/mpegts/producer.go
+++ b/pkg/mpegts/producer.go
@@ -91,7 +91,7 @@ func (c *Producer) probe() error {
 		case StreamTypeMetadata:
 			for _, streamType := range pkt.Payload {
 				switch streamType {
-				case StreamTypeH264, StreamTypeH265, StreamTypeAAC, StreamTypePrivateOPUS:
+				case StreamTypeH264, StreamTypeH265, StreamTypeAAC, StreamTypePrivateOPUS, StreamTypePCMATapo, StreamTypePCMUTapo:
 					waitType = append(waitType, streamType)
 				}
 			}
@@ -128,6 +128,30 @@ func (c *Producer) probe() error {
 				Name:      core.CodecOpus,
 				ClockRate: 48000,
 				Channels:  2,
+			}
+			media := &core.Media{
+				Kind:      core.KindAudio,
+				Direction: core.DirectionRecvonly,
+				Codecs:    []*core.Codec{codec},
+			}
+			c.Medias = append(c.Medias, media)
+
+		case StreamTypePCMATapo:
+			codec := &core.Codec{
+				Name:      core.CodecPCMA,
+				ClockRate: 8000,
+			}
+			media := &core.Media{
+				Kind:      core.KindAudio,
+				Direction: core.DirectionRecvonly,
+				Codecs:    []*core.Codec{codec},
+			}
+			c.Medias = append(c.Medias, media)
+
+		case StreamTypePCMUTapo:
+			codec := &core.Codec{
+				Name:      core.CodecPCMU,
+				ClockRate: 8000,
 			}
 			media := &core.Media{
 				Kind:      core.KindAudio,


### PR DESCRIPTION
This pull request adds support for two new audio stream types, PCMA and PCMU (Tapo variants), to the MPEG-TS producer. The main changes ensure that these audio types are recognized and properly mapped to their respective codecs and media definitions.

Support for new audio stream types:

* Added `StreamTypePCMATapo` and `StreamTypePCMUTapo` to the list of recognized stream types in the probing logic, so the producer now waits for these types when encountered.
* Implemented handling for `StreamTypePCMATapo` and `StreamTypePCMUTapo` by mapping them to the appropriate `core.Codec` (`CodecPCMA` and `CodecPCMU` respectively) with a clock rate of 8000, and appending the corresponding `core.Media` entries to the producer's media list.