### PR TITLE
feat(ui): serve optional extra UI from /ui volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Ultimate camera streaming application with support for dozens formats and protoc
   - [go2rtc: Home Assistant Integration](#go2rtc-home-assistant-integration)
   - [go2rtc: Master version](#go2rtc-master-version)
 - [Configuration](#configuration)
+  - [Extra UI](#extra-ui)
 - [Features](#features)
   - [Streaming input](#streaming-input)
   - [Streaming output](#streaming-output)
@@ -160,6 +161,21 @@ streams:
 
 More information can be [found here](internal/app/README.md).
 
+### Extra UI
+
+You can serve an additional static web UI (HTML, CSS, JS) from a local directory on the same port as the built-in [HTTP API](internal/api/README.md) (default **1984**). When `ui.dir` exists and is a directory, files are served under `{api.base_path}/ui/` (for example `http://<host>:1984/ui/` when `api.base_path` is empty).
+
+```yaml
+ui:
+  dir: /path/to/your/static/files # optional; default is /ui
+```
+
+If `ui.dir` is omitted, go2rtc uses `/ui` (a Unix-style absolute path; on Windows set an explicit path). Set `ui.dir` to `""` to disable this feature.
+
+If you restrict which modules load with `app.modules` (see [Security](#security)), include `ui` or the extra UI will not be registered. If you use `api.allow_paths`, add the extra UI path (for example `/ui/` or `{base_path}/ui/`).
+
+With Docker, bind-mount your files at `/ui` or set `ui.dir` accordingly (see [docker/README.md](docker/README.md#extra-ui)).
+
 ## Features
 
 A summary table of all modules and features can be found [here](internal/README.md).
@@ -168,6 +184,7 @@ A summary table of all modules and features can be found [here](internal/README.
 
 - [`app`](internal/app/README.md) - Reading [configs](internal/app/README.md) and setting up [logs](internal/app/README.md#log).
 - [`api`](internal/api/README.md) - Handle [HTTP](internal/api/README.md) and [WebSocket](internal/api/ws/README.md) API.
+- [`ui`](internal/ui/ui.go) - Optional extra static UI from `ui.dir` (default `/ui`).
 - [`streams`](internal/streams/README.md) - Handle a list of streams.
 
 ### Streaming input

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,21 @@ services:
       - "~/go2rtc:/config"   # folder for go2rtc.yaml file (edit from WebUI)
 ```
 
+## Extra UI
+
+Mount a local directory with static HTML/JS files to `/ui` (read-only). go2rtc serves those files at `http://<host>:1984/ui/`.
+
+```yaml
+services:
+  go2rtc:
+    image: alexxit/go2rtc
+    volumes:
+      - "~/go2rtc:/config"
+      - "./my-ui:/ui:ro"
+```
+
+No extra configuration is required. To use a different host path than `./my-ui`, change the left side of the bind mount; to use a different path inside the container than `/ui`, set `ui.dir` in `go2rtc.yaml` to match.
+
 ## Basic Deployment
 
 ```bash

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,44 @@
+package ui
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/AlexxIT/go2rtc/internal/api"
+	"github.com/AlexxIT/go2rtc/internal/app"
+)
+
+func Init() {
+	var cfg struct {
+		Mod struct {
+			BasePath string `yaml:"base_path"`
+		} `yaml:"api"`
+		UI struct {
+			Dir string `yaml:"dir"`
+		} `yaml:"ui"`
+	}
+	cfg.UI.Dir = "/ui"
+
+	app.LoadConfig(&cfg)
+
+	if cfg.UI.Dir == "" {
+		return
+	}
+
+	log := app.GetLogger("ui")
+	info, err := os.Stat(cfg.UI.Dir)
+	if err != nil {
+		log.Warn().Str("dir", cfg.UI.Dir).Msg("[ui] failed to stat directory")
+		return
+	}
+	if !info.IsDir() {
+		log.Warn().Str("dir", cfg.UI.Dir).Msg("[ui] path is not a directory")
+		return
+	}
+
+	log.Info().Str("dir", cfg.UI.Dir).Msg("[ui] serving extra UI")
+
+	prefix := cfg.Mod.BasePath + "/ui"
+	fs := http.FileServer(http.Dir(cfg.UI.Dir))
+	api.HandleFunc("ui/", http.StripPrefix(prefix+"/", fs).ServeHTTP)
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/internal/tapo"
 	"github.com/AlexxIT/go2rtc/internal/tuya"
+	"github.com/AlexxIT/go2rtc/internal/ui"
 	"github.com/AlexxIT/go2rtc/internal/v4l2"
 	"github.com/AlexxIT/go2rtc/internal/webrtc"
 	"github.com/AlexxIT/go2rtc/internal/webtorrent"
@@ -64,6 +65,7 @@ func main() {
 		{"", app.Init},    // init config and logs
 		{"api", api.Init}, // init API before all others
 		{"ws", ws.Init},   // init WS API endpoint
+		{"ui", ui.Init},   // extra static UI from mounted directory
 		{"", streams.Init},
 		// Main sources and servers
 		{"http", http.Init},     // rtsp source, HTTP server


### PR DESCRIPTION
This pull request adds support for serving an additional static web UI from a local directory, making it easier to provide custom web interfaces alongside the built-in HTTP API. The feature is configurable via `ui.dir`, includes Docker support, and is documented with usage and configuration details.

This approach makes it possible to host a custom UI alongside the Docker container without adding overhead or unnecessary complexity to the existing UI, which already fulfills its purpose well. It also creates room for parallel projects to build solutions and experiences that are better tailored to their specific needs without disrupting the current foundation. At the same time, it keeps those solutions straightforward to adopt and accessible to a broader audience.


**Extra UI feature:**

* Added a new `ui` module (`internal/ui/ui.go`) that serves static files from a configurable directory (`ui.dir`) at the `/ui/` path, with support for disabling or customizing the directory.
* Registered the `ui` module in the application startup sequence (`main.go`) so it is initialized with other modules. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R44) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R68)

**Documentation updates:**

* Updated `README.md` to document the new Extra UI feature, including configuration options and security notes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R164-R178)
* Added `ui` module to the list of modules/features in the summary table in `README.md`.
* Added a section to `docker/README.md` explaining how to mount a local directory for the extra UI in Docker deployments, with usage examples.