### PR TITLE
Add AV1 codec support for WebRTC

### DIFF
--- a/pkg/av1/rtp.go
+++ b/pkg/av1/rtp.go
@@ -1,0 +1,101 @@
+package av1
+
+import (
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/h264"
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+)
+
+// RTPDepay - depacketize AV1 RTP packets (https://aomediacodec.github.io/av1-rtp-spec/)
+// into temporal units in the AV1 low overhead bitstream format (OBUs with obu_size_field).
+// One output packet = one temporal unit (same convention as h264/h265 access units).
+func RTPDepay(handler core.HandlerFunc) core.HandlerFunc {
+	depack := &codecs.AV1Depacketizer{}
+
+	buf := make([]byte, 0, 512*1024) // 512K
+	var seqNum uint16
+
+	return func(packet *rtp.Packet) {
+		// when we collect data into one buffer, we need to make sure
+		// that all of it falls into the same sequence
+		if len(buf) > 0 && packet.SequenceNumber-seqNum != 1 {
+			//log.Printf("broken AV1 sequence")
+			buf = buf[:0]                        // drop data
+			depack = &codecs.AV1Depacketizer{}   // drop pending OBU fragment
+			return
+		}
+
+		seqNum = packet.SequenceNumber
+
+		obus, err := depack.Unmarshal(packet.Payload)
+		if err != nil {
+			buf = buf[:0]
+			depack = &codecs.AV1Depacketizer{}
+			return
+		}
+
+		buf = append(buf, obus...)
+
+		// collect all OBUs for temporal unit
+		if !packet.Marker {
+			return
+		}
+
+		if len(buf) == 0 {
+			return
+		}
+
+		clone := *packet
+		clone.Version = h264.RTPPacketVersionAVC
+		clone.Payload = buf
+
+		buf = buf[:0]
+
+		handler(&clone)
+	}
+}
+
+// RTPPay - packetize AV1 temporal units (low overhead bitstream) into RTP packets
+// sized for the given MTU, per the AV1 RTP specification.
+func RTPPay(mtu uint16, handler core.HandlerFunc) core.HandlerFunc {
+	if mtu == 0 {
+		mtu = 1472
+	}
+
+	payloader := &codecs.AV1Payloader{}
+	sequencer := rtp.NewRandomSequencer()
+	mtu -= 12 // rtp.Header size
+
+	return func(packet *rtp.Packet) {
+		if packet.Version != h264.RTPPacketVersionAVC {
+			handler(packet)
+			return
+		}
+
+		payloads := payloader.Payload(mtu, packet.Payload)
+		last := len(payloads) - 1
+		for i, payload := range payloads {
+			// 4K AV1 keyframe temporal units run to hundreds of packets;
+			// blasting them in one tight loop overflows UDP socket buffers
+			// (~50% observed loss on a gigabit LAN). Pace large bursts —
+			// each sender runs on its own goroutine, so sleeping here only
+			// delays this consumer, never the producer.
+			if i > 0 && i%16 == 0 {
+				time.Sleep(2 * time.Millisecond)
+			}
+			clone := rtp.Packet{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         i == last,
+					SequenceNumber: sequencer.NextSequenceNumber(),
+					Timestamp:      packet.Timestamp,
+				},
+				Payload: payload,
+			}
+			handler(&clone)
+		}
+	}
+}

