### PR TITLE
wip: homekit backchannel working for aqara g4

### DIFF
--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -106,6 +106,11 @@ var defaults = map[string]string{
 	"pcma/48000": "-c:a pcm_alaw -ar:a 48000 -ac:a 1",
 	"aac":        "-c:a aac", // keep sample rate and channels
 	"aac/16000":  "-c:a aac -ar:a 16000 -ac:a 1",
+	// -b:a caps actual output to match the MaxBitrate:24 we advertise to the
+	// camera in SelectedStreamConfiguration (pkg/hap/camera/stream.go); without
+	// it, libfdk_aac's default VBR for ELD runs ~38kbps, well over what we
+	// promised the camera to expect, which some cameras may enforce silently.
+	"eld":        "-c:a libfdk_aac -profile:a aac_eld -ar:a 16000 -ac:a 1 -frame_size 480 -b:a 24k",
 	"mp3":        "-c:a libmp3lame -q:a 8",
 	"pcm":        "-c:a pcm_s16be -ar:a 8000 -ac:a 1",
 	"pcm/8000":   "-c:a pcm_s16be -ar:a 8000 -ac:a 1",

--- a/internal/ffmpeg/producer.go
+++ b/internal/ffmpeg/producer.go
@@ -50,6 +50,7 @@ func NewProducer(url string) (core.Producer, error) {
 				{Name: core.CodecPCM, ClockRate: 8000},
 				{Name: core.CodecPCMA, ClockRate: 8000},
 				{Name: core.CodecPCMU, ClockRate: 8000},
+				{Name: core.CodecELD, ClockRate: 16000, Channels: 1},
 				// AAC has unknown problems on Dahua two way
 				{Name: core.CodecAAC, ClockRate: 16000, FmtpLine: aac.FMTP + "1408"},
 			},
@@ -97,6 +98,8 @@ func (p *Producer) newURL() string {
 		switch codec.Name {
 		case core.CodecOpus:
 			s += "#audio=opus/16000"
+		case core.CodecELD:
+			s += "#audio=eld"
 		case core.CodecAAC:
 			s += "#audio=aac/16000"
 		case core.CodecPCML:

--- a/pkg/hap/camera/stream.go
+++ b/pkg/hap/camera/stream.go
@@ -1,11 +1,16 @@
 package camera
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"log"
+	"net"
 
-	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/hap"
+	"github.com/AlexxIT/go2rtc/pkg/hap/tlv8"
 	"github.com/AlexxIT/go2rtc/pkg/srtp"
+	"github.com/google/uuid"
 )
 
 type Stream struct {
@@ -18,8 +23,9 @@ func NewStream(
 	client *hap.Client, videoCodec *VideoCodecConfiguration, audioCodec *AudioCodecConfiguration,
 	videoSession, audioSession *srtp.Session, bitrate int,
 ) (*Stream, error) {
+	u := uuid.New()
 	stream := &Stream{
-		id:     core.RandString(16, 0),
+		id:     string(u[:]),
 		client: client,
 	}
 
@@ -112,13 +118,27 @@ func (s *Stream) ExchangeEndpoints(videoSession, audioSession *srtp.Session) err
 			AudioRTPPort: audioSession.Local.Port,
 		},
 		VideoCrypto: SRTPCryptoSuite{
-			MasterKey:  string(videoSession.Local.MasterKey),
-			MasterSalt: string(videoSession.Local.MasterSalt),
+			CryptoSuite: CryptoAES_CM_128_HMAC_SHA1_80,
+			MasterKey:   string(videoSession.Local.MasterKey),
+			MasterSalt:  string(videoSession.Local.MasterSalt),
 		},
 		AudioCrypto: SRTPCryptoSuite{
-			MasterKey:  string(audioSession.Local.MasterKey),
-			MasterSalt: string(audioSession.Local.MasterSalt),
+			CryptoSuite: CryptoAES_CM_128_HMAC_SHA1_80,
+			MasterKey:   string(audioSession.Local.MasterKey),
+			MasterSalt:  string(audioSession.Local.MasterSalt),
 		},
+	}
+
+	log.Printf("[hap] SetupEndpointsRequest: SessionID=%x IPAddr=%s VideoPort=%d AudioPort=%d VideoKeyLen=%d AudioKeyLen=%d CryptoSuite=%d IPVersion=%d",
+		req.SessionID, req.Address.IPAddr, req.Address.VideoRTPPort, req.Address.AudioRTPPort, len(req.VideoCrypto.MasterKey), len(req.AudioCrypto.MasterKey), req.VideoCrypto.CryptoSuite, req.Address.IPVersion)
+
+	// Hex dump the marshalled TLV8 for debugging
+	debugBytes, debugErr := tlv8.Marshal(&req)
+	if debugErr != nil {
+		log.Printf("[hap] TLV8 marshal debug error: %v", debugErr)
+	} else {
+		log.Printf("[hap] SetupEndpointsRequest TLV8 hex (%d bytes): %x", len(debugBytes), debugBytes)
+		log.Printf("[hap] SetupEndpointsRequest TLV8 base64: %s", base64.StdEncoding.EncodeToString(debugBytes))
 	}
 
 	char := s.service.GetCharacter(TypeSetupEndpoints)
@@ -133,12 +153,35 @@ func (s *Stream) ExchangeEndpoints(videoSession, audioSession *srtp.Session) err
 	if err := s.client.GetCharacter(char); err != nil {
 		return err
 	}
+	if sVal, ok := char.Value.(string); ok {
+		log.Printf("[hap] SetupEndpointsResponse raw base64: %s", sVal)
+	}
+
 	if err := char.ReadTLV8(&res); err != nil {
 		return err
 	}
+	if res.Status != StreamingStatusAvailable {
+		return fmt.Errorf("hap: setup endpoints rejected with status %d", res.Status)
+	}
+	if len(res.VideoCrypto.MasterKey) != 16 || len(res.VideoCrypto.MasterSalt) != 14 ||
+		len(res.AudioCrypto.MasterKey) != 16 || len(res.AudioCrypto.MasterSalt) != 14 {
+		return fmt.Errorf("hap: setup endpoints returned invalid crypto lengths video=%d/%d audio=%d/%d",
+			len(res.VideoCrypto.MasterKey), len(res.VideoCrypto.MasterSalt),
+			len(res.AudioCrypto.MasterKey), len(res.AudioCrypto.MasterSalt))
+	}
+
+	cameraIP, _, _ := net.SplitHostPort(s.client.DeviceAddress)
+	addr := res.Address.IPAddr
+	if addr == "0.0.0.0" || addr == "" {
+		addr = cameraIP
+	}
+
+	log.Printf("[hap] ExchangeEndpoints VideoCrypto key=%d salt=%d AudioCrypto key=%d salt=%d",
+		len(res.VideoCrypto.MasterKey), len(res.VideoCrypto.MasterSalt),
+		len(res.AudioCrypto.MasterKey), len(res.AudioCrypto.MasterSalt))
 
 	videoSession.Remote = &srtp.Endpoint{
-		Addr:       res.Address.IPAddr,
+		Addr:       addr,
 		Port:       res.Address.VideoRTPPort,
 		MasterKey:  []byte(res.VideoCrypto.MasterKey),
 		MasterSalt: []byte(res.VideoCrypto.MasterSalt),
@@ -146,7 +189,7 @@ func (s *Stream) ExchangeEndpoints(videoSession, audioSession *srtp.Session) err
 	}
 
 	audioSession.Remote = &srtp.Endpoint{
-		Addr:       res.Address.IPAddr,
+		Addr:       addr,
 		Port:       res.Address.AudioRTPPort,
 		MasterKey:  []byte(res.AudioCrypto.MasterKey),
 		MasterSalt: []byte(res.AudioCrypto.MasterSalt),

--- a/pkg/homekit/helpers.go
+++ b/pkg/homekit/helpers.go
@@ -134,13 +134,18 @@ func trackToAudio(track *core.Receiver, audio0 *camera.AudioCodecConfiguration) 
 		}
 	}
 
+	rtpTime := uint8(20)
+	if codecType == 2 { // CodecELD (index 2 in audioCodecs list)
+		rtpTime = 30
+	}
+
 	return &camera.AudioCodecConfiguration{
 		CodecType: codecType,
 		CodecParams: []camera.AudioCodecParameters{
 			{
 				Channels:   channels,
 				SampleRate: []byte{sampleRate},
-				RTPTime:    []uint8{20},
+				RTPTime:    []uint8{rtpTime},
 			},
 		},
 	}

--- a/pkg/homekit/producer.go
+++ b/pkg/homekit/producer.go
@@ -1,12 +1,14 @@
 package homekit
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/rand"
 	"net"
 	"time"
 
+	"github.com/AlexxIT/go2rtc/pkg/aac"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/hap"
 	"github.com/AlexxIT/go2rtc/pkg/hap/camera"
@@ -21,11 +23,22 @@ type Client struct {
 	hap  *hap.Client
 	srtp *srtp.Server
 
+	videoSRTP *srtp.Server
+	audioSRTP *srtp.Server
+
 	videoConfig camera.SupportedVideoStreamConfiguration
 	audioConfig camera.SupportedAudioStreamConfiguration
 
 	videoSession *srtp.Session
 	audioSession *srtp.Session
+
+	// audioSend/audioSeq assign strictly increasing RTP timestamp/sequence
+	// for the backchannel audio SSRC across separate AddTrack calls (one per
+	// talkback playback) and across depacketized AUs within a call. Must not
+	// reset per-call: RTP requires monotonic sequence/timestamp for a given
+	// SSRC or receivers may treat the stream as stale and drop it.
+	audioSend uint32
+	audioSeq  uint16
 
 	stream *camera.Stream
 
@@ -104,6 +117,21 @@ func (c *Client) GetMedias() []*core.Media {
 		},
 	}
 
+	audioMedia := audioToMedia(c.audioConfig.Codecs)
+	backchannelCodecs := make([]*core.Codec, 0, len(audioMedia.Codecs)+1)
+	backchannelCodecs = append(backchannelCodecs, audioMedia.Codecs...)
+	backchannelCodecs = append(backchannelCodecs, &core.Codec{
+		Name:      core.CodecAAC,
+		ClockRate: 16000,
+		Channels:  1,
+	})
+
+	c.Medias = append(c.Medias, &core.Media{
+		Kind:      core.KindAudio,
+		Direction: core.DirectionSendonly,
+		Codecs:    backchannelCodecs,
+	})
+
 	return c.Medias
 }
 
