### PR TITLE
xiaomi: add cs2 cloud-relay handshake

### DIFF
--- a/internal/xiaomi/xiaomi.go
+++ b/internal/xiaomi/xiaomi.go
@@ -149,6 +149,12 @@ func getLegacyURL(url *url.URL) (string, error) {
 	return url.String(), nil
 }
 
+// cs2CloudRelayHost is the Mi-Cloud relay endpoint used by cs2 cameras
+// that do not expose port 32108 on the LAN (e.g. xiaomi.camera.c302n).
+// One of a small published pool of Alibaba Cloud addresses; a future
+// improvement could derive the right one from the p2p_id region prefix.
+const cs2CloudRelayHost = "47.236.156.107"
+
 func getMissURL(url *url.URL) (string, error) {
 	clientPublic, clientPrivate, err := crypto.GenerateKey()
 	if err != nil {
@@ -191,6 +197,17 @@ func getMissURL(url *url.URL) (string, error) {
 
 	if v.Vendor.ID == 1 {
 		query.Set("uid", v.Vendor.Params.UID)
+	}
+
+	// cs2 cloud-relay mode: cameras of the MJA1-secure-element generation
+	// (e.g. xiaomi.camera.c302n) cannot be reached on the LAN port — they
+	// only stream via the Mi-Cloud relay. Pass the p2p_id through and
+	// redirect the host to the relay; the miss client picks this up and
+	// runs the cloud handshake.
+	if v.Vendor.ID == 4 && v.Vendor.Params.UID != "" {
+		query.Set("p2p_id", v.Vendor.Params.UID)
+		log.Debug().Msgf("xiaomi: cs2 cloud-relay mode, redirecting to %s", cs2CloudRelayHost)
+		url.Host = cs2CloudRelayHost
 	}
 
 	url.RawQuery = query.Encode()

--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -55,7 +55,14 @@ func NewClient(rawURL string) (*Client, error) {
 	var conn Conn
 	switch s := query.Get("vendor"); s {
 	case "cs2":
-		conn, err = cs2.Dial(u.Host, query.Get("transport"))
+		// If a p2p_id is present, the camera only reachable via the
+		// Mi-Cloud relay (typical for MJA1-secure-element cameras such
+		// as the c302n). Otherwise fall back to the direct LAN handshake.
+		if p2pID := query.Get("p2p_id"); p2pID != "" {
+			conn, err = cs2.DialCloud(p2pID, u.Host)
+		} else {
+			conn, err = cs2.Dial(u.Host, query.Get("transport"))
+		}
 	case "tutk":
 		conn, err = tutk.Dial(u.Host, query.Get("uid"), "Miss", "client")
 	default:

--- a/pkg/xiaomi/miss/cs2/conn.go
+++ b/pkg/xiaomi/miss/cs2/conn.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,6 +33,407 @@ func Dial(host, transport string) (*Conn, error) {
 	return c, nil
 }
 
+// DialCloud establishes a cs2 connection via Mi-Cloud relay (UDP/32100)
+// using NAT hole-punching. Required for cameras that do not expose the
+// LAN port 32108 directly — typically the MJA1-secure-element generation
+// of Xiaomi cameras (e.g. xiaomi.camera.c302n, xiaomi.camera.cw701,
+// isa.camera.hlc7), which only stream via Mi-Cloud.
+//
+// p2pID is the device identifier from the Mi-Cloud vendor_params,
+// of the form "PREFIX-NUM-SUFFIX" (e.g. "ABCDEF-123456-GHIJK").
+// relayHost is the Mi-Cloud relay IP (one of the published Alibaba Cloud
+// pool addresses, e.g. 47.236.156.107, 47.88.30.183, 47.88.30.225).
+func DialCloud(p2pID, relayHost string) (*Conn, error) {
+	conn, err := cloudHandshake(p2pID, relayHost)
+	if err != nil {
+		return nil, err
+	}
+
+	_, isTCP := conn.(*tcpConn)
+
+	c := &Conn{
+		Conn:  conn,
+		isTCP: isTCP,
+		channels: [4]*dataChannel{
+			newDataChannel(0, 10), nil, newDataChannel(250, 100), nil,
+		},
+	}
+	go c.worker()
+	return c, nil
+}
+
+// cs2CryptoKey is the universal key string used by the CS2-Network
+// P2P_Proprietary_Encrypt cipher, extracted from camera firmware
+// disassembly. The same constant is found in cameras of multiple
+// vendors that license the CS2-Network SDK (see e.g. the VStarcam
+// reverse engineering by BrownFineSecurity).
+const cs2CryptoKey = "SSD@cs2-network."
+
+// cs2LookupTable is the 256-byte permutation used by the CS2-Network
+// cipher. Identical to the table observed in VStarcam firmware.
+var cs2LookupTable = [256]byte{
+	0x7c, 0x9c, 0xe8, 0x4a, 0x13, 0xde, 0xdc, 0xb2, 0x2f, 0x21, 0x23, 0xe4, 0x30, 0x7b, 0x3d, 0x8c,
+	0xbc, 0x0b, 0x27, 0x0c, 0x3c, 0xf7, 0x9a, 0xe7, 0x08, 0x71, 0x96, 0x00, 0x97, 0x85, 0xef, 0xc1,
+	0x1f, 0xc4, 0xdb, 0xa1, 0xc2, 0xeb, 0xd9, 0x01, 0xfa, 0xba, 0x3b, 0x05, 0xb8, 0x15, 0x87, 0x83,
+	0x28, 0x72, 0xd1, 0x8b, 0x5a, 0xd6, 0xda, 0x93, 0x58, 0xfe, 0xaa, 0xcc, 0x6e, 0x1b, 0xf0, 0xa3,
+	0x88, 0xab, 0x43, 0xc0, 0x0d, 0xb5, 0x45, 0x38, 0x4f, 0x50, 0x22, 0x66, 0x20, 0x7f, 0x07, 0x5b,
+	0x14, 0x98, 0x1d, 0x9b, 0xa7, 0x2a, 0xb9, 0xa8, 0xcb, 0xf1, 0xfc, 0x49, 0x47, 0x06, 0x3e, 0xb1,
+	0x0e, 0x04, 0x3a, 0x94, 0x5e, 0xee, 0x54, 0x11, 0x34, 0xdd, 0x4d, 0xf9, 0xec, 0xc7, 0xc9, 0xe3,
+	0x78, 0x1a, 0x6f, 0x70, 0x6b, 0xa4, 0xbd, 0xa9, 0x5d, 0xd5, 0xf8, 0xe5, 0xbb, 0x26, 0xaf, 0x42,
+	0x37, 0xd8, 0xe1, 0x02, 0x0a, 0xae, 0x5f, 0x1c, 0xc5, 0x73, 0x09, 0x4e, 0x69, 0x24, 0x90, 0x6d,
+	0x12, 0xb3, 0x19, 0xad, 0x74, 0x8a, 0x29, 0x40, 0xf5, 0x2d, 0xbe, 0xa5, 0x59, 0xe0, 0xf4, 0x79,
+	0xd2, 0x4b, 0xce, 0x89, 0x82, 0x48, 0x84, 0x25, 0xc6, 0x91, 0x2b, 0xa2, 0xfb, 0x8f, 0xe9, 0xa6,
+	0xb0, 0x9e, 0x3f, 0x65, 0xf6, 0x03, 0x31, 0x2e, 0xac, 0x0f, 0x95, 0x2c, 0x5c, 0xed, 0x39, 0xb7,
+	0x33, 0x6c, 0x56, 0x7e, 0xb4, 0xa0, 0xfd, 0x7a, 0x81, 0x53, 0x51, 0x86, 0x8d, 0x9f, 0x77, 0xff,
+	0x6a, 0x80, 0xdf, 0xe2, 0xbf, 0x10, 0xd7, 0x75, 0x64, 0x57, 0x76, 0xf3, 0x55, 0xcd, 0xd0, 0xc8,
+	0x18, 0xe6, 0x36, 0x41, 0x62, 0xcf, 0x99, 0xf2, 0x32, 0x4c, 0x67, 0x60, 0x61, 0x92, 0xca, 0xd3,
+	0xea, 0x63, 0x7d, 0x16, 0xb6, 0x8e, 0xd4, 0x68, 0x35, 0xc3, 0x52, 0x9d, 0x46, 0x44, 0x1e, 0x17,
+}
+
+// deriveCryptoKey returns the 4-byte stream-cipher state derived from a
+// key string. Mirrors the SDK's key-schedule (truncated at 20 bytes).
+func deriveCryptoKey(key []byte) [4]byte {
+	var c [4]byte
+	n := len(key)
+	if n > 20 {
+		n = 20
+	}
+	for i := 0; i < n; i++ {
+		b := key[i]
+		c[0] += b
+		c[1] -= b
+		c[2] += b / 3
+		c[3] ^= b
+	}
+	return c
+}
+
+// selectTableElement returns the keystream byte for the given previous
+// ciphertext byte: table[(prev + c_key[prev & 3]) & 0xff].
+func selectTableElement(c [4]byte, prev byte) byte {
+	return cs2LookupTable[byte(prev+c[prev&3])]
+}
+
+// encryptP2P applies the CS2-Network P2P_Proprietary_Encrypt cipher
+// to plaintext. The cipher is a stream cipher with previous-ciphertext-byte
+// feedback; the same routine decrypts when fed ciphertext, because the
+// feedback variable always reads from the cipher side.
+func encryptP2P(plain []byte) []byte {
+	c := deriveCryptoKey([]byte(cs2CryptoKey))
+	out := make([]byte, len(plain))
+	var prev byte = 0
+	for i, p := range plain {
+		out[i] = p ^ selectTableElement(c, prev)
+		prev = out[i]
+	}
+	return out
+}
+
+// buildP2PIDBlock encodes a p2p_id string of the form "PREFIX-NUM-SUFFIX"
+// into the 20-byte canonical block used by 0x20 (connect) and 0x41 (punch):
+//
+//	[ 0.. 5] prefix (6 bytes, null-padded)  e.g. "ABCDEF"
+//	[ 6.. 7] padding 0x00 0x00
+//	[ 8..11] num (uint32 big-endian)        e.g. 123456 -> 0x0001E240
+//	[12..16] suffix (5 bytes, null-padded)  e.g. "GHIJK"
+//	[17..19] padding 0x00 0x00 0x00
+func buildP2PIDBlock(p2pID string) ([]byte, error) {
+	parts := strings.Split(p2pID, "-")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("cs2 cloud: invalid p2p_id format: %s", p2pID)
+	}
+	prefix := parts[0]
+	numStr := parts[1]
+	suffix := parts[2]
+
+	if len(prefix) > 6 {
+		return nil, fmt.Errorf("cs2 cloud: p2p_id prefix too long: %s", prefix)
+	}
+	if len(suffix) > 5 {
+		return nil, fmt.Errorf("cs2 cloud: p2p_id suffix too long: %s", suffix)
+	}
+
+	num, err := strconv.ParseUint(numStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("cs2 cloud: invalid p2p_id num %q: %w", numStr, err)
+	}
+
+	block := make([]byte, 20)
+	copy(block[0:6], []byte(prefix))
+	binary.BigEndian.PutUint32(block[8:12], uint32(num))
+	copy(block[12:17], []byte(suffix))
+	return block, nil
+}
+
+// buildCloudConnect builds the 0x20 connect-request message (40 bytes total:
+// 4-byte header + 36-byte payload, made of the 20-byte p2p_id block and a
+// 16-byte nonce/timestamp tail).
+func buildCloudConnect(p2pID string) ([]byte, error) {
+	block, err := buildP2PIDBlock(p2pID)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := make([]byte, 36)
+	copy(payload[0:20], block)
+	binary.BigEndian.PutUint32(payload[22:26], uint32(time.Now().Unix()))
+
+	msg := make([]byte, 4+36)
+	msg[0] = magic
+	msg[1] = msgCloudConnect
+	binary.BigEndian.PutUint16(msg[2:4], 36)
+	copy(msg[4:], payload)
+	return msg, nil
+}
+
+// buildCloudPunch builds the 0x41 (msgPunchPkt) frame with the 20-byte
+// p2p_id block as payload. In cloud-relay mode the camera silently drops
+// the empty 4-byte punch used by the LAN handshake and only responds when
+// the punch frame carries the p2p_id block (so the cam can identify which
+// session the punch belongs to).
+func buildCloudPunch(p2pID string) ([]byte, error) {
+	block, err := buildP2PIDBlock(p2pID)
+	if err != nil {
+		return nil, err
+	}
+
+	msg := make([]byte, 4+20)
+	msg[0] = magic
+	msg[1] = msgPunchPkt
+	binary.BigEndian.PutUint16(msg[2:4], 20)
+	copy(msg[4:], block)
+	return msg, nil
+}
+
+// cloudAuthUnknownBlock is the 16-byte payload at plaintext offset 20-35
+// of the 0xF9 auth message. Captured verbatim from a Mi-Home iOS
+// handshake; the byte pattern (sparse, small values) looks like protocol
+// flags or channel constants rather than client-specific data, and
+// transmitting it verbatim works against the relay and camera. Zeroing
+// this block caused the camera to silently drop subsequent punch packets.
+// Values not verified against a second account; treat as opaque.
+var cloudAuthUnknownBlock = [16]byte{
+	0x00, 0x00, 0x00, 0x06, 0x00, 0x14, 0x00, 0x01,
+	0x00, 0x88, 0x00, 0x00, 0x7a, 0x00, 0x00, 0x00,
+}
+
+// buildCloudAuth builds the 0xF9 session-auth message (88 bytes total)
+// by encrypting an 84-byte plaintext that carries the device_uid block,
+// an opaque flags block and the client's own UDP address.
+//
+// Plaintext layout (84 bytes, verified by decrypting a captured 0xF9):
+//
+//	[ 0..19] device_uid     = encoded p2p_id (prefix + num_be + suffix)
+//	[20..35] unknown        = 16-byte opaque flags/counter block
+//	[36..51] local_address  = Xiaomi sockaddr-style: 2B family (00 00) +
+//	                          2B port LE + 4B ipv4 reverse-LE + 8B pad
+//	[52..67] wan_address    = same format; equal to local when the client
+//	                          sits on a public IP without NAT
+//	[68..83] device_address = zeros (the camera-side LAN address is
+//	                          unknown to us; the relay reports the cam's
+//	                          WAN address back in its 0x40 reply anyway)
+//
+// Zero-filling everything past device_uid produces a working relay
+// response (0x21 ACK, 0x40 punch info) but the camera then ignores
+// punches — likely because the cam validates the addresses against
+// the source it sees on subsequent packets.
+func buildCloudAuth(p2pID string, localIP net.IP, localPort uint16) ([]byte, error) {
+	uidBlock, err := buildP2PIDBlock(p2pID)
+	if err != nil {
+		return nil, err
+	}
+
+	plain := make([]byte, 84)
+	copy(plain[0:20], uidBlock)
+	copy(plain[20:36], cloudAuthUnknownBlock[:])
+
+	if v4 := localIP.To4(); v4 != nil && localPort != 0 {
+		// local_addr [36..51]
+		binary.LittleEndian.PutUint16(plain[38:40], localPort)
+		plain[40] = v4[3]
+		plain[41] = v4[2]
+		plain[42] = v4[1]
+		plain[43] = v4[0]
+		// wan_addr [52..67] — identical to local for clients without
+		// a NAT layer in front (e.g. a server with a public IP).
+		binary.LittleEndian.PutUint16(plain[54:56], localPort)
+		plain[56] = v4[3]
+		plain[57] = v4[2]
+		plain[58] = v4[1]
+		plain[59] = v4[0]
+	}
+
+	cipher := encryptP2P(plain)
+
+	msg := make([]byte, 4+len(cipher))
+	msg[0] = magic
+	msg[1] = msgCloudAuth
+	binary.BigEndian.PutUint16(msg[2:4], uint16(len(cipher)))
+	copy(msg[4:], cipher)
+	return msg, nil
+}
+
+// detectOutboundIP returns the local IPv4 address the OS would use to
+// reach dest. Uses Go's UDP-dial trick — no packet is sent, only the
+// routing table is consulted. Returns nil on error, in which case
+// buildCloudAuth leaves the address fields zeroed.
+func detectOutboundIP(dest string) net.IP {
+	conn, err := net.Dial("udp", net.JoinHostPort(dest, "1"))
+	if err != nil {
+		return nil
+	}
+	defer conn.Close()
+	if u, ok := conn.LocalAddr().(*net.UDPAddr); ok {
+		return u.IP
+	}
+	return nil
+}
+
+// cloudHandshake performs the cs2 cloud-relay handshake against the
+// Mi-Cloud relay at relayHost:32100. Steps:
+//
+//  1. Send 0x20 (connect request) and 0xF9 (encrypted session auth) to
+//     the relay; the relay replies with 0x21 (ACK) and 0x40 (NAT-punch
+//     info containing the camera's external address).
+//  2. Switch the UDP socket's remote to the camera's address from 0x40
+//     and send 0x41 (msgPunchPkt) carrying the p2p_id block.
+//  3. Wait for 0x42 (P2P-ready UDP) from the camera and return.
+//
+// Cloud mode is UDP-only: TCP would require TCP hole-punching from both
+// sides, which is not feasible behind typical NATs.
+func cloudHandshake(p2pID, relayHost string) (net.Conn, error) {
+	udp, err := newUDPConn(relayHost, 32100)
+	if err != nil {
+		return nil, err
+	}
+
+	uc := udp.(*udpConn)
+
+	// Determine our own outbound IP + the ephemeral UDP port the socket
+	// bound to. These end up in the 0xF9 auth payload; the camera
+	// validates them against the source address it sees on subsequent
+	// packets and silently drops punches if they are zero-filled.
+	var localPort uint16
+	if la, ok := uc.UDPConn.LocalAddr().(*net.UDPAddr); ok {
+		localPort = uint16(la.Port)
+	}
+	localIP := detectOutboundIP(relayHost)
+
+	req20, err := buildCloudConnect(p2pID)
+	if err != nil {
+		_ = udp.Close()
+		return nil, err
+	}
+	reqF9, err := buildCloudAuth(p2pID, localIP, localPort)
+	if err != nil {
+		_ = udp.Close()
+		return nil, err
+	}
+
+	// Send 0x20, briefly wait, then 0xF9. This pacing mirrors the
+	// official Mi Home app's handshake timing observed in captures.
+	if _, err = uc.Write(req20); err != nil {
+		_ = udp.Close()
+		return nil, fmt.Errorf("cs2 cloud: send 0x20: %w", err)
+	}
+	time.Sleep(130 * time.Millisecond)
+	if _, err = uc.Write(reqF9); err != nil {
+		_ = udp.Close()
+		return nil, fmt.Errorf("cs2 cloud: send 0xF9: %w", err)
+	}
+
+	// Wait for 0x40 (NAT-punch info). Re-send the connect+auth pair
+	// every 2 s in case packets were dropped.
+	buf := make([]byte, 1500)
+	var natInfo []byte
+	deadline := time.Now().Add(15 * time.Second)
+	lastResend := time.Now()
+
+	for natInfo == nil {
+		if time.Now().After(deadline) {
+			_ = udp.Close()
+			return nil, fmt.Errorf("cs2 cloud: timeout waiting for 0x40 NAT-punch info")
+		}
+		if time.Since(lastResend) > 2*time.Second {
+			_, _ = uc.Write(req20)
+			time.Sleep(130 * time.Millisecond)
+			_, _ = uc.Write(reqF9)
+			lastResend = time.Now()
+		}
+
+		_ = uc.UDPConn.SetReadDeadline(time.Now().Add(1 * time.Second))
+		n, _, err := uc.UDPConn.ReadFromUDP(buf)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			_ = udp.Close()
+			return nil, fmt.Errorf("cs2 cloud: read relay: %w", err)
+		}
+
+		if n < 4 || buf[0] != magic {
+			continue
+		}
+
+		switch buf[1] {
+		case msgCloudAck: // 0x21 — connect was accepted; keep waiting for 0x40
+			continue
+		case msgNatPunch: // 0x40 — got camera NAT info
+			natInfo = make([]byte, n)
+			copy(natInfo, buf[:n])
+		}
+	}
+
+	// 0x40 payload layout: [F1 40 00 10] [flags:2] [port:2 LE] [ip:4 LE] ...
+	// IP and port are little-endian; reading them big-endian silently
+	// sends the punch to a wrong host.
+	if len(natInfo) < 12 {
+		_ = udp.Close()
+		return nil, fmt.Errorf("cs2 cloud: 0x40 too short (%d bytes)", len(natInfo))
+	}
+	camPort := binary.LittleEndian.Uint16(natInfo[6:8])
+	camIP := net.IPv4(natInfo[11], natInfo[10], natInfo[9], natInfo[8])
+	camAddr := &net.UDPAddr{IP: camIP, Port: int(camPort)}
+
+	// Re-target the UDP socket at the camera's NAT-punched address and
+	// send the p2p_id-carrying punch frame.
+	uc.addr = camAddr
+	_ = uc.UDPConn.SetReadDeadline(time.Time{})
+	_ = udp.SetDeadline(time.Now().Add(15 * time.Second))
+
+	punch, err := buildCloudPunch(p2pID)
+	if err != nil {
+		_ = udp.Close()
+		return nil, err
+	}
+
+	// Accept any of: P2P-ready (good), or punch echoed back (cam
+	// acknowledges and keeps punching). msgP2PRdyTCP also unblocks the
+	// loop but we stay on UDP regardless (TCP through NAT is not viable).
+	res, err := uc.WriteUntil(punch, func(res []byte) bool {
+		return res[1] == msgP2PRdyUDP || res[1] == msgP2PRdyTCP || res[1] == msgPunchPkt
+	})
+	if err != nil {
+		_ = udp.Close()
+		return nil, fmt.Errorf("cs2 cloud: punch to cam: %w", err)
+	}
+
+	// If the camera echoed the punch back, keep punching until we get
+	// an actual P2P-ready signal.
+	if res[1] == msgPunchPkt {
+		_, err = uc.WriteUntil(res, func(res []byte) bool {
+			return res[1] == msgP2PRdyUDP || res[1] == msgP2PRdyTCP
+		})
+		if err != nil {
+			_ = udp.Close()
+			return nil, fmt.Errorf("cs2 cloud: wait p2p ready: %w", err)
+		}
+	}
+
+	_ = udp.SetDeadline(time.Time{})
+	return udp, nil
+}
+
 type Conn struct {
 	net.Conn
 	isTCP bool
@@ -46,19 +449,23 @@ type Conn struct {
 }
 
 const (
-	magic        = 0xF1
-	magicDrw     = 0xD1
-	magicTCP     = 0x68
-	msgLanSearch = 0x30
-	msgPunchPkt  = 0x41
-	msgP2PRdyUDP = 0x42
-	msgP2PRdyTCP = 0x43
-	msgDrw       = 0xD0
-	msgDrwAck    = 0xD1
-	msgPing      = 0xE0
-	msgPong      = 0xE1
-	msgClose     = 0xF0
-	msgCloseAck  = 0xF1
+	magic           = 0xF1
+	magicDrw        = 0xD1
+	magicTCP        = 0x68
+	msgCloudConnect = 0x20 // cs2 cloud-relay: client -> relay, session request via p2p_id
+	msgCloudAck     = 0x21 // cs2 cloud-relay: relay -> client, ACK for 0x20
+	msgLanSearch    = 0x30
+	msgNatPunch     = 0x40 // cs2 cloud-relay: relay -> peer, NAT-punch addresses
+	msgPunchPkt     = 0x41
+	msgP2PRdyUDP    = 0x42
+	msgP2PRdyTCP    = 0x43
+	msgDrw          = 0xD0
+	msgDrwAck       = 0xD1
+	msgPing         = 0xE0
+	msgPong         = 0xE1
+	msgClose        = 0xF0
+	msgCloseAck     = 0xF1
+	msgCloudAuth    = 0xF9 // cs2 cloud-relay: client -> relay, encrypted session auth
 )
 
 func handshake(host, transport string) (net.Conn, error) {


### PR DESCRIPTION
**TL;DR:** Adds cs2 **cloud-relay** support so that Xiaomi cameras of
the MJA1-secure-element generation (e.g. `c302n`, `cw701`, `hlc7`) —
which don't expose any LAN port — can be streamed by go2rtc. Until now
those cameras showed up online but never delivered video (#1982).
Tested live on a single C302n.

> **Heads-up to maintainers:** I'm posting this as a one-shot
> contribution. I won't be available to iterate on review feedback —
> if changes are needed, the branch is here for anyone to take over
> and resubmit. The patch has run continuously on a small VPS for the
> past day without issues.

## Summary

Adds a cloud-relay handshake for cs2 cameras that don't expose port 32108
on the LAN. This applies to the MJA1-secure-element generation of Xiaomi
cameras (e.g. `xiaomi.camera.c302n`, `xiaomi.camera.cw701`,
`isa.camera.hlc7`) which never put themselves on the LAN — they only
stream via the Mi-Cloud relay with NAT hole-punching.

Without this, the existing `cs2.Dial` path silently fails with a
`miss_get_vendor` returning `vendor=cs2` and a `p2p_id`, but no LAN port
to dial against. With this PR, presence of `p2p_id` switches the miss
client to a relay handshake against the Mi-Cloud servers, after which
video flows directly camera ↔ go2rtc (the relay drops out post-punch).

Resolves the "camera online but no video" symptom reported in:
- #1982 — multiple users on c302/c302n/cw701/CW400
- Related miloco-side issues: XiaoMi/xiaomi-miloco#189, #243, #254, #255

## Protocol

The cs2 cloud-relay protocol speaks UDP/32100 to a small pool of
Alibaba Cloud relay addresses (e.g. `47.236.156.107`, `47.88.30.183`,
`47.88.30.225`):

1. Client → relay: `0x20` connect request, carrying the device's
   `p2p_id` block (6-byte prefix + uint32 BE + 5-byte suffix).
2. Client → relay: `0xF9` session auth, 84 bytes encrypted with the
   CS2-Network `P2P_Proprietary_Encrypt` cipher (see crypto notes).
3. Relay → client: `0x21` ACK, then `0x40` NAT-punch info containing
   the camera's external IP and port (**little-endian** in the payload
   — big-endian misreads silently drop the punch).
4. Client → camera: `0x41` (`msgPunchPkt`) carrying the `p2p_id` block.
   The cloud variant rejects the empty 4-byte punch used by the LAN
   handshake; it needs the block so it can identify the session.
5. Camera → client: `0x42` P2P-ready UDP. From here the existing
   `cs2.Conn.worker()` takes over and the relay is no longer involved.

TCP mode is not implemented for cloud-relay — TCP hole-punching from
both sides is not viable behind typical NATs, so we stay on UDP.

## Crypto

`0xF9` is encrypted with the CS2-Network SDK's `P2P_Proprietary_Encrypt`
routine: a stream cipher with previous-ciphertext-byte feedback,
keyed by a 4-byte state derived from the key string
`"SSD@cs2-network."` over a fixed 256-byte lookup table.

This algorithm and lookup table are public — they were originally
reverse-engineered from VStarcam firmware
(see [BrownFineSecurity/vstarcam-p2p-decrypt][bfs]) and the same
constants appear in cameras from multiple vendors that license the
CS2-Network SDK, including Xiaomi's `libmiot_camera_lite.so` (where
the key string is loaded by all 12 call-sites to the encrypt routine).

The 84-byte plaintext is laid out as:

- `[ 0..19]` `device_uid` — encoded p2p_id (prefix + num_be + suffix)
- `[20..35]` 16-byte opaque flags/counter block, captured verbatim
  from a Mi-Home iOS handshake (sparse byte pattern, looks like
  protocol constants rather than session-specific data; treat as
  opaque)
- `[36..51]` `local_address` — Xiaomi sockaddr-style: `2B family (00 00)`
  + `2B port LE` + `4B ipv4 reverse-LE` + `8B pad`. Filled with the
  client's own outbound IP and ephemeral UDP port (auto-detected via
  a Go UDP-dial trick — no packet sent, just a routing-table lookup)
- `[52..67]` `wan_address` — same wire format; equal to `local_address`
  for clients on a public IP without NAT
- `[68..83]` `device_address` — zeros (the camera's LAN address is
  not known to us; the relay reports the cam's WAN address back in
  its `0x40` reply anyway)

The camera *does* validate these address fields against the source
address it sees on subsequent packets — zero-filling everything past
`device_uid` produces an apparently successful relay response
(`0x21` ACK + `0x40` punch info) but the camera then silently drops
all incoming punches. Filling `local_address` / `wan_address` with
the actual client UDP socket address makes the cam accept the session
and reply to punches.

The 16-byte opaque block has not been verified against a second
account/device — feedback welcome if anyone observes this needing
adjustment on different cameras.

## Changes

- `internal/xiaomi/xiaomi.go` — when `miss_get_vendor` returns
  `vendor=cs2` (ID 4) with a `p2p_id`, pass that `p2p_id` to the miss
  client and redirect the URL host to the Mi-Cloud relay.
- `pkg/xiaomi/miss/client.go` — `NewClient` branches the `cs2` vendor:
  if a `p2p_id` is in the URL query, run the cloud handshake
  (`cs2.DialCloud`); otherwise the existing LAN `cs2.Dial`.
- `pkg/xiaomi/miss/cs2/conn.go` — adds `DialCloud`, `cloudHandshake`,
  the four message builders (`buildP2PIDBlock`, `buildCloudConnect`,
  `buildCloudPunch`, `buildCloudAuth`), the four cloud message
  constants (`msgCloudConnect`, `msgCloudAck`, `msgNatPunch`,
  `msgCloudAuth`), and the CS2-Network cipher (`encryptP2P` +
  `cs2LookupTable` + key-derivation helpers).

## Limitations / future work

- **NAT-client behavior unverified.** This was developed and tested on
  a server with a public IP. For clients behind NAT (typical home
  NAS/RasPi go2rtc setups), `wan_address` in the auth payload will
  contain the local LAN IP, not the public IP. Whether the camera
  validates this against the source it sees (and therefore drops
  punches in this case) or just relies on the relay-propagated
  NAT-mapped address is not known. Reports from NAT-side setups
  welcome — a STUN-based public-IP discovery would be the natural
  fix if needed.
- The relay address is currently hardcoded to one of the three
  Alibaba-Cloud addresses. A future improvement could pick the right
  one based on the `p2p_id` region prefix (e.g. `XM` + region code)
  once the prefix-to-relay mapping is fully known.
- TCP-over-NAT hole-punching for cloud mode is not implemented; cloud
  cameras stay on UDP. If a cam advertises TCP-only readiness
  (`msgP2PRdyTCP`) the handshake currently stays on UDP and relies on
  the cam falling back, which is what was observed in captures.
- Only the `vendor_params.p2p_id` field is used at the moment. The
  other fields returned by `miss_get_vendor` for cs2 cameras
  (`license`, `crc_key`, `init_string`) are not needed for the
  handshake and are intentionally left out.

## Test setup

Tested against one Xiaomi C302n on a US-region Mi-Home account, running
via go2rtc on a small cloud VPS. Stream is stable continuously since
the address-field fix landed. H.264 transcoding via the
`ffmpeg:<src>#video=h264` alias works for browser playback (audio
dropped, since the cam's OPUS stream is not browser-compatible without
further transcoding).

## Related work

- #2247 (@Komzpa) is also tuning the Xiaomi MISS path, for the LAN-side
  `isa.camera.hlc9a`. Cleanly orthogonal to this PR — different code
  paths in `client.go` and a different code-flow downstream — but cc'ing
  for awareness; could be a useful reviewer given the overlap in
  expertise.
- #2222 (@egormanga) tightens DNS resolving and IP comparison in the
  same `pkg/xiaomi/miss/cs2/conn.go` file (separate code region, in the
  UDP helper layer). The two patches stack cleanly in either merge
  order.

## References

- [Palant: Analysis of PPPP encryption (Jan 2026)][palant]
- [pmarrapese/iot — Wireshark PPPP dissector with `0xF9` struct][pmarrapese]
- [BrownFineSecurity/vstarcam-p2p-decrypt — CS2-Network cipher RE][bfs]

[palant]: https://palant.info/2026/01/05/analysis-of-pppp-encryption/
[pmarrapese]: https://github.com/pmarrapese/iot/blob/master/p2p/dissector/pppp.fdesc
[bfs]: https://github.com/BrownFineSecurity/vstarcam-p2p-decrypt
