### PR TITLE
Fix Xiaomi CS2 pop buffer full error

### DIFF
--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -72,13 +72,25 @@ func NewClient(rawURL string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{Conn: conn, key: key, model: model}, nil
+	client := &Client{Conn: conn, key: key, model: model}
+	client.startCommandLoop()
+	return client, nil
 }
 
 type Client struct {
 	Conn
 	key   []byte
 	model string
+}
+
+func (c *Client) startCommandLoop() {
+	go func() {
+		for {
+			if _, _, err := c.Conn.ReadCommand(); err != nil {
+				return
+			}
+		}
+	}()
 }
 
 const (


### PR DESCRIPTION
This PR fixes the 'miss: read media: cs2: pop buffer is full' issue on Xiaomi cameras (like C301) by spawning a background goroutine to continuously drain the command loop after a successful login.