### PR TITLE
rtsp: opt-in audio re-clock to video (fixes long-run audio decay on clock-drifting cameras, #2303)

### DIFF
--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -23,6 +23,7 @@ func Init() {
 			Password     string `yaml:"password" json:"-"`
 			DefaultQuery string `yaml:"default_query" json:"default_query"`
 			PacketSize   uint16 `yaml:"pkt_size" json:"pkt_size,omitempty"`
+			AudioReclock bool   `yaml:"audio_reclock" json:"audio_reclock,omitempty"`
 		} `yaml:"rtsp"`
 	}
 
@@ -33,7 +34,15 @@ func Init() {
 	app.LoadConfig(&conf)
 	app.Info["rtsp"] = conf.Mod
 
+	// opt-in audio->video re-clock for cameras whose audio RTP clock drifts
+	// from video (go2rtc#2303)
+	rtsp.ReclockAudio = conf.Mod.AudioReclock
+
 	log = app.GetLogger("rtsp")
+
+	if rtsp.ReclockAudio {
+		log.Info().Msg("[rtsp] audio re-clock to video enabled (go2rtc#2303)")
+	}
 
 	// RTSP client support
 	streams.HandleFunc("rtsp", rtspHandler)

--- a/pkg/rtsp/conn.go
+++ b/pkg/rtsp/conn.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/url"
 	"strconv"
@@ -63,6 +64,7 @@ type Conn struct {
 	audFirstTS uint32
 	audLastOut uint32
 	audClock   float64
+	audVidBase float64 // video elapsed captured when audio anchored (offset correction)
 }
 
 // ReclockAudio enables the audio->video re-clock (go2rtc#2303). Off by default;
@@ -103,10 +105,17 @@ func (c *Conn) reclockAudioToVideo(receiver *core.Receiver, packet *rtp.Packet) 
 			if c.audClock <= 0 {
 				c.audClock = 8000
 			}
+			// Capture video's elapsed at the moment audio anchors. Audio often
+			// starts LATER than video on a connection (reconnects bring video up
+			// first); without this, audio elapsed was measured from video's
+			// start and jumped forward by the offset, desyncing audio for the
+			// whole connection (go2rtc#2303 residual).
+			c.audVidBase = c.vidElapsed
 			c.audLastOut = packet.Timestamp
-			return // anchor audio start to video start; keep first packet
+			log.Printf("[reclock] %s audio anchored, video was %.2fs in (offset corrected)", c.URL, c.audVidBase)
+			return
 		}
-		out := c.audFirstTS + uint32(int64(c.vidElapsed*c.audClock+0.5))
+		out := c.audFirstTS + uint32(int64((c.vidElapsed-c.audVidBase)*c.audClock+0.5))
 		if int32(out-c.audLastOut) < 1 {
 			out = c.audLastOut + 1 // keep monotonic between video updates
 		}

