### PR TITLE
h265: de-aggregate RFC 7798 Aggregation Packets (type 48) in RTPDepay

### DIFF
--- a/pkg/h265/helper.go
+++ b/pkg/h265/helper.go
@@ -17,6 +17,7 @@ const (
 	NALUTypePPS       = 34
 	NALUTypePrefixSEI = 39
 	NALUTypeSuffixSEI = 40
+	NALUTypeAP        = 48
 	NALUTypeFU        = 49
 )
 

--- a/pkg/h265/rtp.go
+++ b/pkg/h265/rtp.go
@@ -92,6 +92,27 @@ func RTPDepay(codec *core.Codec, handler core.HandlerFunc) core.HandlerFunc {
 				buf = append(buf, (data[0]&0x81)|(nuType<<1), data[1])
 				buf = append(buf, data[3:]...)
 			}
+		} else if nuType == NALUTypeAP {
+			// RFC 7798 §4.4.2 Aggregation Packet: [PayloadHdr][2-byte size + NALU]*
+			// (no DONL — sprop-max-don-diff=0). Emitted by libavformat's HEVC RTP
+			// packetizer (e.g. exec/ffmpeg sources), which bundles VPS+SPS+PPS into
+			// one packet. Split it into individual AVCC length-prefixed NAL units.
+			// The AP already carries parameter sets in-band — don't prepend ps.
+			for i := 2; i < len(data); {
+				if i+2 > len(data) {
+					buf = buf[:0] // drop truncated AP (same convention as FU)
+					return
+				}
+				size := int(binary.BigEndian.Uint16(data[i:]))
+				i += 2
+				if size < 2 || i+size > len(data) {
+					buf = buf[:0] // drop corrupted AP
+					return
+				}
+				buf = binary.BigEndian.AppendUint32(buf, uint32(size)) // NAL unit size
+				buf = append(buf, data[i:i+size]...)
+				i += size
+			}
 		} else {
 			buf = binary.BigEndian.AppendUint32(buf, uint32(len(data))) // NAL unit size
 			buf = append(buf, data...)

--- a/pkg/h265/rtp_test.go
+++ b/pkg/h265/rtp_test.go
@@ -1,0 +1,90 @@
+package h265
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+// buildAP wraps NAL units into an RFC 7798 §4.4.2 Aggregation Packet:
+// [PayloadHdr (type=48)] [2-byte size][NALU]*  (no DONL — sprop-max-don-diff=0,
+// which is what libavformat's HEVC RTP packetizer emits).
+func buildAP(nalus ...[]byte) []byte {
+	ap := []byte{NALUTypeAP << 1, 0x01}
+	for _, nalu := range nalus {
+		ap = binary.BigEndian.AppendUint16(ap, uint16(len(nalu)))
+		ap = append(ap, nalu...)
+	}
+	return ap
+}
+
+// TestRTPDepayAggregationPacket reproduces the production failure behind
+// black thumbnails / "exit status 183" for HEVC cameras behind exec:ffmpeg
+// sources: libavformat bundles VPS+SPS+PPS into one type-48 Aggregation
+// Packet, which the depacketizer must split into individual AVCC
+// length-prefixed NAL units. Without AP support the whole packet is emitted
+// as a single bogus NAL of type 48 — an unspecified non-VCL type that breaks
+// every downstream decoder.
+func TestRTPDepayAggregationPacket(t *testing.T) {
+	vps := []byte{NALUTypeVPS << 1, 0x01, 0xAA, 0xBB, 0xCC}
+	sps := []byte{NALUTypeSPS << 1, 0x01, 0x11, 0x22, 0x33, 0x44}
+	pps := []byte{NALUTypePPS << 1, 0x01, 0x55}
+	idr := []byte{NALUTypeIFrame << 1, 0x01, 0xDE, 0xAD, 0xBE, 0xEF}
+
+	var got []*rtp.Packet
+	depay := RTPDepay(&core.Codec{}, func(packet *rtp.Packet) {
+		got = append(got, packet)
+	})
+
+	depay(&rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 100, Marker: false},
+		Payload: buildAP(vps, sps, pps),
+	})
+	depay(&rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 101, Marker: true},
+		Payload: idr,
+	})
+
+	require.Len(t, got, 1)
+	require.Equal(t, []byte{NALUTypeVPS, NALUTypeSPS, NALUTypePPS, NALUTypeIFrame}, Types(got[0].Payload))
+
+	// Each NAL must round-trip byte-identical with its own AVCC length prefix.
+	payload := got[0].Payload
+	for _, want := range [][]byte{vps, sps, pps, idr} {
+		size := int(binary.BigEndian.Uint32(payload))
+		require.Equal(t, len(want), size)
+		require.Equal(t, want, payload[4:4+size])
+		payload = payload[4+size:]
+	}
+	require.Empty(t, payload)
+}
+
+// TestRTPDepayAggregationPacketMalformed verifies the corruption-drop
+// convention (same as the FU branch): a truncated AP must clear the buffer
+// and emit nothing, and the next intact access unit must still go through.
+func TestRTPDepayAggregationPacketMalformed(t *testing.T) {
+	var got []*rtp.Packet
+	depay := RTPDepay(&core.Codec{}, func(packet *rtp.Packet) {
+		got = append(got, packet)
+	})
+
+	// Size field claims 200 bytes but only 3 follow.
+	malformed := []byte{NALUTypeAP << 1, 0x01, 0x00, 200, 0x40, 0x01, 0xFF}
+	depay(&rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 50, Marker: false},
+		Payload: malformed,
+	})
+	require.Empty(t, got)
+
+	idr := []byte{NALUTypeIFrame << 1, 0x01, 0xDE, 0xAD}
+	depay(&rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: 51, Marker: true},
+		Payload: idr,
+	})
+
+	require.Len(t, got, 1)
+	require.Equal(t, []byte{NALUTypeIFrame}, Types(got[0].Payload))
+}


