### PR TITLE
fix(xiaomi): tune MISS startup for HLC9A cameras

### DIFF
--- a/internal/xiaomi/README.md
+++ b/internal/xiaomi/README.md
@@ -56,6 +56,14 @@ streams:
   xiaomi1: xiaomi://***&subtype=sd
 ```
 
+Some cameras report offline while waking from standby.
+Use `retries=4` to retry MISS startup before returning an error.
+
+```yaml
+streams:
+  xiaomi1: xiaomi://***&retries=4
+```
+
 You can use a second channel for dual cameras: `channel=2`.
 
 ```yaml

--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -139,6 +139,7 @@ const (
 	ModelLoockV2 = "loock.cateye.v02"
 	ModelC200    = "chuangmi.camera.046c04"
 	ModelC300    = "chuangmi.camera.72ac1"
+	ModelHLC9A   = "isa.camera.hlc9a"
 	// ModelXiaofang looks like it has the same firmware as the ModelDafang.
 	// There is also an older model "isa.camera.isc5" that only works with the legacy protocol.
 	ModelXiaofang = "isa.camera.isc5c1"
@@ -168,7 +169,7 @@ func (c *Client) StartMedia(channel, quality, audio string) error {
 		// Some models have low quality in quality 2.
 		// Different models require different default quality settings.
 		switch c.model {
-		case ModelC200, ModelC300:
+		case ModelC200, ModelC300, ModelHLC9A:
 			quality = "3"
 		default:
 			quality = "2"

--- a/pkg/xiaomi/miss/producer.go
+++ b/pkg/xiaomi/miss/producer.go
@@ -3,6 +3,7 @@ package miss
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -18,13 +19,33 @@ type Producer struct {
 }
 
 func Dial(rawURL string) (core.Producer, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	query := u.Query()
+
+	var lastErr error
+	attempts := dialAttempts(query)
+	for i := 0; i < attempts; i++ {
+		producer, err := dial(rawURL, query)
+		if err == nil {
+			return producer, nil
+		}
+		lastErr = err
+		if i+1 < attempts {
+			time.Sleep(time.Duration(i+1) * time.Second)
+		}
+	}
+
+	return nil, lastErr
+}
+
+func dial(rawURL string, query url.Values) (core.Producer, error) {
 	client, err := NewClient(rawURL)
 	if err != nil {
 		return nil, err
 	}
-
-	u, _ := url.Parse(rawURL)
-	query := u.Query()
 
 	err = client.StartMedia(query.Get("channel"), query.Get("subtype"), query.Get("audio"))
 	if err != nil {
@@ -50,6 +71,25 @@ func Dial(rawURL string) (core.Producer, error) {
 		},
 		client: client,
 	}, nil
+}
+
+func dialAttempts(query url.Values) int {
+	s := query.Get("retries")
+	if s == "" {
+		s = query.Get("retry")
+	}
+	if s == "" {
+		return 1
+	}
+
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return 1
+	}
+	if n > 5 {
+		return 5
+	}
+	return n
 }
 
 func probe(client *Client, audio bool) ([]*core.Media, error) {

--- a/pkg/xiaomi/miss/producer_test.go
+++ b/pkg/xiaomi/miss/producer_test.go
@@ -1,0 +1,53 @@
+package miss
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestDialAttempts(t *testing.T) {
+	tests := []struct {
+		name  string
+		query url.Values
+		want  int
+	}{
+		{
+			name:  "default",
+			query: url.Values{},
+			want:  1,
+		},
+		{
+			name:  "retries",
+			query: url.Values{"retries": {"4"}},
+			want:  4,
+		},
+		{
+			name:  "retry alias",
+			query: url.Values{"retry": {"3"}},
+			want:  3,
+		},
+		{
+			name:  "bounded maximum",
+			query: url.Values{"retries": {"9"}},
+			want:  5,
+		},
+		{
+			name:  "invalid",
+			query: url.Values{"retries": {"nope"}},
+			want:  1,
+		},
+		{
+			name:  "non-positive",
+			query: url.Values{"retries": {"0"}},
+			want:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dialAttempts(tt.query); got != tt.want {
+				t.Fatalf("dialAttempts() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- default `isa.camera.hlc9a` MISS streams to video quality `3`, matching the working profile observed on a real device
- add opt-in bounded MISS startup retries via `retries=` / `retry=` for cameras that initially report offline while waking from standby

## Validation

- `go test ./pkg/xiaomi/...`
- Live smoke on a Xiaomi `isa.camera.hlc9a`: a host-network go2rtc sidecar generated `subtype=3&retries=4`, then received video/audio packets from the camera over CS2 UDP after restart.