--- a/pkg/webrtc/api.go
+++ b/pkg/webrtc/api.go
@@ -222,6 +222,13 @@ func newUDPMux(address string, filters *Filters) ice.UDPMux {
 	var muxes []ice.UDPMux
 	for _, addr := range addrs {
 		if ln, _ := net.ListenPacket(networkUDP, addr); ln != nil {
+			// large keyframes (4K H265/AV1) are written in bursts of hundreds
+			// of packets; the default socket buffer (net.core.wmem_default,
+			// often ~208KB) drops much of such a burst
+			if udpConn, ok := ln.(*net.UDPConn); ok {
+				_ = udpConn.SetWriteBuffer(4 << 20)
+				_ = udpConn.SetReadBuffer(1 << 20)
+			}
 			OnNewListener(ln)
 			mux := ice.NewUDPMuxDefault(ice.UDPMuxParams{UDPConn: ln})
 			muxes = append(muxes, mux)
@@ -305,6 +312,15 @@ func RegisterDefaultCodecs(m *webrtc.MediaEngine) error {
 				RTCPFeedback: videoRTCPFeedback,
 			},
 			PayloadType: 100,
+		},
+		// Chrome 113+, Firefox 136+, Safari 18.4+
+		{
+			RTPCodecCapability: webrtc.RTPCodecCapability{
+				MimeType:     webrtc.MimeTypeAV1,
+				ClockRate:    90000,
+				RTCPFeedback: videoRTCPFeedback,
+			},
+			PayloadType: 105,
 		},
 	} {
 		if err := m.RegisterCodec(codec, webrtc.RTPCodecTypeVideo); err != nil {

--- a/pkg/webrtc/consumer.go
+++ b/pkg/webrtc/consumer.go
@@ -3,6 +3,7 @@ package webrtc
 import (
 	"errors"
 
+	"github.com/AlexxIT/go2rtc/pkg/av1"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/AlexxIT/go2rtc/pkg/h265"
@@ -61,6 +62,14 @@ func (c *Conn) AddTrack(media *core.Media, codec *core.Codec, track *core.Receiv
 			sender.Handler = h265.RTPDepay(track.Codec, sender.Handler)
 		} else {
 			sender.Handler = h265.RepairAVCC(track.Codec, sender.Handler)
+		}
+
+	case core.CodecAV1:
+		// repacketize to browser-safe MTU (RTSP sources are often TCP-interleaved
+		// and can carry RTP packets larger than the WebRTC path MTU)
+		sender.Handler = av1.RTPPay(1200, sender.Handler)
+		if track.Codec.IsRTP() {
+			sender.Handler = av1.RTPDepay(sender.Handler)
 		}
 
 	case core.CodecPCMA, core.CodecPCMU, core.CodecPCM, core.CodecPCML:


### PR DESCRIPTION
## What

Adds AV1 as a negotiable video codec for WebRTC consumers.

- `pkg/webrtc/api.go` — register AV1 in the pion MediaEngine (PT 105, same
  RTCP feedback set as the other video codecs), and request larger socket
  buffers on the WebRTC UDP mux listeners (see below).
- `pkg/av1/rtp.go` (new) — `RTPDepay`/`RTPPay` handlers mirroring the existing
  H264/H265 structure, built on `pion/rtp`'s `AV1Depacketizer`/`AV1Payloader`:
  incoming AV1 RTP is reassembled into temporal units, then re-fragmented at
  MTU 1200 (RTSP sources are often TCP-interleaved and can carry RTP packets
  larger than the UDP/TURN-safe MTU).
- `pkg/webrtc/consumer.go` — wire the AV1 case into `AddTrack`.

## Why the pacing + socket buffers

A 4K AV1 keyframe temporal unit spans hundreds of RTP packets. Writing them
in one tight loop overflowed UDP socket buffers — ~50% packet loss measured on
a gigabit LAN with the kernel-default (~208KB) send buffer. Two mitigations:

- light pacing in the AV1 payloader (2ms per 16 packets); each go2rtc sender
  runs on its own goroutine, so this never delays the producer or other
  consumers,
- `SetWriteBuffer(4MB)` / `SetReadBuffer(1MB)` on the UDP mux listeners (this
  also benefits large H265 keyframes).

## Tested

- UniFi Protect G6 PTZ, 4K AV1 via `rtspx://` → Chrome 148: AV1 negotiated
  first in the answer, 3840x2160 frames decoded, direct and through a coturn
  TURN relay.
- H264/H265/audio paths untouched; regression-checked against an H265 camera
  (MSE + WebRTC negotiation unchanged).

## Not included

MSE/fMP4 AV1 (`av01` muxing) — separate concern, tracked in #2260. Browsers
that can't receive AV1 over WebRTC still get the "codecs not matched" error
as before.