### PR TITLE
fix(nest): per-stream session state and re-arming stream extend timer

### DIFF
--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -26,7 +26,10 @@ type API struct {
 	StreamToken          string
 	StreamExtensionToken string
 
-	extendTimer *time.Timer
+	credsKey string
+
+	extendMu   sync.Mutex
+	extendStop chan struct{}
 }
 
 type Auth struct {
@@ -49,8 +52,10 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 	key := clientID + ":" + clientSecret + ":" + refreshToken
 	now := time.Now()
 
+	// Each caller gets its own API instance (sharing only the cached token),
+	// so concurrent streams don't overwrite each other's session state.
 	if api := cache[key]; api != nil && now.Before(api.ExpiresAt) {
-		return api, nil
+		return &API{Token: api.Token, ExpiresAt: api.ExpiresAt, credsKey: key}, nil
 	}
 
 	data := url.Values{
@@ -89,7 +94,7 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 
 	cache[key] = api
 
-	return api, nil
+	return &API{Token: api.Token, ExpiresAt: api.ExpiresAt, credsKey: key}, nil
 }
 
 func (a *API) GetDevices(projectID string) ([]DeviceInfo, error) {
@@ -228,23 +233,12 @@ func (a *API) ExchangeSDP(projectID, deviceID, offer string) (string, error) {
 }
 
 func (a *API) refreshToken() error {
-	// Get the cached API with matching token to get credentials
-	var refreshKey string
-	cacheMu.Lock()
-	for key, api := range cache {
-		if api.Token == a.Token {
-			refreshKey = key
-			break
-		}
-	}
-	cacheMu.Unlock()
-
-	if refreshKey == "" {
+	if a.credsKey == "" {
 		return errors.New("nest: unable to find cached credentials")
 	}
 
 	// Parse credentials from cache key
-	parts := strings.Split(refreshKey, ":")
+	parts := strings.SplitN(a.credsKey, ":", 3)
 	if len(parts) != 3 {
 		return errors.New("nest: invalid cache key format")
 	}
@@ -464,23 +458,74 @@ type Device struct {
 	} `json:"parentRelations"`
 }
 
+// StartExtendStreamTimer keeps the stream session alive by extending it
+// before every expiry until StopExtendStreamTimer is called. Sessions can
+// be short-lived, so a single extend at expiry minus one minute is not
+// enough: the delay may be negative and the session still dies one expiry
+// later.
 func (a *API) StartExtendStreamTimer() {
-	if a.extendTimer != nil {
+	a.extendMu.Lock()
+	defer a.extendMu.Unlock()
+
+	if a.extendStop != nil {
 		return
 	}
 
-	a.extendTimer = time.NewTimer(time.Until(a.StreamExpiresAt) - time.Minute)
-	go func() {
-		<-a.extendTimer.C
-		if err := a.ExtendStream(); err != nil {
-			return
-		}
-	}()
+	stop := make(chan struct{})
+	a.extendStop = stop
+
+	go a.extendLoop(stop)
 }
 
 func (a *API) StopExtendStreamTimer() {
-	if a.extendTimer != nil {
-		a.extendTimer.Stop()
-		a.extendTimer = nil
+	a.extendMu.Lock()
+	defer a.extendMu.Unlock()
+
+	if a.extendStop != nil {
+		close(a.extendStop)
+		a.extendStop = nil
+	}
+}
+
+func (a *API) extendLoop(stop chan struct{}) {
+	const margin = 30 * time.Second
+	const minDelay = 5 * time.Second
+	const retryDelay = 2 * time.Second
+	const maxFailures = 3
+
+	for {
+		delay := time.Until(a.StreamExpiresAt) - margin
+		if delay < minDelay {
+			delay = minDelay
+		}
+		if !sleep(stop, delay) {
+			return
+		}
+
+		failures := 0
+		for {
+			if err := a.ExtendStream(); err == nil {
+				break
+			}
+
+			failures++
+			if failures >= maxFailures {
+				return
+			}
+			if !sleep(stop, retryDelay) {
+				return
+			}
+		}
+	}
+}
+
+func sleep(stop chan struct{}, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-stop:
+		return false
+	case <-timer.C:
+		return true
 	}
 }


### PR DESCRIPTION
## Problem

Nest WebRTC/RTSP streams die shortly after start (often within a minute) and never recover. With several cameras on the same credentials it is worse: only the most recently started stream can be extended at all. This became much more visible recently as Nest media sessions got shorter-lived (see #2319), but the underlying defects are older and likely also explain long-standing reports like #2108 and #723.

## Root causes (`pkg/nest/api.go`)

1. **All streams with the same credentials share one `*API` instance.** `NewAPI` returns the cached object itself, and `ExchangeSDP` / `GenerateRtspStream` store per-session state (`StreamProjectID`, `StreamDeviceID`, `StreamSessionID`, `StreamExpiresAt`, …) on it. Every new stream overwrites the previous stream's session, so `ExtendStream` targets whichever camera connected last — extensions for every other camera are lost. The `extendTimer != nil` guard also means only one timer ever exists for all streams.

2. **The extend timer is single-shot and never re-arms.** `StartExtendStreamTimer` schedules one extend at `expiresAt − 1 min` and the goroutine exits afterwards, so a session survives at most two expiry windows even when everything works. When `expiresAt` is less than a minute away, the computed delay is ≤ 0, the timer fires immediately, and the only extend is spent right away — the session then dies at the next expiry.

3. **Race + goroutine leak (#2319).** `StopExtendStreamTimer` sets `a.extendTimer = nil` while the goroutine dereferences `a.extendTimer.C` → nil-pointer panic. And because `Timer.Stop` does not close the channel, a stopped timer leaves that goroutine blocked forever — one leaked goroutine per stream start/stop cycle.

## Fix

- `NewAPI` returns a fresh per-caller `API` carrying the cached token (token caching behavior is unchanged), so each stream owns its session state and extend loop. `refreshToken` now uses a stored credentials key instead of the reverse cache lookup by token — that lookup also failed whenever the cached token had rotated.
- `StartExtendStreamTimer` starts a loop that extends the session 30 s before every expiry (minimum 5 s delay), re-arms after each success using the refreshed `expiresAt`, and retries a failed extend up to 3 times, 2 s apart, before giving up.
- The loop is controlled by a stop channel guarded by a mutex: no shared timer pointer, no nil dereference, no leaked goroutine. `StopExtendStreamTimer` stays idempotent.

No logging added, consistent with the logging removal in #1669.

## Testing

Equivalent patch (same logic, plus debug logging) running in production since 2026-07-01 on linux/arm64 Docker with 4 WebRTC-only cameras (Nest Cam battery/wired gen 2 + Nest Doorbell, `supportedProtocols=[WEB_RTC]`), feeding ffmpeg recorders through the RTSP restream:

- **before:** every producer died ~45–60 s after start; consumers received an initial ~2 s burst of video and then nothing (`Could not find codec parameters`, empty recordings);
- **after:** sessions are created with a 5-minute expiry and streams survive well past the previous death point; motion-event recordings complete and save correctly.

Fixes #2319