@@ -122,17 +150,34 @@ func (c *Client) Start() error {
 	audioTrack := c.trackByKind(core.KindAudio)
 	audioCodec := trackToAudio(audioTrack, &c.audioConfig.Codecs[0])
 
-	c.videoSession = &srtp.Session{Local: c.srtpEndpoint()}
-	c.audioSession = &srtp.Session{Local: c.srtpEndpoint()}
+	c.videoSRTP = srtp.NewServer(":0")
+	if err := c.videoSRTP.Start(); err != nil {
+		return err
+	}
+	c.audioSRTP = srtp.NewServer(":0")
+	if err := c.audioSRTP.Start(); err != nil {
+		c.videoSRTP.Close()
+		return err
+	}
+
+	c.videoSession = &srtp.Session{Local: c.srtpEndpoint(c.videoSRTP)}
+	c.audioSession = &srtp.Session{Local: c.srtpEndpoint(c.audioSRTP)}
 
 	var err error
 	c.stream, err = camera.NewStream(c.hap, videoCodec, audioCodec, c.videoSession, c.audioSession, c.Bitrate)
 	if err != nil {
+		c.videoSRTP.Close()
+		c.audioSRTP.Close()
 		return err
 	}
 
-	c.srtp.AddSession(c.videoSession)
-	c.srtp.AddSession(c.audioSession)
+	c.videoSession.PayloadType = 99
+	c.videoSession.RTCPInterval = 500 * time.Millisecond
+	c.audioSession.PayloadType = 110
+	c.audioSession.RTCPInterval = 5 * time.Second
+
+	c.videoSRTP.AddSession(c.videoSession)
+	c.audioSRTP.AddSession(c.audioSession)
 
 	deadline := time.NewTimer(core.ConnDeadline)
 
@@ -168,10 +213,16 @@ func (c *Client) Start() error {
 
 func (c *Client) Stop() error {
 	if c.videoSession != nil && c.videoSession.Remote != nil {
-		c.srtp.DelSession(c.videoSession)
+		c.videoSRTP.DelSession(c.videoSession)
 	}
 	if c.audioSession != nil && c.audioSession.Remote != nil {
-		c.srtp.DelSession(c.audioSession)
+		c.audioSRTP.DelSession(c.audioSession)
+	}
+	if c.videoSRTP != nil {
+		c.videoSRTP.Close()
+	}
+	if c.audioSRTP != nil {
+		c.audioSRTP.Close()
 	}
 
 	return c.Connection.Stop()
@@ -205,10 +256,10 @@ func (c *Client) startMJPEG() error {
 	}
 }
 
-func (c *Client) srtpEndpoint() *srtp.Endpoint {
+func (c *Client) srtpEndpoint(server *srtp.Server) *srtp.Endpoint {
 	return &srtp.Endpoint{
 		Addr:       c.hap.LocalIP(),
-		Port:       uint16(c.srtp.Port()),
+		Port:       uint16(server.Port()),
 		MasterKey:  []byte(core.RandString(16, 0)),
 		MasterSalt: []byte(core.RandString(14, 0)),
 		SSRC:       rand.Uint32(),
@@ -240,4 +291,80 @@ func timekeeper(handler core.HandlerFunc) core.HandlerFunc {
 
 		handler(packet)
 	}
+}
+
+// AddTrack sends backchannel (talkback) audio to the camera.
+func (c *Client) AddTrack(media *core.Media, codec *core.Codec, track *core.Receiver) error {
+	const sampleRate = 16000
+	const sampleSize = 480 // 30ms @ 16kHz, matches negotiated RTPTime
+	const frameInterval = sampleSize * time.Second / sampleRate
+
+	switch codec.Name {
+	case core.CodecELD, core.CodecOpus, core.CodecAAC:
+		sender := core.NewSender(media, track.Codec)
+
+		var lastSent time.Time
+
+		// writeRTP sends exactly one AU per RTP packet, wrapped in the
+		// RFC 3640 §3.3.6 "AAC-hbr" AU-header format required by the HAP
+		// spec for AAC-ELD (11.9 Media Transport: "RFC 3640 - Section 3.3.6
+		// - High Bit-rate AAC for AAC-ELD"; sizeLength=13/indexLength=3, see
+		// aac.FMTP, is exactly a 2-byte AU-header): a 2-byte AU-headers-length
+		// field followed by one 2-byte AU-header giving the AU size.
+		//
+		// Timestamp/sequence for the shared backchannel SSRC must persist
+		// across calls (RTP requires monotonic sequence/timestamp for a
+		// given SSRC), and Marker is always true since every packet is
+		// exactly one complete AU.
+		//
+		// Paced with a rolling minimum spacing (time since the last packet
+		// sent, not a fixed schedule from burst start) so consecutive sends
+		// are never closer than one frame interval even if upstream delivery
+		// (ffmpeg -> internal RTSP loopback -> aac.RTPDepay(), which can
+		// unpack several bundled AUs from one incoming packet at once) is
+		// bursty.
+		writeRTP := func(packet *rtp.Packet) {
+			if c.audioSession == nil || c.audioSession.Remote == nil {
+				return
+			}
+
+			now := time.Now()
+			if !lastSent.IsZero() {
+				if expected := lastSent.Add(frameInterval); now.Before(expected) {
+					time.Sleep(expected.Sub(now))
+				}
+			}
+			lastSent = time.Now()
+
+			auSize := uint16(len(packet.Payload))
+			wrapped := make([]byte, 4+auSize)
+			wrapped[1] = 16 // AU-headers-length in bits: one 16-bit AU-header
+			binary.BigEndian.PutUint16(wrapped[2:], auSize<<3)
+			copy(wrapped[4:], packet.Payload)
+			packet.Payload = wrapped
+
+			packet.Marker = true
+			packet.Timestamp = c.audioSend
+			packet.SequenceNumber = c.audioSeq
+			c.audioSend += sampleSize
+			c.audioSeq++
+
+			if n, err := c.audioSession.WriteRTP(packet); err == nil {
+				c.Send += n
+			}
+		}
+
+		if track.Codec.IsRTP() {
+			// ffmpeg's own RTP muxer may bundle multiple AAC frames per
+			// packet; split back into one AU per packet before forwarding.
+			sender.Handler = aac.RTPDepay(writeRTP)
+		} else {
+			sender.Handler = writeRTP
+		}
+
+		sender.HandleRTP(track)
+		c.Senders = append(c.Senders, sender)
+	}
+
+	return nil
 }

--- a/pkg/srtp/server.go
+++ b/pkg/srtp/server.go
@@ -2,6 +2,7 @@ package srtp
 
 import (
 	"encoding/binary"
+	"log"
 	"net"
 	"strconv"
 	"sync"
@@ -31,17 +32,33 @@ func (s *Server) Port() int {
 	return i
 }
 
+func (s *Server) Start() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn != nil {
+		return nil
+	}
+	var err error
+	if s.conn, err = net.ListenPacket("udp", s.address); err != nil {
+		return err
+	}
+	go s.handle()
+	return nil
+}
+
 func (s *Server) AddSession(session *Session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := session.init(); err != nil {
+		log.Printf("[srtp] AddSession session.init failed: %v", err)
 		return
 	}
 
-	if len(s.sessions) == 0 {
+	if s.conn == nil {
 		var err error
 		if s.conn, err = net.ListenPacket("udp", s.address); err != nil {
+			log.Printf("[srtp] AddSession ListenPacket failed: %v", err)
 			return
 		}
 		go s.handle()
@@ -60,6 +77,7 @@ func (s *Server) DelSession(session *Session) {
 	// check s.conn for https://github.com/AlexxIT/go2rtc/issues/734
 	if len(s.sessions) == 0 && s.conn != nil {
 		_ = s.conn.Close()
+		s.conn = nil
 	}
 
 	s.mu.Unlock()
@@ -98,5 +116,14 @@ func (s *Server) handle() error {
 				session.ReadRTCP(b[:n])
 			}
 		}
+	}
+}
+
+func (s *Server) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.conn != nil {
+		_ = s.conn.Close()
+		s.conn = nil
 	}
 }

--- a/pkg/srtp/session.go
+++ b/pkg/srtp/session.go
@@ -2,6 +2,7 @@ package srtp
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/pion/rtcp"
@@ -25,6 +26,8 @@ type Session struct {
 
 	senderRTCP rtcp.SenderReport
 	senderTime time.Time
+
+	mu sync.Mutex // protects concurrent WriteRTP/WriteRTCP (e.g. backchannel sender vs RTCP auto-reply)
 }
 
 type Endpoint struct {
@@ -69,14 +72,21 @@ func (s *Session) init() error {
 }
 
 func (s *Session) WriteRTP(packet *rtp.Packet) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.Local.srtp == nil {
 		return 0, nil // before init call
 	}
 
 	if now := time.Now(); now.After(s.senderTime) {
-		s.senderRTCP.NTPTime = uint64(now.UnixNano())
+		secs := uint64(now.Unix() + 2208988800)
+		nanos := uint64(now.Nanosecond())
+		frac := (nanos << 32) / 1e9
+		s.senderRTCP.NTPTime = (secs << 32) | frac
+		s.senderRTCP.RTPTime = packet.Timestamp
 		s.senderTime = now.Add(s.RTCPInterval)
-		_, _ = s.WriteRTCP(&s.senderRTCP)
+		_, _ = s.writeRTCPLocked(&s.senderRTCP)
 	}
 
 	clone := rtp.Packet{
@@ -108,6 +118,16 @@ func (s *Session) WriteRTP(packet *rtp.Packet) (int, error) {
 }
 
 func (s *Session) WriteRTCP(packet rtcp.Packet) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.writeRTCPLocked(packet)
+}
+
+// writeRTCPLocked must be called with s.mu held.
+func (s *Session) writeRTCPLocked(packet rtcp.Packet) (int, error) {
+	if s.Local.srtp == nil {
+		return 0, nil // before init call
+	}
 	b, err := packet.Marshal()
 	if err != nil {
 		return 0, err
@@ -142,14 +162,6 @@ func (s *Session) ReadRTCP(b []byte) {
 	if err != nil {
 		return
 	}
-
-	//packets, err := rtcp.Unmarshal(b)
-	//if err != nil {
-	//	return
-	//}
-	//if report, ok := packets[0].(*rtcp.SenderReport); ok {
-	//	log.Printf("[srtp] rtcp type=%d report=%v", header.Type, report)
-	//}
 
 	if header.Type != rtcp.TypeSenderReport {
 		return


### PR DESCRIPTION
Hi everyone! 

I'm working on enabling two-way audio support for the **Aqara Doorbell G4** via HomeKit using `go2rtc`. The changes included in this PR, combined with a custom FFmpeg configuration, successfully make two-way talk functional for this specific device.  There is older PR with mostly the same thing https://github.com/AlexxIT/go2rtc/pull/1981 but with a conflict... i just applied them to master and tested with my device.   

I notice there is currently a lot of active development regarding HomeKit features in the development branch. Because of that, this PR might not be meant for a direct merge as-is, but rather to serve as a practical reference implementation for this hardware. 

# Changes:

# Technical Summary: HomeKit/SRTP Implementation Improvements

### 1. Thread Safety in `pkg/srtp/session.go` (Mutex/Locks)
* **Issue:** `WriteRTP` and `WriteRTCP` on a `Session` can be invoked concurrently by two independent goroutines:
  * The backchannel Sender's dedicated drain goroutine (`audioSession.WriteRTP()`).
  * The SRTP server's UDP receive loop (`server.go`'s `handle()`), which triggers `session.ReadRTCP()` and subsequently `WriteRTCP()`.
* **Resolution:** Both paths mutate shared state counters (`PacketCount`, `OctetCount`, `NTPTime`). Introducing a mutex eliminates race conditions and prevents corrupted updates to outgoing Sender Reports when backchannel audio is active.

---

### 2. Explicit `PayloadType` and `RTCPInterval` in `producer.go`
* **PayloadType:** Defaults to Go's zero value (`0`), causing outgoing packets to be incorrectly tagged as PCMU/G.711 instead of AAC-ELD (`110`) or H.264 (`99`). Explicit assignment aligns outgoing packet headers with the negotiated `SelectedStreamConfiguration`.
* **RTCPInterval:** Without setting a non-zero interval, `WriteRTP` continuously evaluates `now.After(senderTime)` as true, triggering redundant Sender Reports on every 30ms packet. Hardcoding intervals to match negotiated parameters (99/500ms for video, 110/5s for audio) ensures proper RTCP reporting intervals.

---

### 3. Separate Ephemeral SRTP Servers for Audio and Video
* **Specification Requirement:** HAP specification (§11.9, Media Transport) mandates that separate ports must be used to stream audio and video.
* **Resolution:** Replaced the single shared, process-global `srtp.Server` (default port `:8443`) with dedicated ephemeral ports (`:0`) per connection. This guarantees distinct port allocations for video and audio streams, ensuring compliance with stricter camera firmwares during bidirectional streaming.

---

### 4. Corrected RTP Time for AAC-ELD in `helpers.go`
* **Specification Requirement:** Per HAP specification Table 9-28 ("Mandatory RTP Time Values"), `20ms` is not a valid RTP time for AAC-ELD at 16kHz:

| RTP Time | Audio Codecs |
| :--- | :--- |
| **20ms, 40ms, 60ms** | AMR, AMR-WB, AAC-ELD 24K, Opus 16K, Opus 24K |
| **30ms, 60ms** | AAC-ELD 16K |

* **Resolution:** Section §11.8.2 mandates a block size of 480 samples for AAC-ELD, corresponding exactly to 30ms at 16kHz (480/16000s). Hardcoding RTP time to `20ms` caused invalid frame size mismatches. Logic updated to explicitly declare 30ms when `codectype == 2` (ELD).

---

### 5. Robustness and Compliance Improvements in `stream.go`
* **RFC 4122 UUIDs:** Replaced `core.RandString(16, 0)` with `uuid.New()` for session IDs to accommodate strict camera firmwares that validate UUID structure.
* **Explicit CryptoSuite:** Explicitly declared `CryptoAES_CM_128_HMAC_SHA1_80` for code clarity (no functional change, as its numeric constant is `0`).
* **Response Validation:** Added strict validation on `SetupEndpoints` responses (`res.Status != StreamingStatusAvailable` and verification of 16/14-byte key/salt lengths) to catch rejected or malformed negotiations early.
* **Empty IP Fallback:** Added fallback handling to substitute the camera's actual TCP connection IP whenever camera firmwares reply to `SetupEndpoints` with a wildcard (`0.0.0.0`) or empty address.

# Using go2rtc with the Aqara G4 Doorbell (Two-Way Audio Guide)

This guide provides step-by-step instructions for configuring and using `go2rtc` with the **Aqara G4 Doorbell** (`Model: SVD-C02`), focusing on setting up **two-way audio (talkback/backchannel)**.

---

## 📋 Prerequisites

To stream from and talk to the Aqara G4 Doorbell, you need:
1. The doorbell paired with `go2rtc` via the **HomeKit** protocol.
2. A **custom FFmpeg binary** compiled with `libfdk_aac` support (explained below).

> [!IMPORTANT]
> **Why is a custom FFmpeg required?**
> The Aqara G4 Doorbell only accepts **AAC-ELD** (Enhanced Low Delay) audio at 16kHz for its speaker. Standard builds of FFmpeg (such as those bundled in official Docker containers or default OS packages) do not support AAC-ELD encoding because the necessary library (`libfdk_aac`) is non-free/GPL-incompatible.

---

## 🛠️ Step 1: Obtain FFmpeg with `libfdk_aac`

You must obtain or compile an FFmpeg binary compiled with:
`--enable-libfdk-aac --enable-nonfree`

### For Docker Users (Recommended)
You can download a precompiled static binary and mount it into your container:
1. Download a static FFmpeg build with `libfdk_aac` (e.g., from trusted custom static build providers).
2. Mount the binary folder into your `docker-compose.yaml` (e.g. at `/config/custom-ffmpeg/bin/`):
   ```yaml
   volumes:
     - ./config:/config
     - ./custom-ffmpeg/ffmpeg:/config/custom-ffmpeg/bin/ffmpeg:ro
   ```
3. Set executable permissions inside the host directory:
   ```bash
   chmod +x ./custom-ffmpeg/ffmpeg
   ```

---

## ⚙️ Step 2: Configure `go2rtc.yaml`

Add the custom FFmpeg path and the HomeKit doorbell stream definition to your `go2rtc.yaml` file:

```yaml
# Point go2rtc to your custom FFmpeg binary
ffmpeg:
  bin: /config/custom-ffmpeg/bin/ffmpeg
  # Define the low-delay AAC-ELD profile for the camera's budget (24 kbps)
  eld: "-c:a libfdk_aac -profile:a aac_eld -ar:a 16000 -ac:a 1 -frame_size 480 -b:a 24k"

streams:
  # Main doorbell feed from HomeKit
  doorbell: homekit://192.168.1.100:36527?device_id=XX:XX:XX:XX:XX:XX&client_id=YYYYYYYYYYYYYYYY&client_private=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ

# HomeKit pairings configuration block (required if not using inline parameters)
homekit:
  doorbell:
    pin: 123-45-678
    device_id: XX:XX:XX:XX:XX:XX
```

---

## 🔊 Step 3: Trigger Two-Way Audio (Talkback)

Once configured, you can send audio (such as Text-to-Speech or audio files) to the doorbell speaker using the `go2rtc` API or pipeline integrations.

### Option A: Via HTTP API (Command Line / Script)
You can POST to the `/api/streams` endpoint to send a WAV/audio file to the doorbell. 
The stream `src` must request your custom `eld` audio template:

```bash
curl -X POST "http://localhost:1984/api/streams?dst=doorbell&src=ffmpeg:/path/to/speech.wav%23audio=eld%23input=file"
```

To stop talkback playback, clear the stream:
```bash
curl -X POST "http://localhost:1984/api/streams?dst=doorbell&src="
```
