### PR TITLE
Fix urlParse infinite loop on unbracketed IPv6 hosts (Go 1.26)

### DIFF
--- a/pkg/rtsp/client_test.go
+++ b/pkg/rtsp/client_test.go
@@ -38,7 +38,9 @@ func TestMissedControl(t *testing.T) {
 		b := make([]byte, 8192)
 		for {
 			n, err := conn.Read(b)
-			require.Nil(t, err)
+			if err != nil {
+				return // client hung up (test finished)
+			}
 
 			req := string(b[:n])
 

--- a/pkg/rtsp/helpers.go
+++ b/pkg/rtsp/helpers.go
@@ -130,25 +130,40 @@ func urlParse(rawURL string) (*url.URL, error) {
 
 	u, err := url.Parse(rawURL)
 	if err != nil && strings.HasSuffix(err.Error(), "after host") {
-		if i := indexN(rawURL, '/', 3); i > 0 {
-			return urlParse(rawURL[:i] + ":" + rawURL[i:])
+		// Unbracketed IPv6 host (rtsp://::ffff:1.2.3.4/stream): bracket it once and
+		// retry. The old trailing-colon workaround recursed and, under Go 1.26 which
+		// rejects the host unconditionally, looped forever.
+		if fixed, ok := bracketIPv6Host(rawURL); ok {
+			if u2, err2 := url.Parse(fixed); err2 == nil {
+				return u2, nil
+			}
 		}
 	}
 
 	return u, err
 }
 
-func indexN(s string, c byte, n int) int {
-	var offset int
-	for {
-		i := strings.IndexByte(s[offset:], c)
-		if i < 0 {
-			break
-		}
-		if n--; n == 0 {
-			return offset + i
-		}
-		offset += i + 1
+// bracketIPv6Host wraps a bare IPv6 host in brackets (rtsp://::1/live ->
+// rtsp://[::1]/live), or returns false when there's no bare IPv6 host to fix.
+func bracketIPv6Host(rawURL string) (string, bool) {
+	scheme, rest, ok := strings.Cut(rawURL, "://")
+	if !ok {
+		return "", false
 	}
-	return -1
+
+	authority, path := rest, ""
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		authority, path = rest[:i], rest[i:]
+	}
+
+	userinfo := ""
+	if i := strings.LastIndexByte(authority, '@'); i >= 0 {
+		userinfo, authority = authority[:i+1], authority[i+1:]
+	}
+
+	if strings.HasPrefix(authority, "[") || strings.Count(authority, ":") < 2 {
+		return "", false
+	}
+
+	return scheme + "://" + userinfo + "[" + authority + "]" + path, true
 }

--- a/pkg/rtsp/rtsp_test.go
+++ b/pkg/rtsp/rtsp_test.go
@@ -12,7 +12,7 @@ func TestURLParse(t *testing.T) {
 	base := "rtsp://::ffff:192.168.1.123/onvif/profile.1/"
 	u, err := urlParse(base)
 	assert.NoError(t, err)
-	assert.Equal(t, "::ffff:192.168.1.123:", u.Host)
+	assert.Equal(t, "[::ffff:192.168.1.123]", u.Host)
 
 	// https://github.com/AlexxIT/go2rtc/issues/208
 	base = "rtsp://rtsp://turret2-cam.lan:554/stream1/"


### PR DESCRIPTION
We hit this running go2rtc on edge devices once a build moved to Go 1.26.

`urlParse` recovers from `url.Parse`'s "invalid port after host" error by inserting a `:` before the path and recursing. On an unbracketed IPv6 host like `rtsp://::ffff:192.168.1.123/stream`, Go 1.25 and earlier accepted the trailing-colon form, so it converged after one insertion. Go 1.26 rejects that host outright, and since the behaviour is gated by go.mod's `go` version, it flips the moment a project moves to `go 1.26`. Now every retry fails again with "after host", inserts another `:`, and recurses. The goroutine spins forever and the string grows without bound. Any RTSP URL that reaches `urlParse` with a bare IPv6 host triggers it.

The fix replaces the recursion with a single bounded step: bracket the host per RFC 3986 and retry once (`rtsp://::1/live` becomes host `[::1]`). IPv4 and already-bracketed URLs never enter this path. `indexN` is now unused and removed.

You can see it in the existing suite without any new test. `TestURLParse` parses `rtsp://::ffff:192.168.1.123/onvif/profile.1/`, and `pkg/rtsp/helpers.go` is the same on `master` and `dev`, so only the toolchain differs:

- **master (go 1.24):** `go test ./pkg/rtsp/ -run TestURLParse` -> `ok` in ~0.3s. `url.Parse` fails, the old code inserts one `:`, recurses once, and settles on `Host = "::ffff:192.168.1.123:"`.
- **dev (go 1.26), same code:** the test never returns. `panic: test timed out after 30s`.

So that config would peg a stream goroutine at 100% CPU with unbounded stack growth on first connect.

The diff also touches `client_test.go`. `TestMissedControl`'s mock-server goroutine looped on `conn.Read` doing `require.Nil(t, err)`, so after the client disconnected it asserted on an already-finished test. Under Go 1.26 that panics and crashes `pkg/rtsp` before `TestURLParse` even runs, which is why the hang stayed invisible. The goroutine now returns on the read error.