--- a/pkg/rtsp/conn.go
+++ b/pkg/rtsp/conn.go
@@ -47,6 +47,72 @@ type Conn struct {
 
 	state   State
 	stateMu sync.Mutex
+
+	// audio->video re-clock (go2rtc#2303). On some G.711+H.265 cams the audio
+	// RTP clock runs slower than the video clock, so a long-running consumer's
+	// muxer interleave gap grows until audio is starved to silence. We peg the
+	// audio packet timestamp to VIDEO's elapsed time so the two can't drift
+	// apart. Video timestamps are never touched. Single producer read goroutine
+	// updates these, so no locking needed.
+	vidHave    bool
+	vidLastTS  uint32
+	vidTicks   int64 // accumulated video RTP ticks since first video pkt (wrap-safe)
+	vidClock   float64
+	vidElapsed float64 // seconds of video elapsed
+	audHave    bool
+	audFirstTS uint32
+	audLastOut uint32
+	audClock   float64
+}
+
+// ReclockAudio enables the audio->video re-clock (go2rtc#2303). Off by default;
+// opt in with `rtsp: { audio_reclock: true }`. Set from config by internal/rtsp.
+var ReclockAudio = false
+
+// reclockAudioToVideo pegs an incoming audio packet's RTP timestamp to VIDEO's
+// elapsed time so audio cannot drift away from video (the cause of the
+// long-run muxer audio-starvation on these cams). Video packets only update the
+// reference; their timestamps are never modified.
+func (c *Conn) reclockAudioToVideo(receiver *core.Receiver, packet *rtp.Packet) {
+	codec := receiver.Codec
+	if codec == nil {
+		return
+	}
+	switch codec.Kind() {
+	case core.KindVideo:
+		if !c.vidHave {
+			c.vidHave = true
+			c.vidLastTS = packet.Timestamp
+			c.vidClock = float64(codec.ClockRate)
+			if c.vidClock <= 0 {
+				c.vidClock = 90000
+			}
+			return
+		}
+		c.vidTicks += int64(int32(packet.Timestamp - c.vidLastTS)) // wrap-safe signed delta
+		c.vidLastTS = packet.Timestamp
+		c.vidElapsed = float64(c.vidTicks) / c.vidClock
+	case core.KindAudio:
+		if !c.vidHave {
+			return // no video reference yet — leave audio untouched
+		}
+		if !c.audHave {
+			c.audHave = true
+			c.audFirstTS = packet.Timestamp
+			c.audClock = float64(codec.ClockRate)
+			if c.audClock <= 0 {
+				c.audClock = 8000
+			}
+			c.audLastOut = packet.Timestamp
+			return // anchor audio start to video start; keep first packet
+		}
+		out := c.audFirstTS + uint32(int64(c.vidElapsed*c.audClock+0.5))
+		if int32(out-c.audLastOut) < 1 {
+			out = c.audLastOut + 1 // keep monotonic between video updates
+		}
+		c.audLastOut = out
+		packet.Timestamp = out
+	}
 }
 
 const (
@@ -239,6 +305,9 @@ func (c *Conn) Handle() (err error) {
 
 			for _, receiver := range c.Receivers {
 				if receiver.ID == channelID {
+					if ReclockAudio {
+						c.reclockAudioToVideo(receiver, packet)
+					}
 					receiver.WriteRTP(packet)
 					break
 				}


### PR DESCRIPTION
## Problem

Some RTSP cameras run their **audio RTP clock slightly slower than their video clock** — common on budget H.265 + G.711/PCMA units. go2rtc relays both timestamps verbatim, so for a **long-running** streamcopy consumer (e.g. an `ffmpeg -c:v copy -c:a aac -f segment` recorder) the audio↔video interleave gap grows steadily until the muxer starves the audio and it goes silent — typically 15–25 minutes in, then it stays silent until the producer reconnects.

A **direct** ffmpeg client of the same camera is immune, because it re-bases both tracks against the camera's RTCP Sender Reports; go2rtc's RTSP consumer path forwards no RTCP SR, so consumers see the two raw clocks drift apart.

Full diagnosis (instrumented build, drift traces, the audio-vs-video relative drift measurement): #2303.

## Change

Opt-in, **off by default** — no behaviour change unless enabled:

```yaml
rtsp:
  audio_reclock: true
```

When enabled, the RTSP client read pegs each audio RTP packet's timestamp to the connection's **video** elapsed time, so audio can't drift away from video. Details:
- Only engages when a video track is present on the same connection.
- **Video timestamps are never modified.**
- Runs in the single producer read goroutine (no locking), wrap-safe tick accumulation, monotonic output.

Two files: the re-clock in `pkg/rtsp/conn.go`, and the config flag wired in `internal/rtsp/rtsp.go` (with a one-line startup log when enabled).

## Validation

Run on a 26-camera Frigate deployment:
- **20-hour soak** on one affected camera: 7057 recorded segments, exactly **1** with degraded audio (a single reconnect-boundary segment) vs. the prior pattern of sustained multi-hour silences several times a day.
- **~24 hours across 8 cameras** with the flag on: audio held steady throughout; video frame counts unchanged (no freezing/jitter); live view, snapshots and downstream consumers unaffected.

## Notes

- This pegs audio to video at the relay. The arguably-cleaner alternative is forwarding/synthesising **RTCP Sender Reports** to consumers (so they re-base as a direct client does) — I raised that in #2303 and am happy to take the PR in that direction instead if you prefer; this approach had the advantage of being something I could validate end-to-end in production first.

## AI disclosure

Diagnosis, patch and this description were produced with AI assistance (Claude), directed and reviewed by me; the change ran in my production deployment for ~24h before submitting.