### PR TITLE
fix: add MP4A-LATM to audio codec type mapping in GetKind()

### DIFF
--- a/pkg/core/media.go
+++ b/pkg/core/media.go
@@ -94,7 +94,7 @@ func GetKind(name string) string {
 	switch name {
 	case CodecH264, CodecH265, CodecVP8, CodecVP9, CodecAV1, CodecJPEG, CodecRAW:
 		return KindVideo
-	case CodecPCMU, CodecPCMA, CodecAAC, CodecOpus, CodecG722, CodecMP3, CodecPCM, CodecPCML, CodecELD, CodecFLAC:
+	case CodecPCMU, CodecPCMA, CodecAAC, CodecOpus, CodecG722, CodecMP3, CodecPCM, CodecPCML, CodecELD, CodecFLAC, "MP4A-LATM":
 		return KindAudio
 	}
 	return ""


### PR DESCRIPTION
The `GetKind()` function in `pkg/core/media.go` classifies codecs as video or audio for SDP generation and codec metadata. `MP4A-LATM` (an AAC variant used by some RTSP cameras, notably Meraki MV93X 3rd-gen) was missing from the audio codec switch case, causing:

1. `codec_type` to be an empty string instead of `"audio"`
2. Malformed SDP: `m= 0 RTP/AVP 96` instead of `m=audio 0 RTP/AVP 96`
3. Consumer streams (e.g. Frigate FFmpeg) receiving zero audio bytes for that track

This one-line fix adds `"MP4A-LATM"` to the `KindAudio` case so that go2rtc properly identifies it as an audio codec and generates correct SDP.