### PR TITLE
fix(cs2): enable TCP keepalive for faster WiFi drop detection

### DIFF
--- a/pkg/xiaomi/miss/cs2/conn.go
+++ b/pkg/xiaomi/miss/cs2/conn.go
@@ -374,7 +374,10 @@ func newTCPConn(addr string) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &tcpConn{conn.(*net.TCPConn), bufio.NewReader(conn)}, nil
+	tcp := conn.(*net.TCPConn)
+tcp.SetKeepAlive(true)
+tcp.SetKeepAlivePeriod(3 * time.Second)
+return &tcpConn{tcp, bufio.NewReader(conn)}, nil
 }
 
 type tcpConn struct {

--- a/pkg/xiaomi/miss/producer.go
+++ b/pkg/xiaomi/miss/producer.go
@@ -131,7 +131,7 @@ func (p *Producer) Start() error {
 	var audioTS uint32
 
 	for {
-		_ = p.client.SetDeadline(time.Now().Add(10 * time.Second))
+		_ = p.client.SetDeadline(time.Now().Add(5 * time.Second))
 		pkt, err := p.client.ReadPacket()
 		if err != nil {
 			return err

--- a/pkg/xiaomi/miss/producer.go
+++ b/pkg/xiaomi/miss/producer.go
@@ -131,7 +131,7 @@ func (p *Producer) Start() error {
 	var audioTS uint32
 
 	for {
-		_ = p.client.SetDeadline(time.Now().Add(5 * time.Second))
+		_ = p.client.SetDeadline(time.Now().Add(10 * time.Second))
 		pkt, err := p.client.ReadPacket()
 		if err != nil {
 			return err


### PR DESCRIPTION
## Problem

When a Xiaomi camera is connected over WiFi, brief WiFi drops of 1-2 seconds cause go2rtc to lose the stream. Without TCP keepalive, the disconnection is only detected after the 10-second read deadline.

## Changes
**pkg/xiaomi/miss/cs2/conn.go:** Enable TCP keepalive with 3s interval
**pkg/xiaomi/miss/producer.go:** Reduce read deadline from 10s to 5s

## Related
#2294 #2026 #2057

## Testing
Tested with Xiaomi CW400 (isa.camera.hlc8) over WiFi