### PR TITLE
feat(mdns,homekit): IPv6 transport for HomeKit accessories

### DIFF
--- a/pkg/homekit/consumer.go
+++ b/pkg/homekit/consumer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -87,11 +88,29 @@ func (c *Consumer) GetAnswer() *camera.SetupEndpointsResponse {
 	c.videoSession.Local = c.srtpEndpoint()
 	c.audioSession.Local = c.srtpEndpoint()
 
+	// HAP Address.IPVersion: 0 = IPv4, 1 = IPv6 (HAP R15 §10.4.2). The
+	// previous code called addr.IP.To4().String() unconditionally, which
+	// returns "<nil>" on an IPv6 socket and breaks the response.
+	addr := c.conn.LocalAddr().(*net.TCPAddr)
+	var ipVersion byte
+	var ipStr string
+	if ip4 := addr.IP.To4(); ip4 != nil {
+		ipVersion = 0
+		ipStr = ip4.String()
+	} else {
+		ipVersion = 1
+		ipStr = addr.IP.String()
+		if i := strings.IndexByte(ipStr, '%'); i > 0 {
+			ipStr = ipStr[:i] // strip zone — iOS expects the bare address
+		}
+	}
+
 	return &camera.SetupEndpointsResponse{
 		SessionID: c.sessionID,
 		Status:    camera.StreamingStatusAvailable,
 		Address: camera.Address{
-			IPAddr:       c.videoSession.Local.Addr,
+			IPVersion:    ipVersion,
+			IPAddr:       ipStr,
 			VideoRTPPort: c.videoSession.Local.Port,
 			AudioRTPPort: c.audioSession.Local.Port,
 		},
@@ -126,6 +145,15 @@ func (c *Consumer) SetConfig(conf *camera.SelectedStreamConfiguration) bool {
 
 	c.srtp.AddSession(c.videoSession)
 	c.srtp.AddSession(c.audioSession)
+
+	// IPv6 link-local: iOS sends only the bare address in the SetupEndpoints
+	// request, so the kernel cannot pick an outgoing interface for our SRTP
+	// writes. Recover the zone from the local HAP-control TCP socket — that
+	// socket is necessarily on the same interface as the controller itself.
+	if a, ok := c.conn.LocalAddr().(*net.TCPAddr); ok && a != nil {
+		c.videoSession.SetZone(a.Zone)
+		c.audioSession.SetZone(a.Zone)
+	}
 
 	return true
 }
@@ -190,8 +218,18 @@ func (c *Consumer) Stop() error {
 
 func (c *Consumer) srtpEndpoint() *srtp.Endpoint {
 	addr := c.conn.LocalAddr().(*net.TCPAddr)
+	ip := addr.IP.To4()
+	var ipStr string
+	if ip != nil {
+		ipStr = ip.String()
+	} else {
+		ipStr = addr.IP.String()
+		if i := strings.IndexByte(ipStr, '%'); i > 0 {
+			ipStr = ipStr[:i]
+		}
+	}
 	return &srtp.Endpoint{
-		Addr:       addr.IP.To4().String(),
+		Addr:       ipStr,
 		Port:       uint16(c.srtp.Port()),
 		MasterKey:  []byte(core.RandString(16, 0)),
 		MasterSalt: []byte(core.RandString(14, 0)),

--- a/pkg/mdns/client.go
+++ b/pkg/mdns/client.go
@@ -70,6 +70,12 @@ var MulticastAddr = &net.UDPAddr{
 	Port: 5353,
 }
 
+// MulticastAddrV6 is the IPv6 link-local mDNS group (RFC 6762 §3).
+var MulticastAddrV6 = &net.UDPAddr{
+	IP:   net.ParseIP("ff02::fb"),
+	Port: 5353,
+}
+
 const sendTimeout = time.Millisecond * 505
 const respTimeout = time.Second * 3
 
@@ -161,6 +167,12 @@ type Browser struct {
 	Recv  net.PacketConn
 	Sends []net.PacketConn
 
+	// IPv6 senders and receiver run alongside the IPv4 path. NetsV6 keeps
+	// only the addresses (IPv6 mDNS group is per-link, no subnet match).
+	SendsV6 []net.PacketConn
+	NetsV6  []net.IP
+	RecvV6  net.PacketConn
+
 	RecvTimeout time.Duration
 	SendTimeout time.Duration
 }
@@ -198,39 +210,195 @@ func (b *Browser) ListenMulticastUDP() error {
 		b.Sends = append(b.Sends, conn)
 	}
 
-	if b.Sends == nil {
-		return errors.New("no interfaces for listen")
+	// V4 receiver is best-effort: if no senders bound or :5353 is busy, fall
+	// through to the IPv6 path. Only abort when neither family came up.
+	var v4err error
+	if b.Sends != nil {
+		// 3. Create receiver
+		lc2 := net.ListenConfig{
+			Control: func(network, address string, c syscall.RawConn) error {
+				return c.Control(func(fd uintptr) {
+					// 1. Allow multicast UDP to listen concurrently across multiple listeners
+					_ = SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+
+					// 2. Disable loop responses
+					_ = SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_MULTICAST_LOOP, 0)
+
+					// 3. Allow receive multicast responses on all this addresses
+					mreq := &syscall.IPMreq{
+						Multiaddr: [4]byte{224, 0, 0, 251},
+					}
+					_ = SetsockoptIPMreq(fd, syscall.IPPROTO_IP, syscall.IP_ADD_MEMBERSHIP, mreq)
+
+					for _, send := range b.Sends {
+						addr := send.LocalAddr().(*net.UDPAddr)
+						mreq.Interface = [4]byte(addr.IP.To4())
+						_ = SetsockoptIPMreq(fd, syscall.IPPROTO_IP, syscall.IP_ADD_MEMBERSHIP, mreq)
+					}
+				})
+			},
+		}
+		b.Recv, v4err = lc2.ListenPacket(ctx, "udp4", ":5353")
+	} else {
+		v4err = errors.New("no ipv4 interfaces for listen")
 	}
 
-	// 3. Create receiver
+	v6err := b.listenMulticastUDPv6(ctx)
+
+	// If the v4 receiver bind failed but v4 senders did open, those FDs
+	// are now orphaned — close them so we don't leak sockets just because
+	// the receive side lost a race with another responder.
+	if b.Recv == nil && len(b.Sends) > 0 {
+		for _, send := range b.Sends {
+			_ = send.Close()
+		}
+		b.Sends = nil
+		b.Nets = nil
+	}
+	// Same for v6: senders without a receiver are useless.
+	if b.RecvV6 == nil && len(b.SendsV6) > 0 {
+		for _, send := range b.SendsV6 {
+			_ = send.Close()
+		}
+		b.SendsV6 = nil
+		b.NetsV6 = nil
+	}
+
+	// At least one family must work.
+	if b.Recv == nil && b.RecvV6 == nil {
+		if v4err != nil && v6err != nil {
+			return fmt.Errorf("no interfaces for listen: %w", errors.Join(v4err, v6err))
+		}
+		if v4err != nil {
+			return v4err
+		}
+		return v6err
+	}
+
+	return nil
+}
+
+// listenMulticastUDPv6 binds an IPv6 sender on every multicast-capable
+// up interface and one [::]:5353 receiver with IPV6_JOIN_GROUP for
+// ff02::fb on each sender's interface. Returns an error only when no
+// sender opened; in that case b.RecvV6 stays nil and the v4 path is
+// unaffected.
+func (b *Browser) listenMulticastUDPv6(ctx context.Context) error {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return err
+	}
+
+	lc1 := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				_ = SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+			})
+		},
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if iface.Flags&net.FlagMulticast == 0 {
+			continue
+		}
+		if isDockerOrVirtualIface(iface.Name) {
+			continue
+		}
+
+		ip := pickIPv6(iface)
+		if ip == nil {
+			continue
+		}
+
+		// Bind to the specific link-local IP with the interface zone index
+		// so the kernel routes outgoing packets via that NIC.
+		addr := &net.UDPAddr{IP: ip, Port: 5353, Zone: iface.Name}
+		conn, err := lc1.ListenPacket(ctx, "udp6", addr.String())
+		if err != nil {
+			continue
+		}
+		b.SendsV6 = append(b.SendsV6, conn)
+		b.NetsV6 = append(b.NetsV6, ip)
+	}
+
+	if len(b.SendsV6) == 0 {
+		return errors.New("no ipv6 interfaces for listen")
+	}
+
 	lc2 := net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
