### PR TITLE
Add API to stop publishing a stream

### DIFF
--- a/internal/streams/README.md
+++ b/internal/streams/README.md
@@ -40,6 +40,14 @@ You can use the API:
 POST http://localhost:1984/api/streams?src=camera1&dst=rtmps://...
 ```
 
+Stop one publish without deleting the stream by sending a `DELETE` with the same `src` and `dst`:
+
+```text
+DELETE http://localhost:1984/api/streams?src=camera1&dst=rtmps://...
+```
+
+A `DELETE` with only `src` stops every publish for that stream and removes the stream, as before.
+
 Or config file:
 
 ```yaml

--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -98,6 +98,20 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "DELETE":
+		// with dst - stop one publish, keep the stream
+		if dst := query.Get("dst"); dst != "" {
+			if stream := Get(src); stream != nil {
+				stream.StopPublish(dst)
+			} else {
+				http.Error(w, "", http.StatusNotFound)
+			}
+			return
+		}
+
+		// without dst - stop all publishes, then delete the stream
+		if s, ok := streams[src]; ok {
+			s.StopAllPublish()
+		}
 		delete(streams, src)
 
 		if err := app.PatchConfig([]string{"streams", src}, nil); err != nil {

--- a/internal/streams/publish.go
+++ b/internal/streams/publish.go
@@ -1,27 +1,146 @@
 package streams
 
-import "time"
+import (
+	"context"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+// publishHandle tracks one active publish. Closing cons unblocks an in-flight
+// run() so a stop takes effect at once; cancel and cons are guarded by Stream.mu.
+type publishHandle struct {
+	cancel context.CancelFunc
+	cons   core.Consumer
+}
 
 func (s *Stream) Publish(url string) error {
+	s.StopPublish(url) // replace any existing publish for this url
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h := &publishHandle{cancel: cancel}
+
+	s.mu.Lock()
+	if s.publishes == nil {
+		s.publishes = make(map[string]*publishHandle)
+	}
+	s.publishes[url] = h
+	s.mu.Unlock()
+
 	cons, run, err := GetConsumer(url)
 	if err != nil {
+		cancel()
+		s.removeHandle(url, h)
 		return err
 	}
 
 	if err = s.AddConsumer(cons); err != nil {
+		cancel()
+		s.removeHandle(url, h)
 		return err
 	}
 
 	go func() {
-		run()
-		s.RemoveConsumer(cons)
+		defer s.removeHandle(url, h)
 
-		// TODO: more smart retry
-		time.Sleep(5 * time.Second)
-		_ = s.Publish(url)
+		retry := 0
+		for {
+			// register cons under mu, or bail if already cancelled, so a stop can't miss it
+			s.mu.Lock()
+			if ctx.Err() != nil {
+				s.mu.Unlock()
+				s.RemoveConsumer(cons)
+				return
+			}
+			h.cons = cons
+			s.mu.Unlock()
+
+			run()
+			s.RemoveConsumer(cons)
+
+			// exponential backoff, same schedule as producer.go reconnect
+			timeout := time.Minute
+			if retry < 5 {
+				timeout = time.Second
+			} else if retry < 10 {
+				timeout = time.Second * 5
+			} else if retry < 20 {
+				timeout = time.Second * 10
+			}
+			retry++
+
+			log.Debug().Msgf("[streams] publish retry=%d timeout=%s url=%s", retry, timeout, url)
+
+			select {
+			case <-ctx.Done():
+				log.Debug().Msgf("[streams] publish cancelled url=%s", url)
+				return
+			case <-time.After(timeout):
+			}
+
+			cons, run, err = GetConsumer(url)
+			if err != nil {
+				log.Warn().Err(err).Msgf("[streams] publish permanent error, stopping url=%s", url)
+				return
+			}
+			if err = s.AddConsumer(cons); err != nil {
+				log.Debug().Err(err).Msgf("[streams] publish add consumer failed url=%s", url)
+				continue
+			}
+		}
 	}()
 
 	return nil
+}
+
+// removeHandle drops h only if it's still the current handle, so a fast republish
+// that already installed a new handle isn't clobbered.
+func (s *Stream) removeHandle(url string, h *publishHandle) {
+	s.mu.Lock()
+	if s.publishes[url] == h {
+		delete(s.publishes, url)
+	}
+	s.mu.Unlock()
+}
+
+// StopPublish cancels the publish goroutine for url and closes its live consumer,
+// so an in-flight run() unblocks at once instead of lingering until the remote drops.
+func (s *Stream) StopPublish(url string) {
+	s.mu.Lock()
+	h, ok := s.publishes[url]
+	var cons core.Consumer
+	if ok {
+		h.cancel() // cancel under mu, serialized with the goroutine's ctx check
+		cons = h.cons
+		delete(s.publishes, url)
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		return
+	}
+	if cons != nil {
+		s.RemoveConsumer(cons) // RemoveConsumer takes mu, so call it unlocked
+	}
+	log.Info().Msgf("[streams] stopped publish url=%s", url)
+}
+
+// StopAllPublish stops every active publish on this stream.
+func (s *Stream) StopAllPublish() {
+	s.mu.Lock()
+	conss := make([]core.Consumer, 0, len(s.publishes))
+	for _, h := range s.publishes {
+		h.cancel()
+		if h.cons != nil {
+			conss = append(conss, h.cons)
+		}
+	}
+	s.publishes = make(map[string]*publishHandle)
+	s.mu.Unlock()
+
+	for _, cons := range conss {
+		s.RemoveConsumer(cons)
+	}
 }
 
 func Publish(stream *Stream, destination any) {

--- a/internal/streams/publish_test.go
+++ b/internal/streams/publish_test.go
@@ -1,0 +1,84 @@
+package streams
+
+import (
+	"context"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/stretchr/testify/require"
+)
+
+// stopConsumer records Stop calls so tests can check the live consumer was closed.
+type stopConsumer struct {
+	stopped int
+}
+
+func (c *stopConsumer) GetMedias() []*core.Media                                { return nil }
+func (c *stopConsumer) AddTrack(*core.Media, *core.Codec, *core.Receiver) error { return nil }
+
+func (c *stopConsumer) Stop() error {
+	c.stopped++
+	return nil
+}
+
+// addPublish installs a fake active publish and returns its consumer and context.
+func addPublish(s *Stream, url string) (*publishHandle, *stopConsumer, context.Context) {
+	cons := &stopConsumer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	h := &publishHandle{cancel: cancel, cons: cons}
+
+	if s.publishes == nil {
+		s.publishes = map[string]*publishHandle{}
+	}
+	s.publishes[url] = h
+
+	return h, cons, ctx
+}
+
+func TestStopPublish(t *testing.T) {
+	s := &Stream{}
+	_, cons, ctx := addPublish(s, "rtmp://host/a")
+
+	s.StopPublish("rtmp://host/a")
+
+	require.Error(t, ctx.Err(), "retry loop should be cancelled")
+	require.Equal(t, 1, cons.stopped, "live consumer should be closed")
+	require.Empty(t, s.publishes, "handle should be removed")
+}
+
+func TestStopPublishUnknownURL(t *testing.T) {
+	s := &Stream{}
+	_, cons, ctx := addPublish(s, "rtmp://host/a")
+
+	s.StopPublish("rtmp://host/other")
+
+	require.NoError(t, ctx.Err())
+	require.Equal(t, 0, cons.stopped)
+	require.Len(t, s.publishes, 1)
+}
+
+func TestStopAllPublish(t *testing.T) {
+	s := &Stream{}
+	_, consA, ctxA := addPublish(s, "rtmp://host/a")
+	_, consB, ctxB := addPublish(s, "rtmp://host/b")
+
+	s.StopAllPublish()
+
+	require.Error(t, ctxA.Err())
+	require.Error(t, ctxB.Err())
+	require.Equal(t, 1, consA.stopped)
+	require.Equal(t, 1, consB.stopped)
+	require.Empty(t, s.publishes)
+}
+
+func TestRemoveHandleKeepsNewer(t *testing.T) {
+	s := &Stream{}
+	old, _, _ := addPublish(s, "rtmp://host/a")
+	current, _, _ := addPublish(s, "rtmp://host/a") // replaces old in the map
+
+	s.removeHandle("rtmp://host/a", old)
+	require.Same(t, current, s.publishes["rtmp://host/a"], "newer handle must survive")
+
+	s.removeHandle("rtmp://host/a", current)
+	require.Empty(t, s.publishes)
+}

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -13,6 +13,7 @@ type Stream struct {
 	consumers []core.Consumer
 	mu        sync.Mutex
 	pending   atomic.Int32
+	publishes map[string]*publishHandle // active publishes by dst URL (guarded by mu)
 }
 
 func NewStream(source any) *Stream {

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -61,9 +61,13 @@ func New(name string, sources ...string) (*Stream, error) {
 		}
 	}
 
-	stream := NewStream(sources)
-
+	// stop active publishes on the old stream before replacing it
 	streamsMu.Lock()
+	if old, ok := streams[name]; ok {
+		old.StopAllPublish()
+	}
+
+	stream := NewStream(sources)
 	streams[name] = stream
 	streamsMu.Unlock()
 
@@ -152,6 +156,9 @@ func Get(name string) *Stream {
 func Delete(name string) {
 	streamsMu.Lock()
 	defer streamsMu.Unlock()
+	if s, ok := streams[name]; ok {
+		s.StopAllPublish()
+	}
 	delete(streams, name)
 }
 

--- a/pkg/rtmp/client.go
+++ b/pkg/rtmp/client.go
@@ -147,6 +147,10 @@ func (c *Conn) publish() error {
 		return err
 	}
 
+	c.mu.Lock()
+	c.publishing = true // Close should now gracefully unpublish
+	c.mu.Unlock()
+
 	go func() {
 		for {
 			_, _, _, err := c.readMessage()

--- a/pkg/rtmp/conn.go
+++ b/pkg/rtmp/conn.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/flv/amf"
 )
 
@@ -40,9 +42,22 @@ type Conn struct {
 	rdBuf []byte
 	wrBuf []byte
 	mu    sync.Mutex
+
+	publishing bool // guards graceful unpublish on Close (under mu)
 }
 
 func (c *Conn) Close() error {
+	c.mu.Lock()
+	publishing := c.publishing
+	c.mu.Unlock()
+
+	if publishing {
+		// best-effort: release the stream name now instead of at the idle timeout.
+		// The socket is often already dead, so cap the write and ignore errors.
+		_ = c.conn.SetWriteDeadline(time.Now().Add(core.ConnDeadline))
+		_ = c.writeUnpublish()
+	}
+
 	return c.conn.Close()
 }
 
@@ -275,6 +290,17 @@ func (c *Conn) writeReleaseStream() error {
 		return err
 	}
 	return nil
+}
+
+// writeUnpublish sends the FCUnpublish + deleteStream pair so the server frees the
+// stream name and fires its publish-done hooks. Transaction id 0: no reply expected.
+func (c *Conn) writeUnpublish() error {
+	b := amf.EncodeItems("FCUnpublish", 0, nil, c.Stream)
+	if err := c.writeMessage(3, TypeCommand, 0, b); err != nil {
+		return err
+	}
+	b = amf.EncodeItems("deleteStream", 0, nil, int(c.streamID))
+	return c.writeMessage(3, TypeCommand, 0, b)
 }
 func (c *Conn) writeCreateStream() error {
 	b := amf.EncodeItems("createStream", 4, nil)

--- a/pkg/rtmp/unpublish_test.go
+++ b/pkg/rtmp/unpublish_test.go
@@ -1,0 +1,42 @@
+package rtmp
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseSendsUnpublish(t *testing.T) {
+	client, server := net.Pipe()
+	c := &Conn{conn: client, wr: client, wrPacketSize: 4096, streamID: 1, Stream: "streamkey", publishing: true}
+
+	got := make(chan []byte, 1)
+	go func() {
+		b, _ := io.ReadAll(server)
+		got <- b
+	}()
+
+	require.NoError(t, c.Close())
+
+	b := string(<-got)
+	require.Contains(t, b, "FCUnpublish")
+	require.Contains(t, b, "deleteStream")
+	require.Contains(t, b, "streamkey")
+}
+
+// A non-publishing connection (player or server side) closes without sending anything.
+func TestCloseNoUnpublishWhenNotPublishing(t *testing.T) {
+	client, server := net.Pipe()
+	c := &Conn{conn: client, wr: client}
+
+	got := make(chan int, 1)
+	go func() {
+		b, _ := io.ReadAll(server)
+		got <- len(b)
+	}()
+
+	require.NoError(t, c.Close())
+	require.Zero(t, <-got)
+}


### PR DESCRIPTION
Closes #2037.

We publish out to media servers (Ant Media over RTMP/RTMPS) from production, and wanted to be nicer to them: stop a push cleanly so they aren't left holding a dead connection, and have a way to stop publishing without nuking the whole stream.

Today there's no way to stop an outgoing publish on its own. The empty-`src` call from #2037 doesn't tear down the publish consumer, so the push and its FFmpeg process keep running until the container restarts. `DELETE /api/streams?src=NAME` works but it's destructive: it removes the stream definition too.

This bit us publishing to Ant Media over an unstable network. When the outbound connection dropped, the original retry (a flat 5s sleep then recurse, no backoff, no way to cancel) reconnected every 5s forever, the dead connection lingered, and FFmpeg stayed up. A flaky link turned into a constant reconnect loop, and the only way out was restarting the container.

Two stop paths:

```text
DELETE /api/streams?src=NAME&dst=URL   stop one publish, keep the stream
DELETE /api/streams?src=NAME           stop all publishes, then delete the stream
```

The single-arg form keeps its old behaviour, it just stops active publishes first so it no longer leaks a running push.

Stopping a publish closes its live consumer and cancels the retry loop. Closing the consumer is what makes it immediate: the publish goroutine spends most of its life inside `run()` copying frames to the remote, so closing the consumer unblocks that copy and ends the push right away instead of waiting for the remote to drop. Cancelling the loop covers the gaps between retries.

Making the retry cancellable meant turning the `// TODO: more smart retry` placeholder (`sleep 5s` then recurse) into a real loop, which brings two small behaviour changes:

- retry uses the same exponential backoff schedule as `producer.go` `reconnect`, instead of a flat 5s
- publishing the same `dst` again replaces the previous publish instead of stacking a second one

Both stop calls are documented in `internal/streams/README.md`.

### Graceful RTMP teardown

The second commit tears the RTMP connection down cleanly on stop. Before, closing the consumer closed the socket with a bare TCP close, so the server only learned the publish ended when it noticed the dropped socket and freed the stream name after an idle timeout. A fast republish of the same key could then be rejected, and publish-done hooks fired late. The client now sends the `FCUnpublish` + `deleteStream` pair a normal publisher sends before disconnecting, then closes. It's best-effort (the socket is often already dead, which is why we're closing), bounded by a write deadline, and only runs for a client that reached the published state. Players and the server side are unchanged.

### On the API shape

I went with `DELETE` rather than mirroring the playback stop (`POST dst=camera&src=` empties the source). The mirror for publish would be `POST src=NAME&dst=`, but that can only stop every publish on a stream at once. A stream can publish to several destinations (the README example sends one stream to both Telegram and YouTube), and `DELETE src=NAME&dst=URL` can stop just one of them while the rest keep running. Happy to switch it to `POST` if you'd rather have the consistency, just wanted to flag the trade-off rather than decide it for you.

### Testing

- `internal/streams/publish_test.go` covers `StopPublish`, `StopAllPublish`, and the `removeHandle` republish guard: the live consumer gets closed, the retry context is cancelled, the map is cleaned up, and a stale handle doesn't clobber a newer one.
- `pkg/rtmp/unpublish_test.go` checks that closing a publishing connection sends `FCUnpublish` + `deleteStream`, and a non-publishing one sends nothing. All pass under `-race`.
- `go build`, `go vet`, and `gofmt` are clean.
- Manually: start a publish, confirm the consumer shows in `/api/streams`, then `DELETE ...&dst=...` and confirm the consumer and FFmpeg process both go away while the stream stays. Plain `DELETE ...?src=NAME` still removes the stream.

(`TestRecursion` and `TestTempate` in this package already fail on a clean `master` checkout when the package is tested in isolation, because the source handlers are registered by the main binary's blank imports and aren't linked into a bare package test. Both are unrelated to this change.)
