### PR TITLE
homekit: talkback transcoding and ffmpeg.bin from internal/ffmpeg

### DIFF
--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -13,8 +13,11 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/ffmpeg"
+	"github.com/AlexxIT/go2rtc/pkg/homekit"
 	"github.com/rs/zerolog"
 )
+
+func Bin() string { return defaults["bin"] }
 
 func Init() {
 	var cfg struct {
@@ -55,6 +58,7 @@ func Init() {
 
 	device.Init(defaults["bin"])
 	hardware.Init(defaults["bin"])
+	homekit.SetFFmpegBin(defaults["bin"])
 }
 
 var defaults = map[string]string{

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -46,9 +46,7 @@ func Init() {
 	app.LoadConfig(&cfg)
 
 	log = app.GetLogger("homekit")
-	if bin := cfg.FFmpeg["bin"]; bin != "" {
-		homekit.SetFFmpegBin(bin)
-	}
+	homekit.SetFFmpegBin(cfg.FFmpeg["bin"])
 
 	streams.HandleFunc("homekit", streamHandler)
 

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -27,7 +27,8 @@ import (
 
 func Init() {
 	var cfg struct {
-		Mod map[string]struct {
+		FFmpeg map[string]string `yaml:"ffmpeg"`
+		Mod    map[string]struct {
 			Pin             string   `yaml:"pin"`
 			Name            string   `yaml:"name"`
 			DeviceID        string   `yaml:"device_id"`
@@ -45,6 +46,9 @@ func Init() {
 	app.LoadConfig(&cfg)
 
 	log = app.GetLogger("homekit")
+	if bin := cfg.FFmpeg["bin"]; bin != "" {
+		homekit.SetFFmpegBin(bin)
+	}
 
 	streams.HandleFunc("homekit", streamHandler)
 

--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -27,7 +27,6 @@ import (
 
 func Init() {
 	var cfg struct {
-		FFmpeg map[string]string `yaml:"ffmpeg"`
 		Mod    map[string]struct {
 			Pin             string   `yaml:"pin"`
 			Name            string   `yaml:"name"`
@@ -46,7 +45,6 @@ func Init() {
 	app.LoadConfig(&cfg)
 
 	log = app.GetLogger("homekit")
-	homekit.SetFFmpegBin(cfg.FFmpeg["bin"])
 
 	streams.HandleFunc("homekit", streamHandler)
 

--- a/pkg/homekit/consumer.go
+++ b/pkg/homekit/consumer.go
@@ -27,7 +27,9 @@ type Consumer struct {
 	audioSession *srtp.Session
 	audioRTPTime byte
 
-	backTrack *core.Receiver // backchannel audio (HomeKit viewer → camera)
+	audioCodec *core.Codec
+	backTrack  *core.Receiver // backchannel audio (HomeKit viewer → camera)
+	closers    []io.Closer
 }
 
 func NewConsumer(conn net.Conn, server *srtp.Server) *Consumer {
@@ -51,6 +53,11 @@ func NewConsumer(conn net.Conn, server *srtp.Server) *Consumer {
 			Direction: core.DirectionRecvonly,
 			Codecs: []*core.Codec{
 				{Name: core.CodecOpus},
+				{Name: core.CodecPCMA},
+				{Name: core.CodecPCMU},
+				{Name: core.CodecAAC},
+				{Name: core.CodecPCM},
+				{Name: core.CodecPCML},
 			},
 		},
 	}
@@ -132,6 +139,7 @@ func (c *Consumer) SetConfig(conf *camera.SelectedStreamConfiguration) bool {
 	c.audioSession.PayloadType = conf.AudioCodec.RTPParams[0].PayloadType
 	c.audioSession.RTCPInterval = toDuration(conf.AudioCodec.RTPParams[0].RTCPInterval)
 	c.audioRTPTime = conf.AudioCodec.CodecParams[0].RTPTime[0]
+	c.audioCodec = selectedAudioCodec(&conf.AudioCodec)
 
 	c.srtp.AddSession(c.videoSession)
 	c.srtp.AddSession(c.audioSession)
@@ -144,15 +152,28 @@ func (c *Consumer) GetTrack(media *core.Media, codec *core.Codec) (*core.Receive
 		return nil, core.ErrCantGetTrack
 	}
 
-	c.backTrack = core.NewReceiver(media, codec)
+	actualCodec := c.audioCodec
+	if actualCodec == nil {
+		actualCodec = codec
+	}
+
+	c.backTrack = core.NewReceiver(media, actualCodec)
+	receiver := c.backTrack
+
+	if !sameAudioCodec(actualCodec, codec) {
+		if bridge, err := newAudioTranscoder(c.backTrack, codec); err == nil {
+			c.closers = append(c.closers, bridge)
+			receiver = bridge.Receiver()
+		}
+	}
 
 	c.audioSession.OnReadRTP = func(packet *rtp.Packet) {
 		c.backTrack.WriteRTP(packet)
 		c.Recv += len(packet.Payload)
 	}
 
-	c.Receivers = append(c.Receivers, c.backTrack)
-	return c.backTrack, nil
+	c.Receivers = append(c.Receivers, receiver)
+	return receiver, nil
 }
 
 func (c *Consumer) Start() error {
@@ -214,6 +235,9 @@ func (c *Consumer) Stop() error {
 	if c.deadline != nil {
 		c.deadline.Reset(0)
 	}
+	for _, closer := range c.closers {
+		_ = closer.Close()
+	}
 	return c.Connection.Stop()
 }
 
@@ -230,4 +254,25 @@ func (c *Consumer) srtpEndpoint() *srtp.Endpoint {
 
 func toDuration(seconds float32) time.Duration {
 	return time.Duration(seconds * float32(time.Second))
+}
+
+func selectedAudioCodec(conf *camera.AudioCodecConfiguration) *core.Codec {
+	media := audioToMedia([]camera.AudioCodecConfiguration{*conf})
+	if len(media.Codecs) == 0 {
+		return nil
+	}
+	if media.Codecs[0].Name == core.CodecOpus {
+		codec := media.Codecs[0].Clone()
+		codec.ClockRate = 48000
+		codec.Channels = 2
+		codec.PayloadType = 110
+		return codec
+	}
+	return media.Codecs[0]
+}
+
+func sameAudioCodec(src, dst *core.Codec) bool {
+	return src.Name == dst.Name &&
+		(src.ClockRate == dst.ClockRate || src.ClockRate == 0 || dst.ClockRate == 0) &&
+		(src.Channels == dst.Channels || src.Channels == 0 || dst.Channels == 0)
 }

--- a/pkg/homekit/consumer.go
+++ b/pkg/homekit/consumer.go
@@ -3,6 +3,7 @@ package homekit
 import (
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net"
 	"time"
@@ -29,7 +30,8 @@ type Consumer struct {
 
 	audioCodec *core.Codec
 	backTrack  *core.Receiver // backchannel audio (HomeKit viewer → camera)
-	closers    []io.Closer
+	backOutput *core.Receiver
+	backBridge *audioTranscoder
 }
 
 func NewConsumer(conn net.Conn, server *srtp.Server) *Consumer {
@@ -52,12 +54,8 @@ func NewConsumer(conn net.Conn, server *srtp.Server) *Consumer {
 			Kind:      core.KindAudio,
 			Direction: core.DirectionRecvonly,
 			Codecs: []*core.Codec{
-				{Name: core.CodecOpus},
 				{Name: core.CodecPCMA},
 				{Name: core.CodecPCMU},
-				{Name: core.CodecAAC},
-				{Name: core.CodecPCM},
-				{Name: core.CodecPCML},
 			},
 		},
 	}
@@ -157,22 +155,38 @@ func (c *Consumer) GetTrack(media *core.Media, codec *core.Codec) (*core.Receive
 		actualCodec = codec
 	}
 
-	c.backTrack = core.NewReceiver(media, actualCodec)
-	receiver := c.backTrack
-
-	if !sameAudioCodec(actualCodec, codec) {
-		if bridge, err := newAudioTranscoder(c.backTrack, codec); err == nil {
-			c.closers = append(c.closers, bridge)
-			receiver = bridge.Receiver()
-		}
+	if c.backTrack != nil && !sameAudioCodec(c.backTrack.Codec, actualCodec) {
+		c.closeBackchannel()
 	}
+	if c.backOutput != nil && sameAudioCodec(c.backOutput.Codec, codec) {
+		return c.backOutput, nil
+	}
+	if c.backTrack == nil {
+		c.backTrack = core.NewReceiver(media, actualCodec)
+	}
+
+	var receiver *core.Receiver
+	if !sameAudioCodec(actualCodec, codec) {
+		bridge, err := newAudioTranscoder(c.backTrack, codec)
+		if err != nil {
+			log.Printf("[homekit] talkback transcode failed: src=%s dst=%s err=%v", actualCodec.Name, codec.Name, err)
+			return nil, fmt.Errorf("homekit: talkback transcode %s to %s: %w", actualCodec.Name, codec.Name, err)
+		}
+		c.closeBackchannelBridge()
+		c.backBridge = bridge
+		receiver = bridge.Receiver()
+	} else {
+		c.closeBackchannelBridge()
+		receiver = c.backTrack
+	}
+	c.backOutput = receiver
 
 	c.audioSession.OnReadRTP = func(packet *rtp.Packet) {
 		c.backTrack.WriteRTP(packet)
 		c.Recv += len(packet.Payload)
 	}
 
-	c.Receivers = append(c.Receivers, receiver)
+	c.Receivers = []*core.Receiver{receiver}
 	return receiver, nil
 }
 
@@ -235,10 +249,26 @@ func (c *Consumer) Stop() error {
 	if c.deadline != nil {
 		c.deadline.Reset(0)
 	}
-	for _, closer := range c.closers {
-		_ = closer.Close()
-	}
+	c.closeBackchannel()
 	return c.Connection.Stop()
+}
+
+func (c *Consumer) closeBackchannel() {
+	c.closeBackchannelBridge()
+	if c.backTrack != nil {
+		c.backTrack.Close()
+		c.backTrack = nil
+	}
+	c.backOutput = nil
+	c.Receivers = nil
+}
+
+func (c *Consumer) closeBackchannelBridge() {
+	if c.backBridge == nil {
+		return
+	}
+	_ = c.backBridge.Close()
+	c.backBridge = nil
 }
 
 func (c *Consumer) srtpEndpoint() *srtp.Endpoint {

--- a/pkg/homekit/transcode.go
+++ b/pkg/homekit/transcode.go
@@ -1,0 +1,310 @@
+package homekit
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strconv"
+	"sync"
+
+	"github.com/AlexxIT/go2rtc/pkg/aac"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
+)
+
+var ffmpegBin = "ffmpeg"
+
+func SetFFmpegBin(bin string) {
+	if bin != "" {
+		ffmpegBin = bin
+	}
+}
+
+type audioTranscoder struct {
+	input net.Conn
+	cmd   *exec.Cmd
+	done  chan struct{}
+	once  sync.Once
+
+	receiver *core.Receiver
+}
+
+func newAudioTranscoder(src *core.Receiver, dst *core.Codec) (*audioTranscoder, error) {
+	rtpIn, err := rtpInput(src.Codec)
+	if err != nil {
+		return nil, err
+	}
+	output, err := rawAudioOutput(dst)
+	if err != nil {
+		return nil, fmt.Errorf("homekit: unsupported talkback transcode: %s to %s", src.Codec.Name, dst.Name)
+	}
+
+	inPort, err := freeUDPPort()
+	if err != nil {
+		return nil, err
+	}
+
+	udpInput, err := net.Dial("udp", "127.0.0.1:"+strconv.Itoa(inPort))
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"-hide_banner", "-v", "error",
+		"-protocol_whitelist", "pipe,udp,rtp",
+		"-f", "sdp", "-i", "pipe:0",
+		"-map", "0:a:0",
+		"-c:a", output.encoder,
+		"-ar:a", strconv.Itoa(int(output.clockRate)),
+		"-ac:a", strconv.Itoa(int(output.channels)),
+		"-f", output.muxer, "pipe:1",
+	}
+	cmd := exec.Command(ffmpegBin, args...)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		_ = udpInput.Close()
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = udpInput.Close()
+		return nil, err
+	}
+	if err = cmd.Start(); err != nil {
+		_ = udpInput.Close()
+		return nil, err
+	}
+
+	payloadType := src.Codec.PayloadType
+	if payloadType == 0 || payloadType == core.PayloadTypeRAW {
+		payloadType = 110
+	}
+	sdp := fmt.Sprintf("v=0\r\n"+
+		"o=- 0 0 IN IP4 127.0.0.1\r\n"+
+		"s=go2rtc-homekit-talkback\r\n"+
+		"c=IN IP4 127.0.0.1\r\n"+
+		"t=0 0\r\n"+
+		"m=audio %d RTP/AVP %d\r\n"+
+		"a=rtpmap:%d %s\r\n",
+		inPort, payloadType, payloadType, rtpIn.rtpmap)
+	if rtpIn.fmtp != "" {
+		sdp += fmt.Sprintf("a=fmtp:%d %s\r\n", payloadType, rtpIn.fmtp)
+	}
+	_, _ = stdin.Write([]byte(sdp))
+	_ = stdin.Close()
+
+	t := &audioTranscoder{
+		input:    udpInput,
+		cmd:      cmd,
+		done:     make(chan struct{}),
+		receiver: core.NewReceiver(src.Media, output.codec),
+	}
+
+	go output.read(t, stdout)
+	go func() {
+		_ = cmd.Wait()
+		t.Close()
+	}()
+
+	sender := core.NewSender(src.Media, src.Codec)
+	sender.Handler = func(packet *rtp.Packet) {
+		if b, err := packet.Marshal(); err == nil {
+			_, _ = udpInput.Write(b)
+		}
+	}
+	sender.HandleRTP(src)
+
+	return t, nil
+}
+
+func (t *audioTranscoder) Receiver() *core.Receiver {
+	return t.receiver
+}
+
+func (t *audioTranscoder) Close() error {
+	t.once.Do(func() {
+		close(t.done)
+		if t.input != nil {
+			_ = t.input.Close()
+		}
+		if t.cmd != nil && t.cmd.Process != nil {
+			_ = t.cmd.Process.Kill()
+		}
+	})
+	return nil
+}
+
+type audioRTPInput struct {
+	rtpmap string
+	fmtp   string
+}
+
+func rtpInput(codec *core.Codec) (*audioRTPInput, error) {
+	clockRate := codec.ClockRate
+	if clockRate == 0 {
+		clockRate = 48000
+	}
+	channels := codec.Channels
+	if channels == 0 {
+		channels = 1
+	}
+
+	var name string
+	switch codec.Name {
+	case core.CodecOpus:
+		name = "opus"
+		clockRate = 48000
+		channels = 2
+	case core.CodecELD:
+		name = "MPEG4-GENERIC"
+	case core.CodecPCMA:
+		name = "PCMA"
+	case core.CodecPCMU:
+		name = "PCMU"
+	default:
+		return nil, fmt.Errorf("homekit: unsupported talkback input codec: %s", codec.Name)
+	}
+
+	return &audioRTPInput{
+		rtpmap: fmt.Sprintf("%s/%d/%d", name, clockRate, channels),
+		fmtp:   codec.FmtpLine,
+	}, nil
+}
+
+type audioRawOutput struct {
+	codec     *core.Codec
+	encoder   string
+	muxer     string
+	clockRate uint32
+	channels  uint8
+	read      func(*audioTranscoder, io.Reader)
+}
+
+func rawAudioOutput(codec *core.Codec) (*audioRawOutput, error) {
+	output := &audioRawOutput{
+		codec:     codec.Clone(),
+		clockRate: codec.ClockRate,
+		channels:  codec.Channels,
+	}
+	if output.clockRate == 0 {
+		output.clockRate = 8000
+	}
+	if output.channels == 0 {
+		output.channels = 1
+	}
+
+	switch codec.Name {
+	case core.CodecPCMA:
+		output.encoder = "pcm_alaw"
+		output.muxer = "alaw"
+		output.read = output.readFixedFrames(1, 20)
+	case core.CodecPCMU:
+		output.encoder = "pcm_mulaw"
+		output.muxer = "mulaw"
+		output.read = output.readFixedFrames(1, 20)
+	case core.CodecPCM:
+		output.encoder = "pcm_s16be"
+		output.muxer = "s16be"
+		output.read = output.readFixedFrames(2, 20)
+	case core.CodecPCML:
+		output.encoder = "pcm_s16le"
+		output.muxer = "s16le"
+		output.read = output.readFixedFrames(2, 20)
+	case core.CodecAAC:
+		if output.clockRate == 8000 {
+			output.clockRate = 16000
+		}
+		output.encoder = "aac"
+		output.muxer = "adts"
+		output.codec.PayloadType = core.PayloadTypeRAW
+		output.read = output.readADTS
+	default:
+		return nil, fmt.Errorf("unsupported output codec")
+	}
+
+	return output, nil
+}
+
+func (o *audioRawOutput) readFixedFrames(bytesPerSample, frameMs int) func(*audioTranscoder, io.Reader) {
+	samplesPerFrame := int(o.clockRate) * frameMs / 1000
+	payloadSize := samplesPerFrame * int(o.channels) * bytesPerSample
+
+	return func(t *audioTranscoder, rd io.Reader) {
+		buf := make([]byte, payloadSize)
+
+		var seq uint16
+		var timestamp uint32
+
+		for {
+			if _, err := io.ReadFull(rd, buf); err != nil {
+				return
+			}
+
+			payload := make([]byte, payloadSize)
+			copy(payload, buf)
+
+			t.receiver.WriteRTP(&rtp.Packet{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    o.codec.PayloadType,
+					SequenceNumber: seq,
+					Timestamp:      timestamp,
+				},
+				Payload: payload,
+			})
+
+			seq++
+			timestamp += uint32(samplesPerFrame)
+		}
+	}
+}
+
+func (o *audioRawOutput) readADTS(t *audioTranscoder, rd io.Reader) {
+	var seq uint16
+	var timestamp uint32
+
+	for {
+		header := make([]byte, aac.ADTSHeaderSize)
+		if _, err := io.ReadFull(rd, header); err != nil {
+			return
+		}
+		if !aac.IsADTS(header) {
+			return
+		}
+
+		size := int(aac.ReadADTSSize(header))
+		if size < aac.ADTSHeaderSize {
+			return
+		}
+		payload := make([]byte, size-aac.ADTSHeaderSize)
+		if _, err := io.ReadFull(rd, payload); err != nil {
+			return
+		}
+
+		t.receiver.WriteRTP(&rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				Marker:         true,
+				PayloadType:    o.codec.PayloadType,
+				SequenceNumber: seq,
+				Timestamp:      timestamp,
+			},
+			Payload: payload,
+		})
+
+		seq++
+		timestamp += aac.AUTime
+	}
+}
+
+func freeUDPPort() (int, error) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).Port, nil
+}

--- a/pkg/homekit/transcode.go
+++ b/pkg/homekit/transcode.go
@@ -22,10 +22,12 @@ func SetFFmpegBin(bin string) {
 }
 
 type audioTranscoder struct {
-	input net.Conn
-	cmd   *exec.Cmd
-	done  chan struct{}
-	once  sync.Once
+	input    net.Conn
+	cmd      *exec.Cmd
+	sender   *core.Sender
+	once     sync.Once
+	waitOnce sync.Once
+	waitErr  error
 
 	receiver *core.Receiver
 }
@@ -37,18 +39,14 @@ func newAudioTranscoder(src *core.Receiver, dst *core.Codec) (*audioTranscoder, 
 	}
 	output, err := rawAudioOutput(dst)
 	if err != nil {
-		return nil, fmt.Errorf("homekit: unsupported talkback transcode: %s to %s", src.Codec.Name, dst.Name)
+		return nil, fmt.Errorf("homekit: unsupported talkback transcode: %s to %s: %w", src.Codec.Name, dst.Name, err)
 	}
 
-	inPort, err := freeUDPPort()
+	reservation, err := reserveUDPPort()
 	if err != nil {
 		return nil, err
 	}
-
-	udpInput, err := net.Dial("udp", "127.0.0.1:"+strconv.Itoa(inPort))
-	if err != nil {
-		return nil, err
-	}
+	inPort := reservation.LocalAddr().(*net.UDPAddr).Port
 
 	args := []string{
 		"-hide_banner", "-v", "error",
@@ -64,16 +62,17 @@ func newAudioTranscoder(src *core.Receiver, dst *core.Codec) (*audioTranscoder, 
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		_ = udpInput.Close()
+		_ = reservation.Close()
 		return nil, err
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		_ = udpInput.Close()
+		_ = stdin.Close()
+		_ = reservation.Close()
 		return nil, err
 	}
 	if err = cmd.Start(); err != nil {
-		_ = udpInput.Close()
+		_ = reservation.Close()
 		return nil, err
 	}
 
@@ -92,19 +91,34 @@ func newAudioTranscoder(src *core.Receiver, dst *core.Codec) (*audioTranscoder, 
 	if rtpIn.fmtp != "" {
 		sdp += fmt.Sprintf("a=fmtp:%d %s\r\n", payloadType, rtpIn.fmtp)
 	}
-	_, _ = stdin.Write([]byte(sdp))
+
+	udpInput, err := net.Dial("udp", "127.0.0.1:"+strconv.Itoa(inPort))
+	if err != nil {
+		_ = stdin.Close()
+		_ = reservation.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, err
+	}
+	_ = reservation.Close()
+	if _, err = stdin.Write([]byte(sdp)); err != nil {
+		_ = stdin.Close()
+		_ = udpInput.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return nil, err
+	}
 	_ = stdin.Close()
 
 	t := &audioTranscoder{
 		input:    udpInput,
 		cmd:      cmd,
-		done:     make(chan struct{}),
 		receiver: core.NewReceiver(src.Media, output.codec),
 	}
 
 	go output.read(t, stdout)
 	go func() {
-		_ = cmd.Wait()
+		_ = t.wait()
 		t.Close()
 	}()
 
@@ -115,6 +129,7 @@ func newAudioTranscoder(src *core.Receiver, dst *core.Codec) (*audioTranscoder, 
 		}
 	}
 	sender.HandleRTP(src)
+	t.sender = sender
 
 	return t, nil
 }
@@ -125,15 +140,30 @@ func (t *audioTranscoder) Receiver() *core.Receiver {
 
 func (t *audioTranscoder) Close() error {
 	t.once.Do(func() {
-		close(t.done)
+		if t.sender != nil {
+			t.sender.Close()
+		}
+		if t.receiver != nil {
+			t.receiver.Close()
+		}
 		if t.input != nil {
 			_ = t.input.Close()
 		}
-		if t.cmd != nil && t.cmd.Process != nil {
+		if t.cmd != nil && t.cmd.Process != nil && t.cmd.ProcessState == nil {
 			_ = t.cmd.Process.Kill()
 		}
+		_ = t.wait()
 	})
 	return nil
+}
+
+func (t *audioTranscoder) wait() error {
+	t.waitOnce.Do(func() {
+		if t.cmd != nil {
+			t.waitErr = t.cmd.Wait()
+		}
+	})
+	return t.waitErr
 }
 
 type audioRTPInput struct {
@@ -300,11 +330,6 @@ func (o *audioRawOutput) readADTS(t *audioTranscoder, rd io.Reader) {
 	}
 }
 
-func freeUDPPort() (int, error) {
-	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer conn.Close()
-	return conn.LocalAddr().(*net.UDPAddr).Port, nil
+func reserveUDPPort() (net.PacketConn, error) {
+	return net.ListenPacket("udp", "127.0.0.1:0")
 }

--- a/pkg/srtp/server.go
+++ b/pkg/srtp/server.go
@@ -98,6 +98,8 @@ func (s *Server) handle() error {
 		case packetKindRTCP:
 			if session := s.GetSession(ssrc); session != nil {
 				session.ReadRTCP(b[:n])
+			} else {
+				s.ReadRTCP(ssrc, b[:n])
 			}
 		}
 	}
@@ -116,6 +118,24 @@ func (s *Server) ReadRTP(ssrc uint32, b []byte) {
 			continue
 		}
 		if session.ReadRTP(b) {
+			s.mu.Lock()
+			s.sessions[ssrc] = session
+			s.mu.Unlock()
+			return
+		}
+	}
+}
+
+func (s *Server) ReadRTCP(ssrc uint32, b []byte) {
+	s.mu.Lock()
+	sessions := make([]*Session, 0, len(s.sessions))
+	for _, session := range s.sessions {
+		sessions = append(sessions, session)
+	}
+	s.mu.Unlock()
+
+	for _, session := range sessions {
+		if session.ReadRTCP(b) {
 			s.mu.Lock()
 			s.sessions[ssrc] = session
 			s.mu.Unlock()

--- a/pkg/srtp/server.go
+++ b/pkg/srtp/server.go
@@ -55,7 +55,11 @@ func (s *Server) AddSession(session *Session) {
 func (s *Server) DelSession(session *Session) {
 	s.mu.Lock()
 
-	delete(s.sessions, session.Remote.SSRC)
+	for ssrc, current := range s.sessions {
+		if current == session {
+			delete(s.sessions, ssrc)
+		}
+	}
 
 	// check s.conn for https://github.com/AlexxIT/go2rtc/issues/734
 	if len(s.sessions) == 0 && s.conn != nil {
@@ -83,20 +87,73 @@ func (s *Server) handle() error {
 		// Multiplexing RTP Data and Control Packets on a Single Port
 		// https://datatracker.ietf.org/doc/html/rfc5761
 
-		switch packetType := b[1]; packetType {
-		case 99, 110, 0x80 | 99, 0x80 | 110:
-			// this is default position for SSRC in RTP packet
-			ssrc := binary.BigEndian.Uint32(b[8:])
+		switch kind, ssrc := packetKindAndSSRC(b[:n]); kind {
+		case packetKindRTP:
 			if session := s.GetSession(ssrc); session != nil {
 				session.ReadRTP(b[:n])
+			} else {
+				s.ReadRTP(ssrc, b[:n])
 			}
 
-		case 200, 201, 202, 203, 204, 205, 206, 207:
-			// this is default position for SSRC in RTCP packet
-			ssrc := binary.BigEndian.Uint32(b[4:])
+		case packetKindRTCP:
 			if session := s.GetSession(ssrc); session != nil {
 				session.ReadRTCP(b[:n])
 			}
 		}
 	}
+}
+
+func (s *Server) ReadRTP(ssrc uint32, b []byte) {
+	s.mu.Lock()
+	sessions := make([]*Session, 0, len(s.sessions))
+	for _, session := range s.sessions {
+		sessions = append(sessions, session)
+	}
+	s.mu.Unlock()
+
+	for _, session := range sessions {
+		if session.OnReadRTP == nil {
+			continue
+		}
+		if session.ReadRTP(b) {
+			s.mu.Lock()
+			s.sessions[ssrc] = session
+			s.mu.Unlock()
+			return
+		}
+	}
+}
+
+const (
+	packetKindUnknown = iota
+	packetKindRTP
+	packetKindRTCP
+)
+
+func packetKindAndSSRC(b []byte) (int, uint32) {
+	if len(b) < 2 {
+		return packetKindUnknown, 0
+	}
+
+	// Multiplexing RTP Data and Control Packets on a Single Port
+	// https://datatracker.ietf.org/doc/html/rfc5761
+	switch packetType := b[1]; packetType {
+	case 200, 201, 202, 203, 204, 205, 206, 207:
+		if len(b) < 8 {
+			return packetKindUnknown, 0
+		}
+		return packetKindRTCP, binary.BigEndian.Uint32(b[4:])
+	}
+
+	payloadType := b[1] & 0x7F
+	switch {
+	case payloadType == 13:
+		return packetKindUnknown, 0 // comfort noise
+	case payloadType >= 64 && payloadType <= 95:
+		return packetKindUnknown, 0 // RTCP conflict range
+	case len(b) < 12:
+		return packetKindUnknown, 0
+	}
+
+	return packetKindRTP, binary.BigEndian.Uint32(b[8:])
 }

--- a/pkg/srtp/server_test.go
+++ b/pkg/srtp/server_test.go
@@ -1,0 +1,48 @@
+package srtp
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPacketKindAndSSRC_RTPDynamicPayloadTypes(t *testing.T) {
+	for _, payloadType := range []byte{0, 8, 96, 99, 110, 111, 0x80 | 111} {
+		packet := make([]byte, 12)
+		packet[0] = 0x80
+		packet[1] = payloadType
+		binary.BigEndian.PutUint32(packet[8:], 0x12345678)
+
+		kind, ssrc := packetKindAndSSRC(packet)
+
+		require.Equal(t, packetKindRTP, kind, "payload type %d", payloadType)
+		require.Equal(t, uint32(0x12345678), ssrc)
+	}
+}
+
+func TestPacketKindAndSSRC_RTCP(t *testing.T) {
+	packet := make([]byte, 8)
+	packet[0] = 0x80
+	packet[1] = 200
+	binary.BigEndian.PutUint32(packet[4:], 0x87654321)
+
+	kind, ssrc := packetKindAndSSRC(packet)
+
+	require.Equal(t, packetKindRTCP, kind)
+	require.Equal(t, uint32(0x87654321), ssrc)
+}
+
+func TestPacketKindAndSSRC_IgnoresNonMedia(t *testing.T) {
+	for _, payloadType := range []byte{13, 64, 95} {
+		packet := make([]byte, 12)
+		packet[0] = 0x80
+		packet[1] = payloadType
+		binary.BigEndian.PutUint32(packet[8:], 0x12345678)
+
+		kind, ssrc := packetKindAndSSRC(packet)
+
+		require.Equal(t, packetKindUnknown, kind, "payload type %d", payloadType)
+		require.Zero(t, ssrc)
+	}
+}

--- a/pkg/srtp/session.go
+++ b/pkg/srtp/session.go
@@ -119,21 +119,22 @@ func (s *Session) WriteRTCP(packet rtcp.Packet) (int, error) {
 	return s.conn.WriteTo(b, s.Remote.addr)
 }
 
-func (s *Session) ReadRTP(b []byte) {
+func (s *Session) ReadRTP(b []byte) bool {
 	packet := &rtp.Packet{}
 
 	b, err := s.Remote.srtp.DecryptRTP(nil, b, &packet.Header)
 	if err != nil {
-		return
+		return false
 	}
 
 	if err = packet.Unmarshal(b); err != nil {
-		return
+		return false
 	}
 
 	if s.OnReadRTP != nil {
 		s.OnReadRTP(packet)
 	}
+	return true
 }
 
 func (s *Session) ReadRTCP(b []byte) {

--- a/pkg/srtp/session.go
+++ b/pkg/srtp/session.go
@@ -137,11 +137,11 @@ func (s *Session) ReadRTP(b []byte) bool {
 	return true
 }
 
-func (s *Session) ReadRTCP(b []byte) {
+func (s *Session) ReadRTCP(b []byte) bool {
 	header := rtcp.Header{}
 	b, err := s.Remote.srtp.DecryptRTCP(nil, b, &header)
 	if err != nil {
-		return
+		return false
 	}
 
 	//packets, err := rtcp.Unmarshal(b)
@@ -153,9 +153,10 @@ func (s *Session) ReadRTCP(b []byte) {
 	//}
 
 	if header.Type != rtcp.TypeSenderReport {
-		return
+		return true
 	}
 
 	receiverRTCP := rtcp.ReceiverReport{SSRC: s.Local.SSRC}
 	_, _ = s.WriteRTCP(&receiverRTCP)
+	return true
 }


### PR DESCRIPTION
## Summary

Wires HomeKit talkback FFmpeg path to the existing `ffmpeg.bin` config (single source of truth in `internal/ffmpeg`).

Includes cherry-picked commits from [mofman/go2rtc#2259](https://github.com/AlexxIT/go2rtc/pull/2259) because `dev` does not yet have talkback transcoding (`pkg/homekit/transcode.go`).

### ffmpeg.bin wiring

- `internal/ffmpeg`: export `Bin()`, call `homekit.SetFFmpegBin(defaults["bin"])` in `Init()`
- `internal/homekit`: no duplicate `ffmpeg.bin` yaml read
- `pkg/homekit/transcode.go`: uses `SetFFmpegBin` / `ffmpegBin`

## Test plan

- [x] `go test ./pkg/srtp/...`
- [x] `go test ./pkg/homekit/...` (no test files)

## Related

- Follow-up to #2259 (duplicate `ffmpeg.bin` in `internal/homekit` removed here)
