### PR TITLE
fix(h264,homekit): add bounds guards against malformed device data

### DIFF
--- a/pkg/h264/h264.go
+++ b/pkg/h264/h264.go
@@ -130,6 +130,9 @@ func GetFmtpLine(avc []byte) string {
 
 		switch NALUType(avc) {
 		case NALUTypeSPS:
+			if len(avc) < 8 || size > len(avc) {
+				return s
+			}
 			s += ";profile-level-id=" + hex.EncodeToString(avc[5:8])
 			s += ";sprop-parameter-sets=" + base64.StdEncoding.EncodeToString(avc[4:size])
 		case NALUTypePPS:

--- a/pkg/homekit/helpers.go
+++ b/pkg/homekit/helpers.go
@@ -20,9 +20,15 @@ func videoToMedia(codecs []camera.VideoCodecConfiguration) *core.Media {
 
 	for _, codec := range codecs {
 		for _, param := range codec.CodecParams {
-			// get best profile and level
+			// get best profile and level; clamp to table bounds
 			profileID := core.Max(param.ProfileID)
+			if int(profileID) >= len(videoProfiles) {
+				profileID = byte(len(videoProfiles) - 1)
+			}
 			level := core.Max(param.Level)
+			if int(level) >= len(videoLevels) {
+				level = byte(len(videoLevels) - 1)
+			}
 			profile := videoProfiles[profileID] + videoLevels[level]
 			mediaCodec := &core.Codec{
 				Name:      videoCodecs[codec.CodecType],


### PR DESCRIPTION
`h264 GetFmtpLine`: check `len(avc) >= 8` and `size <= len(avc)` before accessing `avc[5:8]` for the SPS profile bytes. A truncated SPS NALU from a misbehaving device caused an index-out-of-range panic.

`homekit videoToMedia`: clamp `profileID` and `level` to the bounds of the `videoProfiles`/`videoLevels` tables before indexing them. A non-compliant HomeKit device advertising an out-of-range profile or level value caused an index-out-of-range panic.