### PR TITLE
ci: build permissions may write packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,8 @@ jobs:
 
   docker-master:
     name: Build docker master
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -171,6 +173,8 @@ jobs:
 
   docker-hardware:
     name: Build docker hardware
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -226,6 +230,8 @@ jobs:
 
   docker-rockchip:
     name: Build docker rockchip
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
When forking the repository to an organization or a recent personal GitHub account and building, there is an error due to lack of write permissions. Let's add appropriate permissions to permit writing packages into the repository.

Resolves: AlexxIT/go2rtc#2252