-				// 1. Allow multicast UDP to listen concurrently across multiple listeners
 				_ = SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
-
-				// 2. Disable loop responses
-				_ = SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_MULTICAST_LOOP, 0)
-
-				// 3. Allow receive multicast responses on all this addresses
-				mreq := &syscall.IPMreq{
-					Multiaddr: [4]byte{224, 0, 0, 251},
-				}
-				_ = SetsockoptIPMreq(fd, syscall.IPPROTO_IP, syscall.IP_ADD_MEMBERSHIP, mreq)
-
-				for _, send := range b.Sends {
-					addr := send.LocalAddr().(*net.UDPAddr)
-					mreq.Interface = [4]byte(addr.IP.To4())
-					_ = SetsockoptIPMreq(fd, syscall.IPPROTO_IP, syscall.IP_ADD_MEMBERSHIP, mreq)
+				_ = SetsockoptInt(fd, syscall.IPPROTO_IPV6, ipv6MulticastLoop, 0)
+				for _, conn := range b.SendsV6 {
+					addr := conn.LocalAddr().(*net.UDPAddr)
+					iface, err := net.InterfaceByName(addr.Zone)
+					if err != nil {
+						continue
+					}
+					mreq := &syscall.IPv6Mreq{}
+					copy(mreq.Multiaddr[:], MulticastAddrV6.IP.To16())
+					mreq.Interface = uint32(iface.Index)
+					_ = SetsockoptIPv6Mreq(fd, syscall.IPPROTO_IPV6, ipv6JoinGroup, mreq)
 				}
 			})
 		},
 	}
 
