### PR TITLE
fix(mp4): guard against zero timeScale to prevent +Inf timestamp corruption

### DIFF
--- a/pkg/mp4/demuxer.go
+++ b/pkg/mp4/demuxer.go
@@ -42,7 +42,7 @@ func (d *Demuxer) Probe(init []byte) (medias []*core.Media) {
 			}
 		}
 
-		if codec != nil {
+		if codec != nil && timeScale > 0 {
 			d.codecs[trackID] = codec
 			d.timeScales[trackID] = float32(codec.ClockRate) / float32(timeScale)
 


### PR DESCRIPTION
When an `mdhd` atom reports `timeScale=0`, `Probe` stored `float32(codec.ClockRate)/float32(0) = +Inf` in the timeScales map. `Demux`'s existing guard `if timeScale == 0` does not catch `+Inf`, so subsequent packet timestamps were computed as `uint32(float32(ts) * +Inf) = 0`, corrupting every packet in the track.

Adding `&& timeScale > 0` to the codec registration condition skips tracks with an invalid timescale instead of storing a bad value.