### PR TITLE
Latch FLV timestamp baseline on the first packet

### DIFF
--- a/pkg/flv/flv_test.go
+++ b/pkg/flv/flv_test.go
@@ -3,8 +3,40 @@ package flv
 import (
 	"testing"
 
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
+
+func tagTimeMS(tag []byte) uint32 {
+	return uint32(tag[4])<<16 | uint32(tag[5])<<8 | uint32(tag[6]) | uint32(tag[7])<<24
+}
+
+// A first packet at timestamp 0 must still latch the baseline, so later packets
+// keep real timestamps instead of re-baselining to 0.
+func TestPayloaderFirstPacketZeroTimestamp(t *testing.T) {
+	m := &Muxer{}
+	pay := m.GetPayloader(&core.Codec{Name: core.CodecH264, ClockRate: 90000})
+
+	idr := []byte{0, 0, 0, 1, 0x65}    // AVCC IDR (keyframe)
+	pframe := []byte{0, 0, 0, 1, 0x41} // AVCC non-keyframe
+
+	// 15 fps @ 90 kHz = 6000 ticks/frame
+	cases := []struct {
+		ts      uint32
+		payload []byte
+		wantMS  uint32
+	}{
+		{0, idr, 0},
+		{6000, pframe, 66}, // old ts0 == 0 sentinel wrongly re-baselined here
+		{12000, pframe, 133},
+		{18000, pframe, 200},
+	}
+	for i, c := range cases {
+		tag := pay(&rtp.Packet{Header: rtp.Header{Timestamp: c.ts}, Payload: c.payload})
+		require.Equal(t, c.wantMS, tagTimeMS(tag), "packet %d", i)
+	}
+}
 
 func TestTimeToRTP(t *testing.T) {
 	// Reolink camera has 20 FPS

--- a/pkg/flv/muxer.go
+++ b/pkg/flv/muxer.go
@@ -79,7 +79,10 @@ func (m *Muxer) GetInit() []byte {
 func (m *Muxer) GetPayloader(codec *core.Codec) func(packet *rtp.Packet) []byte {
 	m.codecs = append(m.codecs, codec)
 
+	// Baseline off the first packet. Guard with tsInit, not ts0 == 0: some cameras
+	// send that first packet at timestamp 0, so a 0 sentinel never latches it.
 	var ts0 uint32
+	var tsInit bool
 	var k = codec.ClockRate / 1000
 
 	switch codec.Name {
@@ -95,8 +98,9 @@ func (m *Muxer) GetPayloader(codec *core.Codec) func(packet *rtp.Packet) []byte 
 
 			buf = append(buf[:5], packet.Payload...) // reset buffer to previous place
 
-			if ts0 == 0 {
+			if !tsInit {
 				ts0 = packet.Timestamp
+				tsInit = true
 			}
 
 			timeMS := (packet.Timestamp - ts0) / k
@@ -109,8 +113,9 @@ func (m *Muxer) GetPayloader(codec *core.Codec) func(packet *rtp.Packet) []byte 
 		return func(packet *rtp.Packet) []byte {
 			buf = append(buf[:2], packet.Payload...)
 
-			if ts0 == 0 {
+			if !tsInit {
 				ts0 = packet.Timestamp
+				tsInit = true
 			}
 
 			timeMS := (packet.Timestamp - ts0) / k


### PR DESCRIPTION
We work with a large range of IP cameras, and some of them open the stream with the first packet already at RTP timestamp 0. This one is about stream startup: getting a usable timestamp to the client as soon as that first packet lands.

The FLV muxer used `ts0 == 0` as its "baseline not captured yet" flag. When a camera's first packet really is 0, that flag never latched, so it re-baselined on the second packet instead. The publish then opened with two frames at timestamp 0 and a skewed clock, which a strict server like Ant Media rejects and never brings the broadcast live.

The fix captures `ts0` on the first packet with an explicit flag rather than leaning on `0` as a sentinel.
