### PR TITLE
fix(rtmp): prevent index out of range panic in encodeFLV

### DIFF
--- a/pkg/rtmp/flv.go
+++ b/pkg/rtmp/flv.go
@@ -55,7 +55,7 @@ func (c *Conn) Read(p []byte) (n int, err error) {
 }
 
 func encodeFLV(b []byte, msgType byte, time uint32, payload []byte) {
-	_ = b[4+11]
+	_ = b[4+10] // bounds check hint to compiler; see golang.org/issue/14808
 
 	b[0] = 0
 	b[1] = 0


### PR DESCRIPTION
Closes #2061.

The compiler bounds-check hint at `pkg/rtmp/flv.go:58` asserted `b[15]` exists, but the buffer only needs to hold 15 bytes (4 prev-tag-size + 11 header) when the payload is empty, panicking with `index out of range [15] with length 15`. Lower the assertion to the last actually-written single byte (`b[14]`); the subsequent `copy(b[4+11:], payload)` is a no-op for empty payloads.