### PR TITLE
fix: tcp error handling

### DIFF
--- a/pkg/tcp/textproto.go
+++ b/pkg/tcp/textproto.go
@@ -74,6 +74,9 @@ func ReadResponse(r *bufio.Reader) (*Response, error) {
 	if val := res.Header.Get("Content-Length"); val != "" {
 		var i int
 		i, err = strconv.Atoi(val)
+		if err != nil {
+			return nil, err
+		}
 		res.Body = make([]byte, i)
 		if _, err = io.ReadAtLeast(r, res.Body, i); err != nil {
 			return nil, err
@@ -140,6 +143,9 @@ func ReadRequest(r *bufio.Reader) (*Request, error) {
 	if val := req.Header.Get("Content-Length"); val != "" {
 		var i int
 		i, err = strconv.Atoi(val)
+		if err != nil {
+			return nil, err
+		}
 		req.Body = make([]byte, i)
 		if _, err = io.ReadAtLeast(r, req.Body, i); err != nil {
 			return nil, err


### PR DESCRIPTION
This picks up two dropped `err` variables in `pkg/tcp`.