### PR TITLE
Add ONVIF authentication with UsernameToken support

### DIFF
--- a/internal/api/README.md
+++ b/internal/api/README.md
@@ -39,6 +39,16 @@ api:
   unix_listen: "/tmp/go2rtc.sock"  # default "", unix socket listener for API
 ```
 
+`/onvif/*` is not protected by `api.username` / `api.password`. Use the ONVIF module configuration for ONVIF authentication:
+
+```yaml
+onvif:
+  username: "admin"
+  password: "pass"
+```
+
+Note that some ONVIF clients require the RTSP username and password to be the same.
+
 **PS:**
 
 - MJPEG over WebSocket plays better than native MJPEG because Chrome [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=527446)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -211,6 +211,11 @@ func isLoopback(remoteAddr string) bool {
 
 func middlewareAuth(username, password string, localAuth bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/onvif/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		if localAuth || !isLoopback(r.RemoteAddr) {
 			user, pass, ok := r.BasicAuth()
 			if !ok || user != username || pass != password {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddlewareAuthSkipsOnvifPath(t *testing.T) {
+	h := middlewareAuth("admin", "pass", true, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/onvif/device_service", nil)
+	req.RemoteAddr = "203.0.113.10:12345"
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestMiddlewareAuthProtectsAPIPath(t *testing.T) {
+	h := middlewareAuth("admin", "pass", true, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/api", nil)
+	req.RemoteAddr = "203.0.113.10:12345"
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+}

--- a/internal/onvif/README.md
+++ b/internal/onvif/README.md
@@ -21,6 +21,16 @@ A regular camera has a single video source (`GetVideoSources`) and two profiles 
 
 Go2rtc has one video source and one profile per stream.
 
+You can protect the ONVIF SOAP service independently from the Web API:
+
+```yaml
+onvif:
+  username: "admin"
+  password: "pass"
+```
+
+This uses WS-Security `UsernameToken` authentication for ONVIF SOAP requests. `GetSystemDateAndTime` stays available without authentication so clients can calculate clock offset before sending password digests.
+
 ## Tested clients
 
 Go2rtc works as ONVIF server:

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -22,6 +22,16 @@ import (
 func Init() {
 	log = app.GetLogger("onvif")
 
+	var cfg struct {
+		Mod struct {
+			Username string `yaml:"username"`
+			Password string `yaml:"password"`
+		} `yaml:"onvif"`
+	}
+	app.LoadConfig(&cfg)
+	authUsername = cfg.Mod.Username
+	authPassword = cfg.Mod.Password
+
 	streams.HandleFunc("onvif", streamOnvif)
 
 	// ONVIF server on all suburls
@@ -32,6 +42,8 @@ func Init() {
 }
 
 var log zerolog.Logger
+var authUsername string
+var authPassword string
 
 func streamOnvif(rawURL string) (core.Producer, error) {
 	client, err := onvif.NewClient(rawURL)
@@ -72,6 +84,14 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Trace().Msgf("[onvif] server request %s %s:\n%s", r.Method, r.RequestURI, b)
+
+	if authUsername != "" && operation != onvif.DeviceGetSystemDateAndTime {
+		if !onvif.ValidateUsernameToken(b, authUsername, authPassword, time.Now(), onvif.DefaultUsernameTokenAge) {
+			log.Debug().Str("addr", r.RemoteAddr).Str("operation", operation).Msg("[onvif] auth failed")
+			api.Response(w, onvif.NotAuthorizedResponse(), "application/soap+xml; charset=utf-8")
+			return
+		}
+	}
 
 	switch operation {
 	case onvif.ServiceGetServiceCapabilities, // important for Hass

--- a/pkg/onvif/auth.go
+++ b/pkg/onvif/auth.go
@@ -1,0 +1,96 @@
+package onvif
+
+import (
+	"crypto/sha1"
+	"crypto/subtle"
+	"encoding/base64"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	UsernameTokenPasswordDigest = "#PasswordDigest"
+	UsernameTokenPasswordText   = "#PasswordText"
+
+	DefaultUsernameTokenAge = 5 * time.Minute
+)
+
+type UsernameToken struct {
+	Username     string
+	Password     string
+	PasswordType string
+	Nonce        string
+	Created      string
+}
+
+func ParseUsernameToken(b []byte) *UsernameToken {
+	token := &UsernameToken{
+		Username: FindTagValue(b, "Username"),
+		Password: FindTagValue(b, "Password"),
+		Nonce:    FindTagValue(b, "Nonce"),
+		Created:  FindTagValue(b, "Created"),
+	}
+
+	re := regexp.MustCompile(`(?s)<(?:\w+:)?Password\b[^>]*\bType="([^"]+)"`)
+	m := re.FindSubmatch(b)
+	if len(m) == 2 {
+		token.PasswordType = string(m[1])
+	}
+
+	if token.Username == "" && token.Password == "" && token.Nonce == "" && token.Created == "" {
+		return nil
+	}
+
+	return token
+}
+
+func ValidateUsernameToken(b []byte, username, password string, now time.Time, maxAge time.Duration) bool {
+	token := ParseUsernameToken(b)
+	if token == nil || token.Username != username {
+		return false
+	}
+
+	return token.Validate(password, now, maxAge)
+}
+
+func (t *UsernameToken) Validate(password string, now time.Time, maxAge time.Duration) bool {
+	if t.Password == "" {
+		return false
+	}
+
+	if maxAge <= 0 {
+		maxAge = DefaultUsernameTokenAge
+	}
+
+	passwordType := t.PasswordType
+	if passwordType == "" || strings.HasSuffix(passwordType, UsernameTokenPasswordText) {
+		return subtle.ConstantTimeCompare([]byte(t.Password), []byte(password)) == 1
+	}
+
+	if !strings.HasSuffix(passwordType, UsernameTokenPasswordDigest) || t.Nonce == "" || t.Created == "" {
+		return false
+	}
+
+	created, err := time.Parse(time.RFC3339Nano, t.Created)
+	if err != nil {
+		return false
+	}
+
+	if created.Before(now.Add(-maxAge)) || created.After(now.Add(maxAge)) {
+		return false
+	}
+
+	nonce, err := base64.StdEncoding.DecodeString(t.Nonce)
+	if err != nil {
+		return false
+	}
+
+	h := sha1.New()
+	_, _ = h.Write(nonce)
+	_, _ = h.Write([]byte(t.Created))
+	_, _ = h.Write([]byte(password))
+
+	digest := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	return subtle.ConstantTimeCompare([]byte(t.Password), []byte(digest)) == 1
+}

--- a/pkg/onvif/auth_test.go
+++ b/pkg/onvif/auth_test.go
@@ -1,0 +1,24 @@
+package onvif
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateUsernameTokenDigest(t *testing.T) {
+	b := NewEnvelopeWithUser(url.UserPassword("admin", "pass")).Bytes()
+	require.True(t, ValidateUsernameToken(b, "admin", "pass", time.Now(), time.Minute))
+	require.False(t, ValidateUsernameToken(b, "admin", "wrong", time.Now(), time.Minute))
+	require.False(t, ValidateUsernameToken(b, "user", "pass", time.Now(), time.Minute))
+}
+
+func TestValidateUsernameTokenRequiresFreshNonceAndTimestamp(t *testing.T) {
+	b := []byte(`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:UsernameToken><wsse:Username>admin</wsse:Username><wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">digest</wsse:Password></wsse:UsernameToken></wsse:Security></s:Header><s:Body /></s:Envelope>`)
+	require.False(t, ValidateUsernameToken(b, "admin", "pass", time.Now(), time.Minute))
+
+	b = []byte(`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Header><wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsse:UsernameToken><wsse:Username>admin</wsse:Username><wsse:Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">digest</wsse:Password><wsse:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">bm9uY2U=</wsse:Nonce><wsu:Created xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">2000-01-01T00:00:00Z</wsu:Created></wsse:UsernameToken></wsse:Security></s:Header><s:Body /></s:Envelope>`)
+	require.False(t, ValidateUsernameToken(b, "admin", "pass", time.Now(), time.Minute))
+}

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -258,6 +258,22 @@ func StaticResponse(operation string) []byte {
 	return e.Bytes()
 }
 
+func NotAuthorizedResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<s:Fault>
+	<s:Code>
+		<s:Value>s:Sender</s:Value>
+		<s:Subcode>
+			<s:Value xmlns:ter="http://www.onvif.org/ver10/error">ter:NotAuthorized</s:Value>
+		</s:Subcode>
+	</s:Code>
+	<s:Reason>
+		<s:Text xml:lang="en">NotAuthorized</s:Text>
+	</s:Reason>
+</s:Fault>`)
+	return e.Bytes()
+}
+
 var responses = map[string]string{
 	ServiceGetServiceCapabilities: `<trt:GetServiceCapabilitiesResponse>
 	<trt:Capabilities SnapshotUri="true" Rotation="false" VideoSourceMode="false" OSD="false" TemporaryOSDText="false" EXICompression="false">


### PR DESCRIPTION
AI DISCLOSURE: This feature was so straightforward that I wanted to try using codex and as far as I can tell, it did quite well. I did review the changes before opening this PR and nothing really bad stuck out to me (some global vars but seems valid tbh).

## Summary
- stop applying `api.username` / `api.password` HTTP Basic auth to `/onvif/*` so ONVIF SOAP requests can reach the ONVIF handler
- add dedicated `onvif.username` / `onvif.password` config and validate WS-Security `UsernameToken` credentials inside the ONVIF service
- keep `GetSystemDateAndTime` unauthenticated and return an ONVIF-style `ter:NotAuthorized` SOAP fault when ONVIF auth fails

## Reasoning
External ONVIF clients such as ODM, NVRs, and VMS platforms typically authenticate with WS-Security `UsernameToken` in the SOAP header, not HTTP Basic auth. When go2rtc applies API Basic auth to the shared HTTP listener, those clients fail before the SOAP request can be processed.

This change separates the two auth layers:
- Web API remains protected by `api.username` / `api.password`
- ONVIF can be protected independently with WS-Security credentials
- `GetSystemDateAndTime` stays open because ONVIF clients commonly use it first to calculate clock skew before generating a valid password digest

## Sources
- ONVIF Core Specification: https://www.onvif.org/specs/2212/ONVIF-Core-Spec-v2212.pdf
- ONVIF Application Programmer's Guide: https://www.onvif.org/wp-content/uploads/2016/12/ONVIF_WG-APG-Application_Programmers_Guide-1.pdf
- OASIS WS-Security UsernameToken Profile 1.1.1: https://docs.oasis-open.org/wss-m/wss/v1.1.1/os/wss-UsernameTokenProfile-v1.1.1-os.html
- ONVIF Device Management WSDL: https://www.onvif.org/ver10/device/wsdl/devicemgmt.wsdl

## Testing
- `go test ./pkg/onvif ./internal/api ./internal/onvif`


closes #2148 