### PR TITLE
fix(iso): use hvc1 sample entry for H.265 fMP4

### DIFF
--- a/pkg/iso/codecs.go
+++ b/pkg/iso/codecs.go
@@ -11,7 +11,7 @@ func (m *Movie) WriteVideo(codec string, width, height uint16, conf []byte) {
 	case core.CodecH264:
 		m.StartAtom("avc1")
 	case core.CodecH265:
-		m.StartAtom("hev1")
+		m.StartAtom("hvc1")
 	default:
 		panic("unsupported iso video: " + codec)
 	}

--- a/pkg/iso/codecs_test.go
+++ b/pkg/iso/codecs_test.go
@@ -1,0 +1,38 @@
+package iso
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+func TestWriteVideoH265UsesHvc1SampleEntry(t *testing.T) {
+	const config = "h265 config"
+
+	m := NewMovie(128)
+	m.WriteVideo(core.CodecH265, 1920, 1080, []byte(config))
+
+	if bytes.Contains(m.Bytes(), []byte("hev1")) {
+		t.Fatalf("H265 video sample entry should not use hev1: %q", m.Bytes())
+	}
+	if !bytes.Contains(m.Bytes(), []byte("hvc1")) {
+		t.Fatalf("H265 video sample entry should use hvc1: %q", m.Bytes())
+	}
+
+	atom, err := DecodeAtom(m.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	video, ok := atom.(*AtomVideo)
+	if !ok {
+		t.Fatalf("expected AtomVideo, got %T", atom)
+	}
+	if video.Name != "hvc1" {
+		t.Fatalf("expected hvc1 sample entry, got %q", video.Name)
+	}
+	if string(video.Config) != config {
+		t.Fatalf("expected config %q, got %q", config, video.Config)
+	}
+}

--- a/pkg/iso/reader.go
+++ b/pkg/iso/reader.go
@@ -86,7 +86,7 @@ func DecodeAtom(b []byte) (any, error) {
 			return DecodeAtom(data[1+3+4:])
 		}
 
-	case "avc1", "hev1":
+	case "avc1", "hev1", "hvc1":
 		b = data[6+2+2+2+4+4+4+2+2+4+4+4+2+32+2+2:]
 		atom, err := DecodeAtom(b)
 		if err != nil {


### PR DESCRIPTION
## Summary

- write H.265 fMP4 video sample entries as `hvc1` instead of `hev1`
- keep ISO parsing compatible with existing `hev1` entries while adding `hvc1` support
- add regression coverage for H.265 sample entry generation and decoding

## Root cause

go2rtc advertises H.265 MSE streams with an `hvc1` codec string, but the fMP4 init segment was written with an `hev1` sample entry. Some browsers reject that mismatch when creating or appending to the MSE SourceBuffer.

## Validation

- `GOCACHE=/private/tmp/go-build-cache GOPATH=/private/tmp/go-path go test ./pkg/iso`

Fixes #2205