### PR TITLE
fix(webrtc): Fixed webrtc asyncCandidates filtering

### DIFF
--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -41,6 +41,8 @@ func Init() {
 			log.Debug().Msgf("[webrtc] interface %+v addrs %v", itf, addrs)
 		}
 	}
+    
+    filters = cfg.Mod.Filters
 
 	address, network, _ := strings.Cut(cfg.Mod.Listen, "/")
 	for _, candidate := range cfg.Mod.Candidates {


### PR DESCRIPTION
Fixes webrtc config filters not filtering - asyncCandidates referenced an unset variable. Resolves #2172