### PR TITLE
core: fix WriteBuffer race causing panics in mp4 HTTP handler after client disconnect

### DIFF
--- a/pkg/core/writebuffer.go
+++ b/pkg/core/writebuffer.go
@@ -47,12 +47,22 @@ func (w *WriteBuffer) WriteTo(wr io.Writer) (n int64, err error) {
 }
 
 func (w *WriteBuffer) Close() error {
-	if closer, ok := w.Writer.(io.Closer); ok {
+	// read w.Writer under the mutex - Reset may swap it concurrently
+	w.mu.Lock()
+	closer, _ := w.Writer.(io.Closer)
+	if closer == nil {
+		// mark the buffer as closed, so that late Write calls from track
+		// senders fail instead of writing into the http.ResponseWriter,
+		// whose bufio.Writer net/http recycles after the handler returns
+		if w.err == nil {
+			w.err = io.ErrClosedPipe
+		}
+		w.done()
+	}
+	w.mu.Unlock()
+	if closer != nil {
 		return closer.Close()
 	}
-	w.mu.Lock()
-	w.done()
-	w.mu.Unlock()
 	return nil
 }
 

--- a/pkg/core/writebuffer_test.go
+++ b/pkg/core/writebuffer_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// recyclableWriter emulates a net/http response writer: after the handler
+// returns (i.e. WriteTo unblocks), net/http puts the response bufio.Writer
+// back into a pool. Any Write after that moment reproduces the production
+// panics (nil deref / slice bounds out of range inside bufio).
+type recyclableWriter struct {
+	first    sync.Once
+	ready    chan struct{}
+	recycled atomic.Bool
+	violated atomic.Bool
+}
+
+func (w *recyclableWriter) Write(p []byte) (int, error) {
+	w.first.Do(func() { close(w.ready) })
+	if w.recycled.Load() {
+		w.violated.Store(true)
+	}
+	return len(p), nil
+}
+
+func TestWriteBufferCloseBlocksLateWrites(t *testing.T) {
+	wb := NewWriteBuffer(nil)
+	rw := &recyclableWriter{ready: make(chan struct{})}
+
+	// init segment is buffered before WriteTo, Reset will copy it into rw
+	_, _ = wb.Write([]byte("init"))
+
+	handlerDone := make(chan struct{})
+	go func() {
+		_, _ = wb.WriteTo(rw) // handlerMP4: blocks until Close
+		rw.recycled.Store(true)
+		close(handlerDone)
+	}()
+	<-rw.ready // WriteTo has been called, Writer is switched to rw
+
+	// track sender goroutines keep pushing frames
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100000; j++ {
+				if _, err := wb.Write([]byte("frame")); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	_ = wb.Close() // client disconnected -> cons.Stop() -> Transport.Close()
+	<-handlerDone
+	wg.Wait()
+
+	if rw.violated.Load() {
+		t.Fatal("Write after handler return: production panic scenario reproduced")
+	}
+	if _, err := wb.Write([]byte("late")); err == nil {
+		t.Fatal("Write after Close must return error")
+	}
+}


### PR DESCRIPTION
Fixes #338
Fixes #1220
Fixes #1261
Fixes #1757

## Root cause

All four issues above are the same race in `pkg/core/writebuffer.go`, triggered by an mp4-over-HTTP viewer disconnecting (`GET /api/stream.mp4`, also used by Home Assistant / Frigate integrations).

Sequence:

1. `handlerMP4` blocks in `cons.WriteTo(w)` → `WriteBuffer.WriteTo` → `wg.Wait()`, while track sender goroutines call `WriteBuffer.Write` and stream fMP4 into the `http.ResponseWriter`.
2. The client disconnects → `ctx.Done()` → `cons.Stop()` → `Transport.Close()` → `WriteBuffer.Close()`.
3. `Close()` only calls `w.done()`. **It never sets `w.err`**, so the buffer is never actually marked closed.
4. `wg.Wait()` unblocks, `handlerMP4` returns, and net/http puts the response's `bufio.Writer` back into its internal pool (`putBufioWriter`), where it is reset and may be handed to a **different connection**.
5. Sender goroutines that were already past (or subsequently pass) the `w.err != nil` check keep calling `w.Writer.Write(p)` / `Flush()` on that recycled writer.

Depending on timing this produces every panic variant reported over the years:

- `nil pointer dereference` in `bufio.(*Writer).Write` / `Flush` (writer reset to nil-underlying state in the pool) — #1220, #1261, #1757
- `slice bounds out of range [:N] with capacity 4096` in `bufio.(*Writer).Write` (writer concurrently owned by another connection)
- `concurrent write` corruption — #338

There is a second, smaller race in the same function: `Close()` performed the `w.Writer.(io.Closer)` type assertion without holding `w.mu`, racing with `Reset()` swapping `w.Writer` (this one is flagged directly by `go test -race`).

## Fix

Two changes in `WriteBuffer.Close()`, nothing else touched:

1. Read `w.Writer` under `w.mu` (fixes the assertion/`Reset` race).
2. For non-Closer writers (the mp4-over-HTTP path), set `w.err = io.ErrClosedPipe` before `done()`. Late `Write` calls from sender goroutines now return an error instead of writing into a writer that net/http has already recycled. This mirrors what `Write` itself does on error, so the error path is not new behavior.

## Test

`TestWriteBufferCloseBlocksLateWrites` emulates the handler lifecycle: a writer that is marked "recycled" the moment `WriteTo` returns, 8 concurrent sender goroutines, then `Close()`.

On current master it fails under `-race` (both the data race and a write-after-recycle are detected within milliseconds):

```
WARNING: DATA RACE
Read at ... by goroutine ...: core.(*WriteBuffer).Close()
Previous write at ... by goroutine ...: core.(*WriteBuffer).Reset()
...
writebuffer_test.go: Write after handler return: production panic scenario reproduced
```

With the fix it passes `go test -race -count=3 ./pkg/core/`.

## Production validation

We run go2rtc with several hundred RTSP cameras and public web pages embedding mp4 streams (constant anonymous viewer churn, 24/7). On stock 1.9.14 the process panicked every 1–2 days with one of the variants above. With this patch (applied on top of v1.9.14) we have had zero panics, including under a stress test of mass parallel connect/disconnect cycles across ~300 streams.

## Note

Unrelated to this PR: `pkg/core/core_test.go` on current master references `StripUserinfo`, which no longer exists in the codebase, so `go test ./pkg/core/` fails to compile with or without this change (the runs above were done with that file temporarily moved aside). Left untouched here to keep the diff minimal.
