### PR TITLE
Reap the keyframe consumer when the client disconnects

### DIFF
--- a/internal/mjpeg/mjpeg.go
+++ b/internal/mjpeg/mjpeg.go
@@ -83,11 +83,23 @@ func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// WriteTo below blocks until a keyframe arrives, and the in-memory OnceBuffer
+	// sink never errors on client disconnect to unblock it. Reap the consumer when
+	// the request context ends so a stuck WriteTo can't leak it.
+	ctx := r.Context()
+	go func() {
+		<-ctx.Done()
+		_ = cons.Stop()
+		stream.RemoveConsumer(cons)
+	}()
+
 	once := &core.OnceBuffer{} // init and first frame
 	_, _ = cons.WriteTo(once)
 	b = once.Buffer()
 
-	stream.RemoveConsumer(cons)
+	if ctx.Err() != nil {
+		return // client gone before a keyframe arrived
+	}
 
 	switch cons.CodecName() {
 	case core.CodecH264, core.CodecH265:

--- a/internal/mp4/mp4.go
+++ b/internal/mp4/mp4.go
@@ -55,10 +55,21 @@ func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// See mjpeg.handlerKeyframe: WriteTo blocks until a keyframe arrives and the
+	// OnceBuffer sink never unblocks it on disconnect. Reap on the request context.
+	ctx := r.Context()
+	go func() {
+		<-ctx.Done()
+		_ = cons.Stop()
+		stream.RemoveConsumer(cons)
+	}()
+
 	once := &core.OnceBuffer{} // init and first frame
 	_, _ = cons.WriteTo(once)
 
-	stream.RemoveConsumer(cons)
+	if ctx.Err() != nil {
+		return // client gone before a keyframe arrived
+	}
 
 	// Apple Safari won't show frame without length
 	header := w.Header()

--- a/pkg/core/writebuffer.go
+++ b/pkg/core/writebuffer.go
@@ -13,10 +13,11 @@ import (
 // WriteTo will be locked until Write fails or Close will be called.
 type WriteBuffer struct {
 	io.Writer
-	err   error
-	mu    sync.Mutex
-	wg    sync.WaitGroup
-	state byte
+	err    error
+	mu     sync.Mutex
+	wg     sync.WaitGroup
+	state  byte
+	closed bool
 }
 
 func NewWriteBuffer(wr io.Writer) *WriteBuffer {
@@ -47,10 +48,16 @@ func (w *WriteBuffer) WriteTo(wr io.Writer) (n int64, err error) {
 }
 
 func (w *WriteBuffer) Close() error {
-	if closer, ok := w.Writer.(io.Closer); ok {
+	// snapshot Writer under the lock; WriteTo/Reset can swap it concurrently
+	w.mu.Lock()
+	writer := w.Writer
+	w.mu.Unlock()
+
+	if closer, ok := writer.(io.Closer); ok {
 		return closer.Close()
 	}
 	w.mu.Lock()
+	w.closed = true
 	w.done()
 	w.mu.Unlock()
 	return nil
@@ -76,7 +83,8 @@ const (
 )
 
 func (w *WriteBuffer) add() {
-	if w.state == none {
+	// don't Add if Close already ran, or WriteTo would block on a Done that already fired
+	if w.state == none && !w.closed {
 		w.state = start
 		w.wg.Add(1)
 	}

--- a/pkg/core/writebuffer_test.go
+++ b/pkg/core/writebuffer_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A WriteTo still blocked on a keyframe must unblock on Close, or the consumer leaks.
+func TestWriteBufferCloseUnblocksWriteTo(t *testing.T) {
+	wb := NewWriteBuffer(nil)
+
+	returned := make(chan struct{})
+	go func() {
+		_, _ = wb.WriteTo(&OnceBuffer{}) // no keyframe is ever written
+		close(returned)
+	}()
+
+	// WriteTo must still be blocked: no keyframe, no Close yet.
+	select {
+	case <-returned:
+		t.Fatal("WriteTo returned before any keyframe or Close")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, wb.Close())
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("WriteTo did not unblock after Close - the consumer would leak")
+	}
+}
+
+// Close before WriteTo registers its wait must not block WriteTo forever.
+func TestWriteBufferCloseBeforeWriteTo(t *testing.T) {
+	wb := NewWriteBuffer(nil)
+	require.NoError(t, wb.Close())
+
+	returned := make(chan struct{})
+	go func() {
+		_, _ = wb.WriteTo(&OnceBuffer{})
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("WriteTo blocked after Close-before-WriteTo - the race window leaks the consumer")
+	}
+}


### PR DESCRIPTION
We poll snapshots from a lot of cameras, and when one goes offline the keyframe consumers just keep growing until the container restarts.

`GET /api/frame.jpeg` and `/api/frame.mp4` add a keyframe consumer and block in `cons.WriteTo(once)` until the first keyframe arrives, then call `RemoveConsumer` once it returns. The sink is an in-memory `OnceBuffer`, decoupled from the socket, so unlike the streaming handlers (which write to the live `ResponseWriter`) a client disconnect doesn't error the write and unblock it.

So when a source never delivers a keyframe (an offline camera that's still registered, a very long GOP, a broken re-publish) and the client times out and drops, `WriteTo` blocks forever, `RemoveConsumer` is never reached, and the consumer leaks. One per request. A snapshot poller hitting `frame.jpeg` every 30s against a stream that couldn't produce a keyframe built up thousands of stuck consumers, each pinning a receiver on the producer so memory kept climbing, while `ss` showed zero live connections to the API port.

The fix ties the consumer's lifetime to the request context, the same idiom `handlerMP4` already uses: a goroutine stops the consumer when the client disconnects or the handler returns, which unblocks `WriteTo` and lets it be removed. It also skips the transcode and response when the client is already gone.

There's one related fix in `pkg/core`. `WriteBuffer.Close` read `w.Writer` outside the mutex while `Reset` writes it, a race the detector flags as soon as `Close` runs concurrently with `WriteTo`, which this change now does on every disconnect. Snapshot the writer under the lock and add a `closed` guard so a `Close` that lands before `WriteTo` registers its wait can't re-block. `pkg/core/writebuffer_test.go` covers both the reap and the race.
