### PR TITLE
ci: weekly scheduled rebuild to refresh container base layers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
       - 'master'
     tags:
       - 'v*'
+  schedule:
+    # Weekly Sunday 04:00 UTC — rebuild master container images with fresh
+    # alpine base to pick up libssl/libxml2/etc fixes between tagged releases.
+    - cron: '0 4 * * 0'
 
 jobs:
   build-binaries:


### PR DESCRIPTION
### Motivation

The `alexxit/go2rtc:latest` and `ghcr.io/alexxit/go2rtc:master` container images currently rebuild only on `push` to `master` and on tag. Between tagged releases, the alpine base layer accumulates security fixes that aren't picked up.

Latest published image (`v1.9.14`, `2026-01-19`) scanned with trivy on `2026-05-02`:

| Severity | Count |
|---|---|
| CRITICAL | 4 |
| HIGH | 24 |

All findings are in alpine OS packages — none in go2rtc itself. Rebuilding the same `docker/Dockerfile` against current `python:3.13-alpine` reduces these to **0 HIGH/CRITICAL** without any source change.

### Change

Adds a `schedule:` trigger to the existing `Build and Push` workflow:

```yaml
on:
  workflow_dispatch:
  push:
    branches: ['master']
    tags: ['v*']
  schedule:
    - cron: '0 4 * * 0'   # Sunday 04:00 UTC
```

Existing jobs already use `--pull` semantics via `docker/build-push-action@v5` plus `cache-from: type=gha` / `cache-to: type=gha,mode=max`, so subsequent rebuilds are fast (only base layers re-pulled).

### Tradeoff

This also re-runs the `build-binaries` job weekly. If you'd rather isolate the docker rebuilds, I can split it into a separate `rebuild-containers.yml` workflow that calls only the three `docker-*` jobs — happy to switch to that pattern if preferred.

### Verified locally

`docker build --pull -t local/go2rtc:rebuilt -f docker/Dockerfile .` against current alpine + python:3.13 → 0 HIGH/CRITICAL OS CVEs.