### PR TITLE
Propagate RTMP publish errors and write extended timestamps

### DIFF
--- a/pkg/rtmp/client.go
+++ b/pkg/rtmp/client.go
@@ -25,10 +25,12 @@ func DialPlay(rawURL string) (*flv.Producer, error) {
 
 	client, err := NewClient(conn, u)
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 
 	if err = client.play(); err != nil {
+		_ = client.Close()
 		return nil, err
 	}
 
@@ -48,10 +50,12 @@ func DialPublish(rawURL string, cons *flv.Consumer) (io.Writer, error) {
 
 	client, err := NewClient(conn, u)
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 
 	if err = client.publish(); err != nil {
+		_ = client.Close()
 		return nil, err
 	}
 

--- a/pkg/rtmp/conn.go
+++ b/pkg/rtmp/conn.go
@@ -197,9 +197,9 @@ func (c *Conn) writeMessage(chunkID, tagType byte, timeMS uint32, payload []byte
 		for {
 			b = b[c.wrPacketSize:]
 			if uint32(len(b)) > c.wrPacketSize {
-				c.appendType3(chunkID, b[:c.wrPacketSize])
+				c.appendType3(chunkID, timeMS, b[:c.wrPacketSize])
 			} else {
-				c.appendType3(chunkID, b)
+				c.appendType3(chunkID, timeMS, b)
 				break
 			}
 		}
@@ -219,19 +219,30 @@ func (c *Conn) resetBuffer() {
 }
 
 func (c *Conn) appendType0(chunkID, tagType byte, timeMS, size uint32, payload []byte) {
-	// TODO: timeMS more than 24 bit
+	// >= 0xFFFFFF: sentinel in the 3-byte field, real value in the extended timestamp (RTMP 5.3.1.3)
+	ts := timeMS
+	if timeMS >= 0xFFFFFF {
+		ts = 0xFFFFFF
+	}
 	c.wrBuf = append(c.wrBuf,
 		chunkID,
-		byte(timeMS>>16), byte(timeMS>>8), byte(timeMS),
+		byte(ts>>16), byte(ts>>8), byte(ts),
 		byte(size>>16), byte(size>>8), byte(size),
 		tagType,
 		c.streamID, 0, 0, 0, // little endian streamID
 	)
+	if timeMS >= 0xFFFFFF {
+		c.wrBuf = binary.BigEndian.AppendUint32(c.wrBuf, timeMS)
+	}
 	c.wrBuf = append(c.wrBuf, payload...)
 }
 
-func (c *Conn) appendType3(chunkID byte, payload []byte) {
+func (c *Conn) appendType3(chunkID byte, timeMS uint32, payload []byte) {
 	c.wrBuf = append(c.wrBuf, 3<<6|chunkID)
+	// extended timestamp repeats on every continuation chunk (RTMP 5.3.1.3)
+	if timeMS >= 0xFFFFFF {
+		c.wrBuf = binary.BigEndian.AppendUint32(c.wrBuf, timeMS)
+	}
 	c.wrBuf = append(c.wrBuf, payload...)
 }
 
@@ -310,7 +321,7 @@ func (c *Conn) writePublish() error {
 		return len(items) >= 3 && items[0] == "onStatus"
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	code := getString(v, 3, "code")
@@ -332,7 +343,7 @@ func (c *Conn) writePlay() error {
 		return len(items) >= 3 && items[0] == "onStatus"
 	})
 	if err != nil {
-		return nil
+		return err
 	}
 
 	code := getString(v, 3, "code")

--- a/pkg/rtmp/conn_test.go
+++ b/pkg/rtmp/conn_test.go
@@ -1,0 +1,70 @@
+package rtmp
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteMessageExtendedTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	c := &Conn{wr: &buf, wrPacketSize: 4096}
+
+	require.NoError(t, c.writeMessage(4, TypeVideo, 0xFFFFFF, []byte{0x01, 0x02}))
+
+	got := buf.Bytes()
+	// basic header(1) + message header(11) + extended timestamp(4) + payload(2)
+	require.Len(t, got, 1+11+4+2)
+	require.Equal(t, byte(4), got[0])                    // fmt 0, chunk id 4
+	require.Equal(t, []byte{0xFF, 0xFF, 0xFF}, got[1:4]) // sentinel
+	require.Equal(t, []byte{0x00, 0x00, 0x02}, got[4:7]) // message length
+	require.Equal(t, byte(TypeVideo), got[7])
+	require.Equal(t, uint32(0xFFFFFF), binary.BigEndian.Uint32(got[12:16])) // extended timestamp
+	require.Equal(t, []byte{0x01, 0x02}, got[16:])
+}
+
+func TestWriteMessageExtendedTimestampChunked(t *testing.T) {
+	var buf bytes.Buffer
+	c := &Conn{wr: &buf, wrPacketSize: 4} // tiny chunk size to force a continuation
+
+	require.NoError(t, c.writeMessage(4, TypeVideo, 0x1000000, []byte{1, 2, 3, 4, 5, 6}))
+
+	got := buf.Bytes()
+	// type 0: basic(1) + header(11) + ext(4) + 4 payload = 20
+	// type 3: basic(1) + ext(4) + 2 payload = 7
+	require.Len(t, got, 20+7)
+
+	require.Equal(t, []byte{0xFF, 0xFF, 0xFF}, got[1:4])                     // sentinel
+	require.Equal(t, []byte{0x00, 0x00, 0x06}, got[4:7])                     // full message length
+	require.Equal(t, uint32(0x1000000), binary.BigEndian.Uint32(got[12:16])) // ext on type 0
+	require.Equal(t, []byte{1, 2, 3, 4}, got[16:20])
+
+	require.Equal(t, byte(3<<6|4), got[20])                                  // fmt 3, chunk id 4
+	require.Equal(t, uint32(0x1000000), binary.BigEndian.Uint32(got[21:25])) // ext repeated
+	require.Equal(t, []byte{5, 6}, got[25:27])
+}
+
+func TestWriteMessageNoExtendedTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	c := &Conn{wr: &buf, wrPacketSize: 4096}
+
+	require.NoError(t, c.writeMessage(4, TypeVideo, 1000, []byte{0x01, 0x02}))
+
+	got := buf.Bytes()
+	require.Len(t, got, 1+11+2)                          // no extended timestamp
+	require.Equal(t, []byte{0x00, 0x03, 0xE8}, got[1:4]) // 1000
+	require.Equal(t, []byte{0x01, 0x02}, got[12:])
+}
+
+func TestWritePublishPropagatesReadError(t *testing.T) {
+	c := &Conn{rd: bytes.NewReader(nil), wr: io.Discard, wrPacketSize: 4096}
+	require.Error(t, c.writePublish())
+}
+
+func TestWritePlayPropagatesReadError(t *testing.T) {
+	c := &Conn{rd: bytes.NewReader(nil), wr: io.Discard, wrPacketSize: 4096}
+	require.Error(t, c.writePlay())
+}


### PR DESCRIPTION
Two correctness fixes in the RTMP publish path, both of which bit us publishing to Ant Media from production.

**1. Propagate publish errors.** `writePublish` and `writePlay` returned nil when `readResponse` failed, so a dropped or rejected publish (server close, auth or app error, a network blip) came back as success. The consumer then wrote media into a dead socket and only failed later, turning a transient error into a reconnect loop. Now they return the error, and `DialPublish`/`DialPlay` close the connection on failure so we don't leak the socket on every retry.

**2. Extended timestamps.** The chunk writer truncated timestamps to 24 bits (the old `TODO: timeMS more than 24 bit`). Publishing to Ant Media for long stretches, once the relative timestamp crosses `0xFFFFFF` (~4h40m) it wraps and the stream drops or stutters. Now it writes the `0xFFFFFF` sentinel plus a 4-byte extended timestamp per RTMP spec 5.3.1.3, repeated on every type 3 continuation chunk. The read path already handled this.

`pkg/rtmp/conn_test.go` covers both.
