### PR TITLE
rtsp: send RTCP Sender Reports to RTP consumers

### DIFF
--- a/pkg/rtsp/consumer.go
+++ b/pkg/rtsp/consumer.go
@@ -84,6 +84,11 @@ func (c *Conn) packetWriter(codec *core.Codec, channel, payloadType uint8) core.
 		buf = make([]byte, startAudioBuf)
 	}
 
+	var sr *senderReport
+	if codec.ClockRate > 0 {
+		sr = &senderReport{clockRate: codec.ClockRate}
+	}
+
 	flushBuf := func() {
 		//log.Printf("[rtsp] channel:%2d write_size:%6d buffer_size:%6d", channel, n, len(buf))
 		if err := c.writeInterleavedData(buf[:n]); err != nil {
@@ -138,6 +143,10 @@ func (c *Conn) packetWriter(codec *core.Codec, channel, payloadType uint8) core.
 
 		n += 4 + size
 
+		if sr != nil {
+			sr.count(packet)
+		}
+
 		if !packet.Marker || !c.playOK {
 			// collect continious video packets to buffer
 			// or wait OK for PLAY command for backchannel
@@ -146,6 +155,17 @@ func (c *Conn) packetWriter(codec *core.Codec, channel, payloadType uint8) core.
 		}
 
 		flushBuf()
+
+		if sr != nil {
+			// send on the RTCP channel of this track: interleaved data
+			// channels are even, control channels odd (for UDP transport
+			// writeInterleavedData routes it to the RTCP socket pair)
+			if b := sr.marshal(channel+1, clone.SSRC, clone.Timestamp, time.Now()); b != nil {
+				if err := c.writeInterleavedData(b); err == nil {
+					c.Send += len(b)
+				}
+			}
+		}
 	}
 
 	if !codec.IsRTP() {

--- a/pkg/rtsp/rtcp.go
+++ b/pkg/rtsp/rtcp.go
@@ -1,0 +1,106 @@
+package rtsp
+
+import (
+	"time"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+)
+
+// RFC 3550 requires RTP senders to send periodic RTCP Sender Reports.
+// The NTP<->RTP mapping in them is the only way for a receiver to sync
+// the clocks of multiple tracks (lipsync) and to map a stream onto its
+// own wallclock. Some receivers (ex. UniFi Protect) log clock warnings,
+// lose A/V sync or drift the recording timeline when SRs are missing.
+// https://github.com/AlexxIT/go2rtc/issues/2303
+const (
+	srInterval  = 2500 * time.Millisecond // media senders commonly use 2..5s
+	srMaxDrift  = 30 * time.Second        // hard re-anchor beyond this
+	srSlewBand  = 150 * time.Millisecond  // ignore drift smaller than this
+	srSlewStep  = 5 * time.Millisecond    // max timeline correction per report
+	srStartBias = 100 * time.Millisecond  // assumed pipeline latency of the first frame
+)
+
+type senderReport struct {
+	clockRate uint32
+	packets   uint32
+	octets    uint32
+	anchorNTP time.Time // wallclock moment that maps to anchorTS
+	anchorTS  uint32
+	last      time.Time
+}
+
+func (s *senderReport) count(packet *rtp.Packet) {
+	s.packets++
+	s.octets += uint32(len(packet.Payload))
+}
+
+// marshal returns an interleaved framed compound RTCP packet (SR+SDES)
+// for the given RTP timestamp when a report is due, otherwise nil.
+//
+// The NTP<->RTP mapping is anchored once and then advanced along the RTP
+// timeline, slewed only a few ms per report toward wallclock. Stamping
+// each report with the current wallclock instead would jitter the mapping
+// on every delivery stall or burst, which receivers translate into stream
+// clock jumps (UniFi Protect logs "streamClock regression" / "Back time"
+// DTS corrections on every such report).
+func (s *senderReport) marshal(channel uint8, ssrc, ts uint32, now time.Time) []byte {
+	if now.Sub(s.last) < srInterval {
+		return nil
+	}
+	s.last = now
+
+	if s.anchorNTP.IsZero() {
+		// the first frame was produced slightly in the past, and the small
+		// bias makes later slew corrections mostly forward, which receivers
+		// tolerate better than backward corrections
+		s.anchorNTP = now.Add(-srStartBias)
+	} else {
+		// int32 diff handles timestamp wraparound and reordering
+		diff := int32(ts - s.anchorTS)
+		s.anchorNTP = s.anchorNTP.Add(time.Duration(diff) * time.Second / time.Duration(s.clockRate))
+
+		// absorb long-term clock drift between producer and wallclock
+		if drift := now.Sub(s.anchorNTP); drift > srMaxDrift || drift < -srMaxDrift {
+			s.anchorNTP = now.Add(-srStartBias)
+		} else if drift > srSlewBand {
+			s.anchorNTP = s.anchorNTP.Add(srSlewStep)
+		} else if drift < -srSlewBand {
+			s.anchorNTP = s.anchorNTP.Add(-srSlewStep)
+		}
+	}
+	s.anchorTS = ts
+
+	sr := rtcp.SenderReport{
+		SSRC:        ssrc,
+		NTPTime:     ntpTime(s.anchorNTP),
+		RTPTime:     ts,
+		PacketCount: s.packets,
+		OctetCount:  s.octets,
+	}
+	sd := rtcp.SourceDescription{
+		Chunks: []rtcp.SourceDescriptionChunk{{
+			Source: ssrc,
+			Items:  []rtcp.SourceDescriptionItem{{Type: rtcp.SDESCNAME, Text: "go2rtc"}},
+		}},
+	}
+
+	data, err := rtcp.Marshal([]rtcp.Packet{&sr, &sd})
+	if err != nil {
+		return nil
+	}
+
+	b := make([]byte, 4, 4+len(data))
+	b[0] = '$'
+	b[1] = channel
+	b[2] = byte(len(data) >> 8)
+	b[3] = byte(len(data))
+	return append(b, data...)
+}
+
+// ntpTime converts wallclock time to a 64-bit fixed point NTP timestamp
+func ntpTime(t time.Time) uint64 {
+	secs := uint64(t.Unix()) + 2208988800 // seconds between 1900 and 1970
+	frac := (uint64(t.Nanosecond()) << 32) / 1e9
+	return secs<<32 | frac
+}

--- a/pkg/rtsp/rtcp_test.go
+++ b/pkg/rtsp/rtcp_test.go
@@ -1,0 +1,186 @@
+package rtsp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+func parseSR(t *testing.T, b []byte, channel uint8) *rtcp.SenderReport {
+	t.Helper()
+
+	require.NotNil(t, b)
+	require.Equal(t, byte('$'), b[0])
+	require.Equal(t, channel, b[1])
+	require.Equal(t, len(b)-4, int(b[2])<<8|int(b[3]))
+
+	packets, err := rtcp.Unmarshal(b[4:])
+	require.NoError(t, err)
+	require.Len(t, packets, 2)
+
+	sd, ok := packets[1].(*rtcp.SourceDescription)
+	require.True(t, ok)
+	require.Equal(t, rtcp.SDESCNAME, sd.Chunks[0].Items[0].Type)
+
+	sr, ok := packets[0].(*rtcp.SenderReport)
+	require.True(t, ok)
+	return sr
+}
+
+func ntpToTime(ntp uint64) time.Time {
+	secs := int64(ntp>>32) - 2208988800
+	frac := int64((ntp & 0xFFFFFFFF) * 1e9 >> 32)
+	return time.Unix(secs, frac)
+}
+
+func TestSenderReportBasic(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	s := senderReport{clockRate: 90000}
+
+	s.count(&rtp.Packet{Payload: make([]byte, 100)})
+	s.count(&rtp.Packet{Payload: make([]byte, 50)})
+
+	sr := parseSR(t, s.marshal(3, 0x11223344, 1000, now), 3)
+	require.Equal(t, uint32(0x11223344), sr.SSRC)
+	require.Equal(t, uint32(1000), sr.RTPTime)
+	require.Equal(t, uint32(2), sr.PacketCount)
+	require.Equal(t, uint32(150), sr.OctetCount)
+
+	// first report maps the RTP timestamp slightly into the past
+	require.WithinDuration(t, now.Add(-srStartBias), ntpToTime(sr.NTPTime), time.Millisecond)
+}
+
+func TestSenderReportInterval(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	s := senderReport{clockRate: 90000}
+
+	require.NotNil(t, s.marshal(1, 1, 0, now))
+	require.Nil(t, s.marshal(1, 1, 3000, now.Add(time.Second)))
+	require.NotNil(t, s.marshal(1, 1, 90000*3, now.Add(3*time.Second)))
+}
+
+func TestSenderReportMappingConsistency(t *testing.T) {
+	// the NTP<->RTP mapping must advance along the RTP timeline even when
+	// wallclock delivery is bursty, otherwise receivers see clock jumps
+	const clockRate = 90000
+	base := time.Unix(1700000000, 0)
+	s := senderReport{clockRate: clockRate}
+
+	first := parseSR(t, s.marshal(1, 1, 0, base), 1)
+
+	for i := 1; i <= 10; i++ {
+		ts := uint32(i) * 3 * clockRate // 3s of media per report
+		mediaTime := time.Duration(i) * 3 * time.Second
+		// delivery jitter oscillates around zero and stays inside the
+		// slew dead band, so it must never disturb the mapping
+		jitter := time.Duration(1-2*(i%2)) * 40 * time.Millisecond
+		now := base.Add(mediaTime + jitter)
+
+		sr := parseSR(t, s.marshal(1, 1, ts, now), 1)
+
+		ntpDelta := ntpToTime(sr.NTPTime).Sub(ntpToTime(first.NTPTime))
+		require.InDelta(t, mediaTime, ntpDelta, float64(time.Millisecond),
+			"report %d: NTP advance must equal RTP advance", i)
+	}
+}
+
+func TestSenderReportSlewBounds(t *testing.T) {
+	const clockRate = 8000
+	now := time.Unix(1700000000, 0)
+	s := senderReport{clockRate: clockRate}
+
+	prev := parseSR(t, s.marshal(1, 1, 0, now), 1)
+
+	// producer runs 1% slow vs wallclock: drift accumulates, correction
+	// must stay bounded to srSlewStep per report
+	ts := uint32(0)
+	for i := 1; i <= 5; i++ {
+		ts += 3 * clockRate
+		now = now.Add(3*time.Second + 500*time.Millisecond) // way past dead band
+
+		sr := parseSR(t, s.marshal(1, 1, ts, now), 1)
+
+		mediaTime := 3 * time.Second
+		ntpDelta := ntpToTime(sr.NTPTime).Sub(ntpToTime(prev.NTPTime))
+		require.LessOrEqual(t, (ntpDelta - mediaTime).Abs(), srSlewStep+time.Millisecond,
+			"report %d: correction exceeds slew step", i)
+		prev = sr
+	}
+}
+
+func TestSenderReportHardReset(t *testing.T) {
+	const clockRate = 90000
+	now := time.Unix(1700000000, 0)
+	s := senderReport{clockRate: clockRate}
+
+	parseSR(t, s.marshal(1, 1, 0, now), 1)
+
+	// producer stalled for a minute with no RTP advance: drift exceeds
+	// srMaxDrift, mapping must re-anchor to wallclock
+	now = now.Add(time.Minute)
+	sr := parseSR(t, s.marshal(1, 1, 3000, now), 1)
+	require.WithinDuration(t, now.Add(-srStartBias), ntpToTime(sr.NTPTime), time.Millisecond)
+}
+
+func TestSenderReportTimestampWraparound(t *testing.T) {
+	const clockRate = 90000
+	now := time.Unix(1700000000, 0)
+	s := senderReport{clockRate: clockRate}
+
+	start := uint32(0xFFFFFFFF - clockRate) // 1s before wrap
+	first := parseSR(t, s.marshal(1, 1, start, now), 1)
+
+	now = now.Add(3 * time.Second)
+	sr := parseSR(t, s.marshal(1, 1, start+3*clockRate, now), 1) // wrapped
+
+	ntpDelta := ntpToTime(sr.NTPTime).Sub(ntpToTime(first.NTPTime))
+	require.InDelta(t, 3*time.Second, ntpDelta, float64(time.Millisecond))
+}
+
+func TestNTPTime(t *testing.T) {
+	// known value: 1900-01-01 maps to 0
+	require.Equal(t, uint64(0), ntpTime(time.Unix(-2208988800, 0)))
+	// half second fraction
+	require.Equal(t, uint64(2208988800)<<32|1<<31, ntpTime(time.Unix(0, 5e8)))
+}
+
+func TestSenderReportUDPRouting(t *testing.T) {
+	// for transport=udp the framed report must arrive unframed on the
+	// RTCP socket of the pair (odd channel)
+	rtpConn, rtcpConn, err := ListenUDPPair()
+	require.NoError(t, err)
+	defer rtpConn.Close()
+	defer rtcpConn.Close()
+
+	sink, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	defer sink.Close()
+
+	c := &Conn{
+		Transport: "udp",
+		udpConn:   []*net.UDPConn{rtpConn, rtcpConn},
+		udpAddr: []*net.UDPAddr{
+			sink.LocalAddr().(*net.UDPAddr), // RTP (unused here)
+			sink.LocalAddr().(*net.UDPAddr), // RTCP
+		},
+	}
+
+	s := senderReport{clockRate: 90000}
+	b := s.marshal(1, 0x42, 90000, time.Unix(1700000000, 0))
+	require.NoError(t, c.writeInterleavedData(b))
+
+	_ = sink.SetReadDeadline(time.Now().Add(time.Second))
+	buf := make([]byte, 1500)
+	n, _, err := sink.ReadFromUDP(buf)
+	require.NoError(t, err)
+
+	packets, err := rtcp.Unmarshal(buf[:n])
+	require.NoError(t, err)
+	sr, ok := packets[0].(*rtcp.SenderReport)
+	require.True(t, ok)
+	require.Equal(t, uint32(0x42), sr.SSRC)
+}


### PR DESCRIPTION
## Problem

go2rtc never sends RTCP Sender Reports on outgoing RTP: `pkg/rtsp/consumer.go` writes RTP packets only, both for RTSP server consumers and for the client backchannel. RFC 3550 (§6) requires senders to emit periodic SRs — they carry the NTP↔RTP mapping, which is the **only** way a receiver can sync the clocks of the audio and video tracks (lipsync) and map the stream onto its own wallclock.

Tolerant players (VLC, ffmpeg) free-run without SRs, so this goes mostly unnoticed. Strict receivers don't:

* **UniFi Protect** consuming a go2rtc RTSP restream logs a constant storm of `InNetRTPStream::SendOnClockSync ... streamClock regression clamped` warnings (~570 per 10 minutes for two cameras in my setup), its **browser live view dies** right after the fMP4 init segment (endless reconnect loop), and its **recording timeline drifted ~38 minutes** behind wallclock.
* This is also a plausible root cause of #2303 (relayed consumers gradually losing A/V sync over hours, while camera-direct consumers — which do get SRs from the camera — stay fine). #2308 works around that symptom by re-clocking audio to video; proper SRs attack the missing-clock problem itself.

## Change

Send a compound RTCP SR+SDES every 2.5s per track:

* TCP-interleaved: on the track's odd control channel.
* UDP transport (backchannel): routed to the RTCP socket of the pair via the existing `writeInterleavedData` demux — no separate code path.

**Design note on the mapping:** the NTP↔RTP anchor is set once, then advanced along the RTP timeline and slewed at most 5 ms per report toward wallclock (hard re-anchor only past 30 s of drift, e.g. a stalled producer). The obvious alternative — stamping each report with the current wallclock — makes things *worse* on real streams: any delivery stall/burst jitters the mapping, and strict receivers translate every jittered report into a stream-clock jump (UniFi Protect logs a DTS correction per report). Verified both behaviors against a live Protect NVR while iterating on this.

## Testing

* Unit tests (`pkg/rtsp/rtcp_test.go`): interval gating, mapping consistency under delivery jitter, slew bounds under persistent producer drift, hard re-anchor after a stall, 32-bit RTP timestamp wraparound, NTP conversion, and UDP routing of the framed report to the RTCP socket.
* On-wire: raw RTSP client (SETUP×2/PLAY, parsing interleaved frames) against a synthetic ffmpeg H.264+AAC stream — compound SR+SDES every ~2.5 s on both control channels, NTP advance == RTP advance within the 5 ms slew bound, cross-track anchor agreement 0.1 ms.
* Real world: deployed to the box feeding two ONVIF cameras into UniFi Protect (UDM-Pro, Protect 7.1.83). Before: ~570 `streamClock regression` clamps per 10 min, dead web live view, recording timeline ~38 min behind. After a 14-minute soak: **one clamp total, too small for the log's display precision** (a single 5 ms slew step landing during a delivery burst) — browser live view works and recording chunk timestamps match wallclock.