### PR DESCRIPTION
## Problem

`RTPDepay` in `pkg/h265/rtp.go` only special-cases Fragmentation Units (`NALUTypeFU` = 49). RFC 7798 §4.4.2 **Aggregation Packets (type 48)** fall through to the single-NAL branch and are written into the AVCC stream as one length-prefixed entry whose first payload byte (`0x60`) parses as an unspecified non-VCL NAL type.

Any H.265 RTP source that aggregates VPS/SPS/PPS(+SEI) ahead of a RAP produces an undecodable bytestream downstream:

- `magic.Keyframe` never sees the keyframe
- AVCC→AnnexB hands ffmpeg consumers corrupt data → `Invalid data found when processing input` (exit 1/183)
- `frame.jpeg` returns HTTP 500, `stream.mp4` emits 0 bytes, MSE consumers get a malformed init/bytestream

This notably affects go2rtc's own `exec:ffmpeg` producers: libavformat's RTSP muxer emits type-48 APs for HEVC when parameter sets repeat (e.g. `repeat-headers=1`), so any HEVC camera routed through an ffmpeg source (audio transcode, filters, etc.) hits this — while the same camera consumed natively works, which makes it confusing to diagnose.

## Reproduction (no camera needed)

```yaml
streams:
  hevc_ap_test:
    - exec:ffmpeg -re -f lavfi -i testsrc2=size=640x360:rate=10 -c:v libx265 -preset ultrafast -tune zerolatency -x265-params repeat-headers=1:keyint=20 -f rtsp {output}
```

`GET /api/frame.jpeg?src=hevc_ap_test` → **500 before this patch, 200 + JPEG after.** Verified both ways.

## Fix

Adds `NALUTypeAP = 48` and a de-aggregation branch in `RTPDepay` that walks the AP payload (2-byte NALU-size + NALU, per RFC 7798 §4.4.2) and emits each constituent NAL as its own length-prefixed AVCC entry. Truncated/malformed AP payloads stop parsing at the malformed unit (covered by a test) rather than emitting garbage.

Unit tests included for the AP split and malformed-AP handling; existing tests untouched and passing.

Running in production on three sites (Raspberry Pi 5 / Apple Silicon / x86_64 Docker) since 2026-06-11 against Dahua and VIVOTEK HEVC cameras.