### PR TITLE
fix(api): add support for CORS preflight requests

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -211,6 +211,11 @@ func isLoopback(remoteAddr string) bool {
 
 func middlewareAuth(username, password string, localAuth bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "OPTIONS" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		if localAuth || !isLoopback(r.RemoteAddr) {
 			user, pass, ok := r.BasicAuth()
 			if !ok || user != username || pass != password {
@@ -229,6 +234,10 @@ func middlewareCORS(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		if r.Method == "OPTIONS" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
- handle OPTIONS method in middlewareAuth to allow preflight requests
- handle OPTIONS method in middlewareCORS to respond with no content
fix #2218