### PR TITLE
Feature: Add per-request WebRTC ICE configuration for JSON /api/webrtc requests.

### DIFF
--- a/internal/hass/api.go
+++ b/internal/hass/api.go
@@ -63,7 +63,7 @@ func apiStream(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		s, err = webrtc.ExchangeSDP(stream, string(offer), "hass/webrtc", r.UserAgent())
+		s, err = webrtc.ExchangeSDP(stream, string(offer), "hass/webrtc", r.UserAgent(), nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/webrtc/server.go
+++ b/internal/webrtc/server.go
@@ -18,6 +18,13 @@ import (
 
 const MimeSDP = "application/sdp"
 
+type jsonWebRTCOffer struct {
+	Type               string                   `json:"type"`
+	SDP                string                   `json:"sdp"`
+	ICEServers         []pion.ICEServer         `json:"ice_servers"`
+	ICETransportPolicy *pion.ICETransportPolicy `json:"ice_transport_policy"`
+}
+
 var sessions = map[string]*webrtc.Conn{}
 
 func syncHandler(w http.ResponseWriter, r *http.Request) {
@@ -77,16 +84,18 @@ func outputWebRTC(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var offer string
+	var peerConf *pion.Configuration
 
 	switch mediaType {
 	case "application/json":
-		var desc pion.SessionDescription
-		if err := json.NewDecoder(r.Body).Decode(&desc); err != nil {
+		var req jsonWebRTCOffer
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			log.Error().Err(err).Caller().Send()
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		offer = desc.SDP
+		offer = req.SDP
+		peerConf = PeerConfigFromOptions(req.ICEServers, req.ICETransportPolicy)
 
 	case "application/x-www-form-urlencoded":
 		if err := r.ParseForm(); err != nil {
@@ -124,7 +133,7 @@ func outputWebRTC(w http.ResponseWriter, r *http.Request) {
 		desc = "webrtc/post"
 	}
 
-	answer, err := ExchangeSDP(stream, offer, desc, r.UserAgent())
+	answer, err := ExchangeSDP(stream, offer, desc, r.UserAgent(), peerConf)
 	if err != nil {
 		log.Error().Err(err).Caller().Send()
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/webrtc/webrtc.go
+++ b/internal/webrtc/webrtc.go
@@ -86,6 +86,7 @@ func Init() {
 		ICEServers:   cfg.Mod.IceServers,
 		SDPSemantics: pion.SDPSemanticsUnifiedPlanWithFallback,
 	}
+	defaultPionConf = pionConf
 
 	PeerConnection = func(active bool) (*pion.PeerConnection, error) {
 		// active - client, passive - server
@@ -112,7 +113,26 @@ var serverAPI, clientAPI *pion.API
 
 var log zerolog.Logger
 
+var defaultPionConf pion.Configuration
+
 var PeerConnection func(active bool) (*pion.PeerConnection, error)
+
+// PeerConfigFromOptions returns per-request PeerConnection config when JSON
+// options override YAML defaults. Returns nil when no overrides are present.
+func PeerConfigFromOptions(iceServers []pion.ICEServer, policy *pion.ICETransportPolicy) *pion.Configuration {
+	if iceServers == nil && policy == nil {
+		return nil
+	}
+
+	conf := defaultPionConf
+	if iceServers != nil {
+		conf.ICEServers = iceServers
+	}
+	if policy != nil {
+		conf.ICETransportPolicy = *policy
+	}
+	return &conf
+}
 
 func asyncHandler(tr *ws.Transport, msg *ws.Message) (err error) {
 	var stream *streams.Stream
@@ -239,8 +259,13 @@ func asyncHandler(tr *ws.Transport, msg *ws.Message) (err error) {
 	return nil
 }
 
-func ExchangeSDP(stream *streams.Stream, offer, desc, userAgent string) (answer string, err error) {
-	pc, err := PeerConnection(false)
+func ExchangeSDP(stream *streams.Stream, offer, desc, userAgent string, conf *pion.Configuration) (answer string, err error) {
+	var pc *pion.PeerConnection
+	if conf == nil {
+		pc, err = PeerConnection(false)
+	} else {
+		pc, err = serverAPI.NewPeerConnection(*conf)
+	}
 	if err != nil {
 		log.Error().Err(err).Caller().Send()
 		return

--- a/internal/webrtc/webrtc_test.go
+++ b/internal/webrtc/webrtc_test.go
@@ -38,6 +38,55 @@ func TestWebRTCAPIv2(t *testing.T) {
 	require.Equal(t, "stun:stun.l.google.com:19302", offer.ICEServers[0].URLs[0])
 }
 
+func TestPeerConfigFromOptions(t *testing.T) {
+	defaultPionConf = pion.Configuration{
+		ICEServers: []pion.ICEServer{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+		},
+		SDPSemantics: pion.SDPSemanticsUnifiedPlanWithFallback,
+	}
+
+	require.Nil(t, PeerConfigFromOptions(nil, nil))
+
+	overrideServers := []pion.ICEServer{
+		{URLs: []string{"turn:turn.example.com:3478"}, Username: "u", Credential: "p"},
+	}
+	conf := PeerConfigFromOptions(overrideServers, nil)
+	require.NotNil(t, conf)
+	require.Equal(t, overrideServers, conf.ICEServers)
+	require.Equal(t, defaultPionConf.SDPSemantics, conf.SDPSemantics)
+
+	policy := pion.ICETransportPolicyRelay
+	conf = PeerConfigFromOptions(nil, &policy)
+	require.NotNil(t, conf)
+	require.Equal(t, defaultPionConf.ICEServers, conf.ICEServers)
+	require.Equal(t, pion.ICETransportPolicyRelay, conf.ICETransportPolicy)
+
+	conf = PeerConfigFromOptions(overrideServers, &policy)
+	require.NotNil(t, conf)
+	require.Equal(t, overrideServers, conf.ICEServers)
+	require.Equal(t, pion.ICETransportPolicyRelay, conf.ICETransportPolicy)
+}
+
+func TestJSONWebRTCOffer(t *testing.T) {
+	raw := `{
+		"type":"offer",
+		"sdp":"v=0\n...",
+		"ice_servers":[{"urls":["turn:turn.example.com:3478"],"username":"u","credential":"p"}],
+		"ice_transport_policy":"relay"
+	}`
+
+	var req jsonWebRTCOffer
+	err := json.Unmarshal([]byte(raw), &req)
+	require.Nil(t, err)
+	require.Equal(t, "offer", req.Type)
+	require.Equal(t, "v=0\n...", req.SDP)
+	require.Equal(t, "turn:turn.example.com:3478", req.ICEServers[0].URLs[0])
+	require.Equal(t, "u", req.ICEServers[0].Username)
+	require.NotNil(t, req.ICETransportPolicy)
+	require.Equal(t, pion.ICETransportPolicyRelay, *req.ICETransportPolicy)
+}
+
 func TestCrealitySDP(t *testing.T) {
 	sdp := `v=0
 o=- 1495799811084970 1495799811084970 IN IP4 0.0.0.0

--- a/internal/webtorrent/init.go
+++ b/internal/webtorrent/init.go
@@ -47,7 +47,7 @@ func Init() {
 			if stream == nil {
 				return "", errors.New(api.StreamNotFound)
 			}
-			return webrtc.ExchangeSDP(stream, offer, "webtorrent", "")
+			return webrtc.ExchangeSDP(stream, offer, "webtorrent", "", nil)
 		},
 	}
 


### PR DESCRIPTION
This change lets clients pass `ice_servers` and `ice_transport_policy`
in the request body so each session can use its own ICE configuration
without relying on global `go2rtc.yaml` settings.
Raw WHEP `application/sdp` flow stays unchanged and continues to use
existing default configuration.