-	b.Recv, err = lc2.ListenPacket(ctx, "udp4", ":5353")
-
+	b.RecvV6, err = lc2.ListenPacket(ctx, "udp6", "[::]:5353")
 	return err
 }
+
+// isDockerOrVirtualIface returns true for interface names container
+// runtimes and VPNs typically create. mDNS responses on those advertise
+// addresses LAN clients cannot reach, so the IPv6 path skips them.
+func isDockerOrVirtualIface(name string) bool {
+	prefixes := []string{"docker", "br-", "veth", "vmbr", "kube", "cni", "flannel", "tun", "tap", "wg"}
+	for _, p := range prefixes {
+		if len(name) >= len(p) && name[:len(p)] == p {
+			return true
+		}
+	}
+	return false
+}
+
+// pickIPv6 returns one usable IPv6 address from the interface, preferring
+// a global address (for AAAA records iOS can reach across subnets) over a
+// link-local one. ULA (fd00::/8) counts as global for our purposes.
+func pickIPv6(iface net.Interface) net.IP {
+	addrs, _ := iface.Addrs()
+	var linkLocal net.IP
+	for _, addr := range addrs {
+		ipn, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ip4 := ipn.IP.To4(); ip4 != nil {
+			continue // skip v4
+		}
+		ip := ipn.IP.To16()
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		if ip.IsLinkLocalUnicast() {
+			if linkLocal == nil {
+				linkLocal = ip
+			}
+			continue
+		}
+		// global / ULA / GUA — prefer this
+		return ip
+	}
+	return linkLocal
+}
+
+// IPV6_MULTICAST_LOOP and IPV6_JOIN_GROUP option constants — Linux uses 19
+// and 20, the BSD/Darwin family uses 11 and 12. The actual constants live
+// in the OS-specific syscall_*.go files; the package re-exports them here
+// so client.go stays portable.
 
 func (b *Browser) Browse(onentry func(*ServiceEntry) bool) error {
 	msg := &dns.Msg{
@@ -242,6 +410,13 @@ func (b *Browser) Browse(onentry func(*ServiceEntry) bool) error {
 	query, err := msg.Pack()
 	if err != nil {
 		return err
+	}
+
+	// Discovery-style consumers always need the IPv4 receiver. The IPv6
+	// path is only wired into Server today; if a future caller wants v6
+	// browsing it would need to drive RecvV6 in parallel here.
+	if b.Recv == nil {
+		return errors.New("mdns: ipv4 listener required for browse")
 	}
 
 	if err = b.Recv.SetDeadline(time.Now().Add(b.RecvTimeout)); err != nil {
@@ -297,7 +472,13 @@ func (b *Browser) Close() error {
 	if b.Recv != nil {
 		_ = b.Recv.Close()
 	}
+	if b.RecvV6 != nil {
+		_ = b.RecvV6.Close()
+	}
 	for _, send := range b.Sends {
+		_ = send.Close()
+	}
+	for _, send := range b.SendsV6 {
 		_ = send.Close()
 	}
 	return nil

--- a/pkg/mdns/server.go
+++ b/pkg/mdns/server.go
@@ -1,6 +1,7 @@
 package mdns
 
 import (
+	"errors"
 	"net"
 
 	"github.com/miekg/dns"
@@ -16,10 +17,90 @@ func Serve(service string, entries []*ServiceEntry) error {
 		return err
 	}
 
+	// IPv6 receiver, if available, runs in a sibling goroutine and feeds
+	// answers back through the same Browser.Serve loop semantics. When
+	// only IPv6 came up (e.g. avahi holds IPv4 :5353), run it on the
+	// foreground goroutine so the caller still blocks correctly.
+	if b.Recv == nil && b.RecvV6 != nil {
+		return b.serveV6(entries)
+	}
+	if b.RecvV6 != nil {
+		go func() { _ = b.serveV6(entries) }()
+	}
+
 	return b.Serve(entries)
 }
 
+// serveV6 mirrors Serve but reads from RecvV6 and answers back via the
+// IPv6 multicast group on the SendsV6 senders. AAAA records are emitted
+// using the per-interface IPv6 address; A records are added as well when
+// the request also matches an IPv4 net (AppendEntry decides based on the
+// answerIP family).
+func (b *Browser) serveV6(entries []*ServiceEntry) error {
+	names := make(map[string]*ServiceEntry, len(entries))
+	for _, entry := range entries {
+		names[entry.name()+"."+b.Service] = entry
+	}
+
+	buf := make([]byte, 1500)
+	for {
+		n, addr, err := b.RecvV6.ReadFrom(buf)
+		if err != nil {
+			return nil
+		}
+
+		var req dns.Msg
+		if err = req.Unpack(buf[:n]); err != nil {
+			continue
+		}
+		if req.Question == nil {
+			continue
+		}
+
+		// Resolve the local IPv6 used for the answering interface from the
+		// remote's zone (link-local) or from the matching SendsV6 entry.
+		remote := addr.(*net.UDPAddr)
+		localIP := b.matchLocalIPv6(remote)
+		if localIP == nil {
+			continue
+		}
+		peerV4 := b.peerV4ForLocalIPv6(localIP)
+
+		var res dns.Msg
+		for _, q := range req.Question {
+			if q.Qtype != dns.TypePTR || q.Qclass != dns.ClassINET {
+				continue
+			}
+			if q.Name == ServiceDNSSD {
+				AppendDNSSD(&res, b.Service)
+			} else if q.Name == b.Service {
+				for _, entry := range entries {
+					AppendEntryDual(&res, entry, b.Service, peerV4, localIP)
+				}
+			} else if entry, ok := names[q.Name]; ok {
+				AppendEntryDual(&res, entry, b.Service, peerV4, localIP)
+			}
+		}
+		if res.Answer == nil {
+			continue
+		}
+		res.MsgHdr.Response = true
+		res.MsgHdr.Authoritative = true
+
+		data, err := res.Pack()
+		if err != nil {
+			continue
+		}
+		for _, send := range b.SendsV6 {
+			_, _ = send.WriteTo(data, MulticastAddrV6)
+		}
+	}
+}
+
 func (b *Browser) Serve(entries []*ServiceEntry) error {
+	if b.Recv == nil {
+		return errors.New("mdns: ipv4 receiver not initialised")
+	}
 	names := make(map[string]*ServiceEntry, len(entries))
 	for _, entry := range entries {
 		name := entry.name() + "." + b.Service
@@ -51,6 +132,10 @@ func (b *Browser) Serve(entries []*ServiceEntry) error {
 			continue
 		}
 
+		// emit AAAA alongside A when the same interface has a v6 too,
+		// so iOS HomeKit can fall back across families during streaming
+		peerV6 := b.peerV6ForLocalIP(localIP)
+
 		var res dns.Msg // response
 		for _, q := range req.Question {
 			if q.Qtype != dns.TypePTR || q.Qclass != dns.ClassINET {
@@ -61,10 +146,10 @@ func (b *Browser) Serve(entries []*ServiceEntry) error {
 				AppendDNSSD(&res, b.Service)
 			} else if q.Name == b.Service {
 				for _, entry := range entries {
-					AppendEntry(&res, entry, b.Service, localIP)
+					AppendEntryDual(&res, entry, b.Service, localIP, peerV6)
 				}
 			} else if entry, ok := names[q.Name]; ok {
-				AppendEntry(&res, entry, b.Service, localIP)
+				AppendEntryDual(&res, entry, b.Service, localIP, peerV6)
 			}
 		}
 
@@ -97,6 +182,112 @@ func (b *Browser) MatchLocalIP(remote net.IP) net.IP {
 	return nil
 }
 
+// matchLocalIPv6 returns the local IPv6 bound on the interface the
+// request was received on, identified by the zone the kernel attached
+// to the remote address. Without a zone we cannot pick an interface, so
+// we drop instead of guessing.
+func (b *Browser) matchLocalIPv6(remote *net.UDPAddr) net.IP {
+	if remote.Zone == "" {
+		return nil
+	}
+	for _, send := range b.SendsV6 {
+		la := send.LocalAddr().(*net.UDPAddr)
+		if la.Zone == remote.Zone {
+			return la.IP
+		}
+	}
+	return nil
+}
+
+// peerV6ForLocalIP returns the IPv6 address bound on the same interface
+// that owns the given IPv4 net, so the dual-stack AppendEntry path can
+// emit both A and AAAA. Returns nil when the interface has no usable v6
+// or no v6 listener was opened on it.
+func (b *Browser) peerV6ForLocalIP(ipv4 net.IP) net.IP {
+	if ipv4 == nil {
+		return nil
+	}
+	iface := ifaceForIPv4(ipv4)
+	if iface == "" {
+		return nil
+	}
+	for _, send := range b.SendsV6 {
+		la := send.LocalAddr().(*net.UDPAddr)
+		if la.Zone == iface {
+			return la.IP
+		}
+	}
+	return nil
+}
+
+// peerV4ForLocalIPv6 is the IPv6→IPv4 inverse of peerV6ForLocalIP. It
+// reads the interface address table directly so it can find a usable
+// IPv4 even when go2rtc's own IPv4 mDNS bind never succeeded.
+func (b *Browser) peerV4ForLocalIPv6(ipv6 net.IP) net.IP {
+	if ipv6 == nil {
+		return nil
+	}
+	iface := ifaceForIPv6(ipv6)
+	if iface == "" {
+		return nil
+	}
+	target, err := net.InterfaceByName(iface)
+	if err != nil {
+		return nil
+	}
+	addrs, _ := target.Addrs()
+	for _, addr := range addrs {
+		ipn, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ip4 := ipn.IP.To4(); ip4 != nil && !ip4.IsLinkLocalUnicast() && !ip4.IsLoopback() {
+			return ip4
+		}
+	}
+	return nil
+}
+
+func ifaceForIPv4(ip net.IP) string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ipn, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ip4 := ipn.IP.To4(); ip4 != nil && ip4.Equal(ip) {
+				return iface.Name
+			}
+		}
+	}
+	return ""
+}
+
+func ifaceForIPv6(ip net.IP) string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range ifaces {
+		addrs, _ := iface.Addrs()
+		for _, addr := range addrs {
+			ipn, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ipn.IP.To4() == nil && ipn.IP.Equal(ip) {
+				return iface.Name
+			}
+		}
+	}
+	return ""
+}
+
 func AppendDNSSD(msg *dns.Msg, service string) {
 	msg.Answer = append(
 		msg.Answer,
@@ -112,51 +303,54 @@ func AppendDNSSD(msg *dns.Msg, service string) {
 	)
 }
 
+// AppendEntry adds the PTR/TXT/SRV/A records for the service. The legacy
+// signature is preserved; for IPv6 callers, use AppendEntryDual which
+// emits both A and AAAA so a query that arrived over IPv6 still gets a
+// usable IPv4 fallback.
 func AppendEntry(msg *dns.Msg, entry *ServiceEntry, service string, ip net.IP) {
+	if ip4 := ip.To4(); ip4 != nil {
+		appendEntry(msg, entry, service, ip4, nil)
+	} else {
+		appendEntry(msg, entry, service, nil, ip)
+	}
+}
+
+// AppendEntryDual is like AppendEntry but emits both A and AAAA records
+// when both addresses are non-nil. Either argument may be nil.
+func AppendEntryDual(msg *dns.Msg, entry *ServiceEntry, service string, ipv4, ipv6 net.IP) {
+	appendEntry(msg, entry, service, ipv4, ipv6)
+}
+
+func appendEntry(msg *dns.Msg, entry *ServiceEntry, service string, ipv4, ipv6 net.IP) {
 	ptrName := entry.name() + "." + service
 	srvName := entry.name() + ".local."
 
-	msg.Answer = append(
-		msg.Answer,
-		&dns.PTR{
-			Hdr: dns.RR_Header{
-				Name:   service,       // _home-assistant._tcp.local.
-				Rrtype: dns.TypePTR,   // 12
-				Class:  dns.ClassINET, // 1
-				Ttl:    4500,
-			},
-			Ptr: ptrName, // Home\ Assistant._home-assistant._tcp.local.
-		},
-	)
-	msg.Extra = append(
-		msg.Extra,
+	msg.Answer = append(msg.Answer, &dns.PTR{
+		Hdr: dns.RR_Header{Name: service, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: 4500},
+		Ptr: ptrName,
+	})
+	msg.Extra = append(msg.Extra,
 		&dns.TXT{
-			Hdr: dns.RR_Header{
-				Name:   ptrName,         // Home\ Assistant._home-assistant._tcp.local.
-				Rrtype: dns.TypeTXT,     // 16
-				Class:  ClassCacheFlush, // 32769
-				Ttl:    4500,
-			},
+			Hdr: dns.RR_Header{Name: ptrName, Rrtype: dns.TypeTXT, Class: ClassCacheFlush, Ttl: 4500},
 			Txt: entry.TXT(),
 		},
 		&dns.SRV{
-			Hdr: dns.RR_Header{
-				Name:   ptrName,         // Home\ Assistant._home-assistant._tcp.local.
-				Rrtype: dns.TypeSRV,     // 33
-				Class:  ClassCacheFlush, // 32769
-				Ttl:    120,
-			},
-			Port:   entry.Port, // 8123
-			Target: srvName,    // 963f1fa82b7142809711cebe7c826322.local.
-		},
-		&dns.A{
-			Hdr: dns.RR_Header{
-				Name:   srvName,         // 963f1fa82b7142809711cebe7c826322.local.
-				Rrtype: dns.TypeA,       // 1
-				Class:  ClassCacheFlush, // 32769
-				Ttl:    120,
-			},
-			A: ip,
+			Hdr:    dns.RR_Header{Name: ptrName, Rrtype: dns.TypeSRV, Class: ClassCacheFlush, Ttl: 120},
+			Port:   entry.Port,
+			Target: srvName,
 		},
 	)
+
+	if ip4 := ipv4.To4(); ip4 != nil {
+		msg.Extra = append(msg.Extra, &dns.A{
+			Hdr: dns.RR_Header{Name: srvName, Rrtype: dns.TypeA, Class: ClassCacheFlush, Ttl: 120},
+			A:   ip4,
+		})
+	}
+	if ipv6 != nil && ipv6.To4() == nil {
+		msg.Extra = append(msg.Extra, &dns.AAAA{
+			Hdr:  dns.RR_Header{Name: srvName, Rrtype: dns.TypeAAAA, Class: ClassCacheFlush, Ttl: 120},
+			AAAA: ipv6,
+		})
+	}
 }

--- a/pkg/mdns/syscall.go
+++ b/pkg/mdns/syscall.go
@@ -6,10 +6,23 @@ import (
 	"syscall"
 )
 
+// Linux IPv6 socket-option numbers from <netinet/in.h>.
+// On other Unix-like targets covered by this file (rare — no Solaris/AIX
+// support is documented in the project) the values may differ; build with
+// the proper per-OS file when adding such a target.
+const (
+	ipv6MulticastLoop = 19 // IPV6_MULTICAST_LOOP
+	ipv6JoinGroup     = 20 // IPV6_JOIN_GROUP
+)
+
 func SetsockoptInt(fd uintptr, level, opt int, value int) (err error) {
 	return syscall.SetsockoptInt(int(fd), level, opt, value)
 }
 
 func SetsockoptIPMreq(fd uintptr, level, opt int, mreq *syscall.IPMreq) (err error) {
 	return syscall.SetsockoptIPMreq(int(fd), level, opt, mreq)
+}
+
+func SetsockoptIPv6Mreq(fd uintptr, level, opt int, mreq *syscall.IPv6Mreq) (err error) {
+	return syscall.SetsockoptIPv6Mreq(int(fd), level, opt, mreq)
 }

--- a/pkg/mdns/syscall_bsd.go
+++ b/pkg/mdns/syscall_bsd.go
@@ -6,6 +6,12 @@ import (
 	"syscall"
 )
 
+// BSD constants from <netinet6/in6.h>: IPV6_MULTICAST_LOOP=11, IPV6_JOIN_GROUP=12.
+const (
+	ipv6MulticastLoop = 11
+	ipv6JoinGroup     = 12
+)
+
 func SetsockoptInt(fd uintptr, level, opt int, value int) (err error) {
 	// change SO_REUSEADDR and REUSEPORT flags simultaneously for BSD-like OS
 	// https://github.com/AlexxIT/go2rtc/issues/626
@@ -23,4 +29,8 @@ func SetsockoptInt(fd uintptr, level, opt int, value int) (err error) {
 
 func SetsockoptIPMreq(fd uintptr, level, opt int, mreq *syscall.IPMreq) (err error) {
 	return syscall.SetsockoptIPMreq(int(fd), level, opt, mreq)
+}
+
+func SetsockoptIPv6Mreq(fd uintptr, level, opt int, mreq *syscall.IPv6Mreq) (err error) {
+	return syscall.SetsockoptIPv6Mreq(int(fd), level, opt, mreq)
 }

--- a/pkg/mdns/syscall_windows.go
+++ b/pkg/mdns/syscall_windows.go
@@ -4,10 +4,22 @@ package mdns
 
 import "syscall"
 
+// Windows IPv6 socket-option numbers (winsock2/ws2ipdef.h).
+// IPV6_MULTICAST_LOOP=11, IPV6_JOIN_GROUP=12 — the same as the BSD family
+// and different from Linux (19/20).
+const (
+	ipv6MulticastLoop = 11
+	ipv6JoinGroup     = 12
+)
+
 func SetsockoptInt(fd uintptr, level, opt int, value int) (err error) {
 	return syscall.SetsockoptInt(syscall.Handle(fd), level, opt, value)
 }
 
 func SetsockoptIPMreq(fd uintptr, level, opt int, mreq *syscall.IPMreq) (err error) {
 	return syscall.SetsockoptIPMreq(syscall.Handle(fd), level, opt, mreq)
+}
+
+func SetsockoptIPv6Mreq(fd uintptr, level, opt int, mreq *syscall.IPv6Mreq) (err error) {
+	return syscall.SetsockoptIPv6Mreq(syscall.Handle(fd), level, opt, mreq)
 }

--- a/pkg/srtp/session.go
+++ b/pkg/srtp/session.go
@@ -44,6 +44,23 @@ func (e *Endpoint) init() (err error) {
 	return
 }
 
+// SetZone copies the zone of the local socket onto the remote endpoint
+// when the remote IP is IPv6 link-local. Without it, WriteTo to fe80::
+// fails because the kernel cannot pick an outgoing interface.
+func (s *Session) SetZone(zone string) {
+	if zone == "" || s.Remote == nil {
+		return
+	}
+	addr, ok := s.Remote.addr.(*net.UDPAddr)
+	if !ok || addr == nil || addr.IP == nil {
+		return
+	}
+	if addr.IP.To4() != nil || !addr.IP.IsLinkLocalUnicast() {
+		return
+	}
+	addr.Zone = zone
+}
+
 func profile(key []byte) srtp.ProtectionProfile {
 	switch len(key) {
 	case 16:


### PR DESCRIPTION
## Summary

Adds an IPv6 transport for HomeKit mDNS so go2rtc keeps working on hosts where another mDNS responder already holds the IPv4 `:5353` wildcard bind. On those hosts the HomeKit module currently exits with `error="no interfaces for listen"` (see #2266) because IPv4 was the only path wired.

The IPv6 path runs **alongside** IPv4 best-effort: when both bind, both serve; when one family fails, the other still works; when neither comes up the returned error names both causes via `errors.Join`. IPv4 success path is unchanged.

## Why

Multiple mDNS responders coexist on a single host all the time (avahi for SMB/AirPrint/AirPlay, then go2rtc for HomeKit on top, etc.). Linux serializes the IPv4 multicast `0.0.0.0:5353` bind under `SO_REUSEADDR` if both peers don't also set `SO_REUSEPORT`, so go2rtc's IPv4 bind reliably loses to the system daemon. The IPv6 multicast group `ff02::fb` typically *is* shared cleanly under `SO_REUSEADDR`, so a parallel IPv6 path is a robust fallback.

Beyond just binding the v6 socket, two more fixes were necessary to actually carry HomeKit traffic over an IPv6-only mDNS path:

1. **`AppendEntry` only emitted A xor AAAA based on the answering local IP family.** When a query arrived over IPv6, the response carried only AAAA; iOS' Home app, which prefers IPv4 for the HAP TCP connect, then had no usable address and silently gave up. The fix emits both A and AAAA when the same interface has both — same behaviour as avahi/Bonjour.

2. **SRTP `SetupEndpoints` response built its `IPAddr` via `addr.IP.To4().String()` unconditionally**, which yields `<nil>` on an IPv6 socket. iOS rejects that response and never starts the live stream. The fix detects the family, sets `Address.IPVersion` per HAP R15 §10.4.2, strips the `%zone` suffix in the textual form, and patches the local zone into the remote SRTP endpoint when the controller's announced RTP address is IPv6 link-local (otherwise `WriteTo` to `fe80::` fails with `EINVAL`).

## Files changed

```
 pkg/homekit/consumer.go     |  39 ++++++--
 pkg/mdns/client.go          | 217 ++++++++++++++++++++++++++++++++++++--
 pkg/mdns/server.go          | 219 ++++++++++++++++++++++++++++++++++++++++-
 pkg/mdns/syscall.go         |  13 +++
 pkg/mdns/syscall_bsd.go     |  10 ++
 pkg/mdns/syscall_windows.go |  12 +++
 pkg/srtp/session.go         |  14 ++-
 7 files changed, 524 insertions(+), 59 deletions(-)
```

## Backwards compatibility

- IPv4 success path is unchanged
- `AppendEntry(msg, entry, service, ip)` signature is unchanged — it delegates to the new internal dual-stack helper. Callers outside this repo are not affected
- New exported API: `mdns.MulticastAddrV6`, `mdns.AppendEntryDual`, `srtp.Session.SetZone`, plus `Browser.SendsV6` / `NetsV6` / `RecvV6` (parallel to existing exported `Sends` / `Nets` / `Recv`)

## Test

```
$ go build ./...
$ go test ./pkg/mdns/
ok      github.com/AlexxIT/go2rtc/pkg/mdns
```

linux/amd64 build deployed in a Frigate container running alongside another mDNS responder that holds the wildcard `:5353` bind. Before: `error="no interfaces for listen"` at HomeKit init. After: cameras pair, snapshots load, live stream plays in the iOS Home app over the LAN.

## Closes / refs

- Fixes #2266
- Refs #1225 (the `xnet.IPNets` 172.16/12 filter blocks similar setups; this PR sidesteps that via the v6 fallback rather than changing the v4 filter)
- Complements #2304 (per-IP bind-error diagnostic)
