### PR TITLE
fix(mdns): surface per-interface bind errors

### DIFF
--- a/pkg/mdns/client.go
+++ b/pkg/mdns/client.go
@@ -189,9 +189,11 @@ func (b *Browser) ListenMulticastUDP() error {
 
 	ctx := context.Background()
 
+	var bindErrs []error
 	for _, ipn := range nets {
 		conn, err := lc1.ListenPacket(ctx, "udp4", ipn.IP.String()+":5353") // same port important
 		if err != nil {
+			bindErrs = append(bindErrs, fmt.Errorf("%s: %w", ipn.IP, err))
 			continue
 		}
 		b.Nets = append(b.Nets, ipn)
@@ -199,6 +201,9 @@ func (b *Browser) ListenMulticastUDP() error {
 	}
 
 	if b.Sends == nil {
+		if len(bindErrs) > 0 {
+			return fmt.Errorf("no interfaces for listen: %w", errors.Join(bindErrs...))
+		}
 		return errors.New("no interfaces for listen")
 	}
 


### PR DESCRIPTION
## Summary

The mDNS sender loop in `pkg/mdns/client.go` silently swallows every `ListenPacket` error and returns a generic `error="no interfaces for listen"` if nothing binds. This PR collects the per-IP causes with `errors.Join` so the log actually shows what failed.

Before:
```
ERR error="no interfaces for listen"
```

After:
```
ERR error="no interfaces for listen: 192.168.1.10: listen udp4 192.168.1.10:5353: bind: address already in use"
```

The success path is unchanged.

## Why

When users hit this error today (issue #1225 — Class-B LAN inside `172.16.0.0/12` is filtered out; issue #2266 — `EADDRINUSE` because another mDNS responder on the host already holds `:5353`), the message gives no clue which it is. With the per-IP cause attached, the right diagnosis becomes obvious from the log.

## Changes

`pkg/mdns/client.go` only — 5 added lines, no public API change, no behaviour change on the success path.

## Tested

- `go build ./...` — clean
- linux/amd64 build deployed in a Frigate container original `no interfaces for listen` was replaced by the actionable `… 192.168.178.2: bind: address already in use`, exposing the host-avahi `:5353` collision.

## Refs

- #1225
- #2266
- Smaller alternative to #1283 — fixes the diagnostic only; the auto-discovery filter and any opt-in override are out of scope here and would be separate PRs if/when needed.
