### PR TITLE
Add UniFi Protect Opus talkback source

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ A summary table of all modules and features can be found [here](internal/README.
 - [`tapo`](internal/tapo/README.md) - [TP-Link Tapo](https://www.tapo.com/) cameras with two-way audio support.
 - [`vigi`](internal/tapo/README.md#tp-link-vigi) - TP-Link Vigi cameras.
 - [`tuya`](internal/tuya/README.md) - [Tuya](https://www.tuya.com/) ecosystem cameras with two-way audio support.
+- [`unifi`](internal/unifi/README.md) - UniFi Protect cameras with Opus talkback support.
 - [`webtorrent`](internal/webtorrent/README.md) - Stream from another go2rtc via [WebTorrent](https://en.wikipedia.org/wiki/WebTorrent) protocol.
 - [`wyze`](internal/wyze/README.md) - [Wyze](https://wyze.com/) cameras using native P2P protocol
 - [`xiaomi`](internal/xiaomi/README.md) - [Xiaomi Mi Home](https://home.mi.com/) ecosystem cameras with two-way audio support.
@@ -282,6 +283,7 @@ Supported for:
 [`rtsp`](internal/rtsp/README.md#two-way-audio), 
 [`tapo`](internal/tapo/README.md), 
 [`tuya`](internal/tuya/README.md), 
+[`unifi`](internal/unifi/README.md), 
 [`webrtc`](internal/webrtc/README.md), 
 [`wyze`](internal/wyze/README.md), 
 [`xiaomi`](internal/xiaomi/README.md).

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A summary table of all modules and features can be found [here](internal/README.
 - [`tapo`](internal/tapo/README.md) - [TP-Link Tapo](https://www.tapo.com/) cameras with two-way audio support.
 - [`vigi`](internal/tapo/README.md#tp-link-vigi) - TP-Link Vigi cameras.
 - [`tuya`](internal/tuya/README.md) - [Tuya](https://www.tuya.com/) ecosystem cameras with two-way audio support.
-- [`unifi`](internal/unifi/README.md) - UniFi Protect cameras with Opus talkback support.
+- [`unifi`](internal/unifi/README.md) - UniFi Protect cameras with talkback support.
 - [`webtorrent`](internal/webtorrent/README.md) - Stream from another go2rtc via [WebTorrent](https://en.wikipedia.org/wiki/WebTorrent) protocol.
 - [`wyze`](internal/wyze/README.md) - [Wyze](https://wyze.com/) cameras using native P2P protocol
 - [`xiaomi`](internal/xiaomi/README.md) - [Xiaomi Mi Home](https://home.mi.com/) ecosystem cameras with two-way audio support.

--- a/internal/README.md
+++ b/internal/README.md
@@ -59,6 +59,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | [`rtsp`]       | `rtsp`          | `rtsp`           | yes   | yes    | yes    | yes     |
 | [`tapo`]       | `mpegts`        | `http`           | yes   |        |        | yes     |
 | [`tuya`]       | `srtp`          | `webrtc`         | yes   |        |        | yes     |
+| [`unifi`]      | `rtp`           | `http`           |       |        |        | yes     |
 | [`v4l2`]       | `rawvideo`      | `ioctl`          | yes   |        |        |         |
 | [`webrtc`]     | `srtp`          | `webrtc`         | yes   | yes    | yes    | yes     |
 | [`webtorrent`] | `srtp`          | `webrtc`         | yes   | yes    |        |         |
@@ -104,6 +105,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 [`streams`]: streams/README.md
 [`tapo`]: tapo/README.md
 [`tuya`]: tuya/README.md
+[`unifi`]: unifi/README.md
 [`v4l2`]: v4l2/README.md
 [`webrtc`]: webrtc/README.md
 [`webtorrent`]: webtorrent/README.md

--- a/internal/app/README.md
+++ b/internal/app/README.md
@@ -94,4 +94,4 @@ log:
   api: trace   # module name: log level
 ```
 
-Modules: `api`, `streams`, `rtsp`, `webrtc`, `mp4`, `hls`, `mjpeg`, `hass`, `homekit`, `onvif`, `rtmp`, `webtorrent`, `wyoming`, `echo`, `exec`, `expr`, `ffmpeg`, `wyze`, `xiaomi`.
+Modules: `api`, `streams`, `rtsp`, `webrtc`, `mp4`, `hls`, `mjpeg`, `hass`, `homekit`, `onvif`, `rtmp`, `webtorrent`, `wyoming`, `echo`, `exec`, `expr`, `ffmpeg`, `unifi`, `wyze`, `xiaomi`.

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
 )
 
 type state byte
@@ -135,7 +136,7 @@ func (p *Producer) MarshalJSON() ([]byte, error) {
 	if conn := p.conn; conn != nil {
 		return json.Marshal(conn)
 	}
-	info := map[string]string{"url": p.url}
+	info := map[string]string{"url": creds.SecretString(p.url)}
 	return json.Marshal(info)
 }
 
@@ -149,7 +150,7 @@ func (p *Producer) start() {
 		return
 	}
 
-	log.Debug().Msgf("[streams] start producer url=%s", p.url)
+	log.Debug().Msgf("[streams] start producer url=%s", creds.SecretString(p.url))
 
 	p.state = stateStart
 	p.workerID++
@@ -167,7 +168,7 @@ func (p *Producer) worker(conn core.Producer, workerID int) {
 			return
 		}
 
-		log.Warn().Err(err).Str("url", p.url).Caller().Send()
+		log.Warn().Err(err).Str("url", creds.SecretString(p.url)).Caller().Send()
 	}
 
 	p.reconnect(workerID, 0)
@@ -178,11 +179,11 @@ func (p *Producer) reconnect(workerID, retry int) {
 	defer p.mu.Unlock()
 
 	if p.workerID != workerID {
-		log.Trace().Msgf("[streams] stop reconnect url=%s", p.url)
+		log.Trace().Msgf("[streams] stop reconnect url=%s", creds.SecretString(p.url))
 		return
 	}
 
-	log.Debug().Msgf("[streams] retry=%d to url=%s", retry, p.url)
+	log.Debug().Msgf("[streams] retry=%d to url=%s", retry, creds.SecretString(p.url))
 
 	conn, err := GetProducer(p.url)
 	if err != nil {
@@ -257,7 +258,7 @@ func (p *Producer) stop() {
 		p.workerID++
 	}
 
-	log.Debug().Msgf("[streams] stop producer url=%s", p.url)
+	log.Debug().Msgf("[streams] stop producer url=%s", creds.SecretString(p.url))
 
 	if p.conn != nil {
 		_ = p.conn.Stop()

--- a/internal/unifi/README.md
+++ b/internal/unifi/README.md
@@ -1,0 +1,24 @@
+# UniFi Protect
+
+UniFi Protect talkback is supported as a native go2rtc audio backchannel.
+
+## Configuration
+
+```yaml
+streams:
+  gate:
+    - rtspx://192.168.1.1:7441/<alias>#backchannel=0
+    - ffmpeg:gate#audio=opus
+    - unifi-talkback:https://192.168.1.1?camera_id=<id>&api_key=<secret>
+```
+
+The `unifi-talkback:` source uses the UniFi Protect public API:
+
+- `GET /proxy/protect/integration/v1/cameras/{camera_id}` checks whether the camera has a speaker
+- `POST /proxy/protect/integration/v1/cameras/{camera_id}/talkback-session` starts a talkback session
+
+Normal `video+audio` viewing does not activate talkback. go2rtc opens the UniFi talkback session only after a client sends microphone RTP into the audio backchannel.
+
+Push-to-talk clients should start sending microphone audio when talk begins and stop or disconnect that microphone send session when talk ends. go2rtc closes the FFmpeg RTP output when the backchannel producer stops.
+
+Only UniFi talkback sessions that report `codec: "opus"` are supported.

--- a/internal/unifi/README.md
+++ b/internal/unifi/README.md
@@ -19,6 +19,6 @@ The `unifi-talkback:` source uses the UniFi Protect public API:
 
 Normal `video+audio` viewing does not activate talkback. go2rtc opens the UniFi talkback session only after a client sends microphone RTP into the audio backchannel.
 
-Push-to-talk clients should start sending microphone audio when talk begins and stop or disconnect that microphone send session when talk ends. go2rtc closes the FFmpeg RTP output when the backchannel producer stops.
+Push-to-talk clients should start sending microphone audio when talk begins and stop or disconnect that microphone send session when talk ends. go2rtc closes the FFmpeg output when the backchannel producer stops.
 
-Only UniFi talkback sessions that report `codec: "opus"` are supported.
+Supported UniFi talkback session codecs are `opus` over RTP, `aac` over ADTS, and `vorbis` over Ogg. Any other codec is rejected.

--- a/internal/unifi/unifi.go
+++ b/internal/unifi/unifi.go
@@ -1,0 +1,22 @@
+package unifi
+
+import (
+	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/internal/streams"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/unifi"
+)
+
+func Init() {
+	unifi.SetLogger(app.GetLogger("unifi"))
+
+	streams.HandleFunc(unifi.SchemeTalkback, func(source string) (core.Producer, error) {
+		return unifi.DialTalkback(source)
+	})
+
+	for _, sources := range streams.GetAllSources() {
+		for _, source := range sources {
+			unifi.RegisterTalkbackSecrets(source)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/internal/tapo"
 	"github.com/AlexxIT/go2rtc/internal/tuya"
+	"github.com/AlexxIT/go2rtc/internal/unifi"
 	"github.com/AlexxIT/go2rtc/internal/v4l2"
 	"github.com/AlexxIT/go2rtc/internal/webrtc"
 	"github.com/AlexxIT/go2rtc/internal/webtorrent"
@@ -105,6 +106,7 @@ func main() {
 		{"roborock", roborock.Init},
 		{"tapo", tapo.Init},
 		{"tuya", tuya.Init},
+		{"unifi", unifi.Init},
 		{"wyze", wyze.Init},
 		{"xiaomi", xiaomi.Init},
 		{"yandex", yandex.Init},

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -42,7 +42,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | Net (priv) | roborock     | webrtc          |         | h264, opus                      | opus                | `roborock:`   |
 | Net (priv) | tapo         | http            |         | h264, pcma                      | pcm_alaw            | `tapo:`       |
 | Net (priv) | tuya         | webrtc          |         |                                 |                     | `tuya:`       |
-| Net (priv) | unifi        | http, rtp       |         |                                 | opus                | `unifi-talkback:` |
+| Net (priv) | unifi        | http, rtp, udp  |         |                                 | aac, opus, vorbis   | `unifi-talkback:` |
 | Net (priv) | vigi         | http            |         |                                 |                     | `vigi:`       |
 | Net (priv) | webtorrent   | webrtc          | TODO    | TODO                            | TODO                | `webtorrent:` |
 | Net (priv) | xiaomi*      | cs2, tutk       |         |                                 |                     | `xiaomi:`     |

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -42,6 +42,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | Net (priv) | roborock     | webrtc          |         | h264, opus                      | opus                | `roborock:`   |
 | Net (priv) | tapo         | http            |         | h264, pcma                      | pcm_alaw            | `tapo:`       |
 | Net (priv) | tuya         | webrtc          |         |                                 |                     | `tuya:`       |
+| Net (priv) | unifi        | http, rtp       |         |                                 | opus                | `unifi-talkback:` |
 | Net (priv) | vigi         | http            |         |                                 |                     | `vigi:`       |
 | Net (priv) | webtorrent   | webrtc          | TODO    | TODO                            | TODO                | `webtorrent:` |
 | Net (priv) | xiaomi*      | cs2, tutk       |         |                                 |                     | `xiaomi:`     |

--- a/pkg/creds/secrets.go
+++ b/pkg/creds/secrets.go
@@ -35,8 +35,13 @@ func getReplacer() *strings.Replacer {
 	defer secretsMu.Unlock()
 
 	if secretsReplacer == nil {
-		oldnew := make([]string, 0, 2*len(secrets))
-		for _, s := range secrets {
+		values := slices.Clone(secrets)
+		slices.SortFunc(values, func(a, b string) int {
+			return len(b) - len(a)
+		})
+
+		oldnew := make([]string, 0, 2*len(values))
+		for _, s := range values {
 			oldnew = append(oldnew, s, "***")
 		}
 		secretsReplacer = strings.NewReplacer(oldnew...)
@@ -59,14 +64,24 @@ const (
 
 func SecretString(s string) string {
 	re := getReplacer()
-	s = userinfoRegexp.ReplaceAllString(s, `://***@`)
+	s = secretUserinfo(s)
 	return re.Replace(s)
 }
 
 func SecretWrite(w io.Writer, s string) (n int, err error) {
 	re := getReplacer()
-	s = userinfoRegexp.ReplaceAllString(s, `://***@`)
+	s = secretUserinfo(s)
 	return re.WriteString(w, s)
+}
+
+func secretUserinfo(s string) string {
+	return userinfoRegexp.ReplaceAllStringFunc(s, func(match string) string {
+		userinfo := match[3 : len(match)-1]
+		if strings.Contains(userinfo, ":") {
+			return `://***:***@`
+		}
+		return `://***@`
+	})
 }
 
 func SecretWriter(w io.Writer) io.Writer {

--- a/pkg/creds/secrets_test.go
+++ b/pkg/creds/secrets_test.go
@@ -13,3 +13,11 @@ func TestString(t *testing.T) {
 	s := SecretString("rtsp://admin:pa$$word@192.168.1.123/stream1")
 	require.Equal(t, "rtsp://***:***@192.168.1.123/stream1", s)
 }
+
+func TestStringOverlappingSecrets(t *testing.T) {
+	AddSecret("rtp://127.0.0.1:6500")
+	AddSecret("rtp://127.0.0.1:6500/talkback?token=secret")
+
+	s := SecretString(`{"url":"rtp://127.0.0.1:6500/talkback?token=secret"}`)
+	require.Equal(t, `{"url":"***"}`, s)
+}

--- a/pkg/unifi/ffmpeg.go
+++ b/pkg/unifi/ffmpeg.go
@@ -77,14 +77,19 @@ func (w *udpRTPWriter) Write(b []byte) (int, error) {
 }
 
 func startFFmpegRTP(inputCodec *core.Codec, session *TalkbackSession) (*talkbackOutput, error) {
+	command, err := buildFFmpegCommand(session.URL, session.Codec, session.SamplingRate)
+	if err != nil {
+		return nil, err
+	}
+
 	port, err := reserveRTPPort()
 	if err != nil {
 		return nil, err
 	}
 
-	command := buildFFmpegCommand(session.URL, session.SamplingRate)
 	log.Debug().
 		Int("local_port", port).
+		Str("codec", session.Codec).
 		Int("sampling_rate", session.SamplingRate).
 		Str("url", creds.SecretString(session.URL)).
 		Msg("[unifi] start ffmpeg")
@@ -138,7 +143,12 @@ func logFFmpegStderr(stderr io.Reader) {
 	}
 }
 
-func buildFFmpegCommand(outputURL string, samplingRate int) string {
+func buildFFmpegCommand(outputURL, codec string, samplingRate int) (string, error) {
+	audioCodec, err := ffmpegAudioCodec(codec)
+	if err != nil {
+		return "", err
+	}
+
 	args := []string{
 		"ffmpeg",
 		"-hide_banner",
@@ -150,7 +160,7 @@ func buildFFmpegCommand(outputURL string, samplingRate int) string {
 		"-i", "pipe:0",
 		"-map", "0:a:0",
 		"-vn",
-		"-c:a", "libopus",
+		"-c:a", audioCodec,
 		"-application:a", "lowdelay",
 		"-ar:a", strconv.Itoa(samplingRate),
 		"-ac:a", "1",
@@ -159,7 +169,16 @@ func buildFFmpegCommand(outputURL string, samplingRate int) string {
 		outputURL,
 	}
 
-	return strings.Join(args, " ")
+	return strings.Join(args, " "), nil
+}
+
+func ffmpegAudioCodec(codec string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(codec)) {
+	case "opus":
+		return "libopus", nil
+	default:
+		return "", fmt.Errorf("unifi: unsupported talkback codec: %s", codec)
+	}
 }
 
 func buildInputSDP(codec *core.Codec, port int) string {

--- a/pkg/unifi/ffmpeg.go
+++ b/pkg/unifi/ffmpeg.go
@@ -1,0 +1,228 @@
+package unifi
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
+	"github.com/AlexxIT/go2rtc/pkg/shell"
+)
+
+type ffmpegCommand interface {
+	StdinPipe() (io.WriteCloser, error)
+	Start() error
+	Wait() error
+	Close() error
+}
+
+type ffmpegStderr interface {
+	StderrPipe() (io.ReadCloser, error)
+}
+
+type rtpWriter interface {
+	io.WriteCloser
+	SetWriteDeadline(time.Time) error
+}
+
+type talkbackOutput struct {
+	cmd      ffmpegCommand
+	rtp      rtpWriter
+	closeErr error
+	close    sync.Once
+}
+
+var newFFmpegCommand = func(command string) ffmpegCommand {
+	return shell.NewCommand(command)
+}
+
+var reserveRTPPort = func() (int, error) {
+	conn, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+
+	addr := conn.LocalAddr().(*net.UDPAddr)
+	return addr.Port, nil
+}
+
+var dialRTPPort = func(port int) (rtpWriter, error) {
+	addr, err := net.ResolveUDPAddr("udp4", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.ListenUDP("udp4", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &udpRTPWriter{UDPConn: conn, addr: addr}, nil
+}
+
+type udpRTPWriter struct {
+	*net.UDPConn
+	addr *net.UDPAddr
+}
+
+func (w *udpRTPWriter) Write(b []byte) (int, error) {
+	return w.WriteTo(b, w.addr)
+}
+
+func startFFmpegRTP(inputCodec *core.Codec, session *TalkbackSession) (*talkbackOutput, error) {
+	port, err := reserveRTPPort()
+	if err != nil {
+		return nil, err
+	}
+
+	command := buildFFmpegCommand(session.URL, session.SamplingRate)
+	log.Debug().
+		Int("local_port", port).
+		Int("sampling_rate", session.SamplingRate).
+		Str("url", creds.SecretString(session.URL)).
+		Msg("[unifi] start ffmpeg")
+	log.Trace().
+		Str("cmd", creds.SecretString(command)).
+		Msg("[unifi] ffmpeg command")
+
+	cmd := newFFmpegCommand(command)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	var stderr io.ReadCloser
+	if cmd, ok := cmd.(ffmpegStderr); ok {
+		stderr, _ = cmd.StderrPipe()
+	}
+
+	if err = cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+
+	if stderr != nil {
+		go logFFmpegStderr(stderr)
+	}
+
+	if _, err = io.WriteString(stdin, buildInputSDP(inputCodec, port)); err != nil {
+		_ = stdin.Close()
+		_ = cmd.Close()
+		return nil, err
+	}
+	_ = stdin.Close()
+
+	rtp, err := dialRTPPort(port)
+	if err != nil {
+		_ = cmd.Close()
+		return nil, err
+	}
+
+	return &talkbackOutput{cmd: cmd, rtp: rtp}, nil
+}
+
+func logFFmpegStderr(stderr io.Reader) {
+	scanner := bufio.NewScanner(stderr)
+	for scanner.Scan() {
+		log.Debug().
+			Str("line", creds.SecretString(scanner.Text())).
+			Msg("[unifi] ffmpeg")
+	}
+}
+
+func buildFFmpegCommand(outputURL string, samplingRate int) string {
+	args := []string{
+		"ffmpeg",
+		"-hide_banner",
+		"-loglevel", "error",
+		"-protocol_whitelist", "file,pipe,udp,rtp",
+		"-fflags", "nobuffer",
+		"-flags", "low_delay",
+		"-f", "sdp",
+		"-i", "pipe:0",
+		"-map", "0:a:0",
+		"-vn",
+		"-c:a", "libopus",
+		"-application:a", "lowdelay",
+		"-ar:a", strconv.Itoa(samplingRate),
+		"-ac:a", "1",
+		"-flush_packets", "1",
+		"-f", "rtp",
+		outputURL,
+	}
+
+	return strings.Join(args, " ")
+}
+
+func buildInputSDP(codec *core.Codec, port int) string {
+	payloadType, rtpmap := inputRTPMap(codec)
+
+	return fmt.Sprintf(
+		"v=0\r\n"+
+			"o=- 0 0 IN IP4 127.0.0.1\r\n"+
+			"s=go2rtc-unifi-talkback\r\n"+
+			"c=IN IP4 127.0.0.1\r\n"+
+			"t=0 0\r\n"+
+			"m=audio %d RTP/AVP %d\r\n"+
+			"a=rtpmap:%d %s\r\n"+
+			"a=recvonly\r\n",
+		port, payloadType, payloadType, rtpmap,
+	)
+}
+
+func inputRTPMap(codec *core.Codec) (uint8, string) {
+	switch codec.Name {
+	case core.CodecPCMU:
+		return 0, "PCMU/8000"
+	case core.CodecPCMA:
+		return 8, "PCMA/8000"
+	case core.CodecOpus:
+		return 111, "opus/48000/2"
+	}
+
+	payloadType := codec.PayloadType
+	if payloadType == 0 {
+		payloadType = 111
+	}
+
+	clockRate := codec.ClockRate
+	if clockRate == 0 {
+		clockRate = 48000
+	}
+
+	codecName := strings.ToLower(codec.Name)
+	if codecName == "" {
+		codecName = "opus"
+	}
+
+	rtpmap := fmt.Sprintf("%s/%d", codecName, clockRate)
+	if codec.Channels > 1 {
+		rtpmap += fmt.Sprintf("/%d", codec.Channels)
+	}
+
+	return payloadType, rtpmap
+}
+
+func (o *talkbackOutput) Close() error {
+	o.close.Do(func() {
+		log.Debug().Msg("[unifi] stop ffmpeg")
+
+		if o.rtp != nil {
+			o.closeErr = o.rtp.Close()
+		}
+		if o.cmd != nil {
+			if closeErr := o.cmd.Close(); o.closeErr == nil {
+				o.closeErr = closeErr
+			}
+		}
+	})
+	return o.closeErr
+}

--- a/pkg/unifi/ffmpeg.go
+++ b/pkg/unifi/ffmpeg.go
@@ -144,7 +144,7 @@ func logFFmpegStderr(stderr io.Reader) {
 }
 
 func buildFFmpegCommand(outputURL, codec string, samplingRate int) (string, error) {
-	audioCodec, err := ffmpegAudioCodec(codec)
+	audioConfig, err := ffmpegAudioCodec(codec)
 	if err != nil {
 		return "", err
 	}
@@ -160,24 +160,40 @@ func buildFFmpegCommand(outputURL, codec string, samplingRate int) (string, erro
 		"-i", "pipe:0",
 		"-map", "0:a:0",
 		"-vn",
-		"-c:a", audioCodec,
-		"-application:a", "lowdelay",
+		"-c:a", audioConfig.encoder,
+	}
+	args = append(args, audioConfig.options...)
+	args = append(args,
 		"-ar:a", strconv.Itoa(samplingRate),
 		"-ac:a", "1",
 		"-flush_packets", "1",
-		"-f", "rtp",
+		"-f", audioConfig.format,
 		outputURL,
-	}
+	)
 
 	return strings.Join(args, " "), nil
 }
 
-func ffmpegAudioCodec(codec string) (string, error) {
+type ffmpegAudioConfig struct {
+	encoder string
+	format  string
+	options []string
+}
+
+func ffmpegAudioCodec(codec string) (*ffmpegAudioConfig, error) {
 	switch strings.ToLower(strings.TrimSpace(codec)) {
+	case "aac":
+		return &ffmpegAudioConfig{encoder: "aac", format: "adts"}, nil
 	case "opus":
-		return "libopus", nil
+		return &ffmpegAudioConfig{
+			encoder: "libopus",
+			format:  "rtp",
+			options: []string{"-application:a", "lowdelay"},
+		}, nil
+	case "vorbis":
+		return &ffmpegAudioConfig{encoder: "libvorbis", format: "ogg"}, nil
 	default:
-		return "", fmt.Errorf("unifi: unsupported talkback codec: %s", codec)
+		return nil, fmt.Errorf("unifi: unsupported talkback codec: %s", codec)
 	}
 }
 

--- a/pkg/unifi/log.go
+++ b/pkg/unifi/log.go
@@ -1,0 +1,9 @@
+package unifi
+
+import "github.com/rs/zerolog"
+
+var log = zerolog.Nop()
+
+func SetLogger(logger zerolog.Logger) {
+	log = logger
+}

--- a/pkg/unifi/talkback.go
+++ b/pkg/unifi/talkback.go
@@ -300,9 +300,6 @@ func (c *Client) openTalkback(inputCodec *core.Codec) (*talkbackOutput, error) {
 		Str("url", creds.SecretString(session.URL)).
 		Msg("[unifi] talkback session")
 
-	if !strings.EqualFold(session.Codec, "opus") {
-		return nil, fmt.Errorf("unifi: unsupported talkback codec: %s", session.Codec)
-	}
 	if session.SamplingRate == 0 {
 		return nil, errors.New("unifi: talkback samplingRate required")
 	}

--- a/pkg/unifi/talkback.go
+++ b/pkg/unifi/talkback.go
@@ -1,0 +1,455 @@
+package unifi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
+	"github.com/AlexxIT/go2rtc/pkg/tcp"
+	"github.com/pion/rtp"
+)
+
+const SchemeTalkback = "unifi-talkback"
+
+var errStopped = errors.New("unifi: stopped")
+
+type Client struct {
+	core.Connection
+
+	baseURL  *url.URL
+	cameraID string
+	apiKey   string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	do     func(*http.Request) (*http.Response, error)
+
+	mu          sync.Mutex
+	stopped     bool
+	active      *talkbackOutput
+	activeOnce  sync.Once
+	activeReady chan struct{}
+
+	done     chan struct{}
+	doneOnce sync.Once
+	err      error
+}
+
+type publicCamera struct {
+	FeatureFlags struct {
+		HasSpeaker bool `json:"hasSpeaker"`
+	} `json:"featureFlags"`
+}
+
+type TalkbackSession struct {
+	URL           string `json:"url"`
+	Codec         string `json:"codec"`
+	SamplingRate  int    `json:"samplingRate"`
+	BitsPerSample int    `json:"bitsPerSample,omitempty"`
+}
+
+func DialTalkback(rawURL string) (*Client, error) {
+	innerURL := strings.TrimPrefix(rawURL, SchemeTalkback+":")
+	if innerURL == rawURL {
+		return nil, fmt.Errorf("unifi: unsupported scheme: %s", rawURL)
+	}
+
+	u, err := url.Parse(innerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	query := u.Query()
+	cameraID := query.Get("camera_id")
+	apiKey := query.Get("api_key")
+	if cameraID == "" {
+		return nil, errors.New("unifi: camera_id required")
+	}
+	if apiKey == "" {
+		return nil, errors.New("unifi: api_key required")
+	}
+
+	RegisterTalkbackSecrets(rawURL)
+	log.Debug().
+		Str("url", creds.SecretString(rawURL)).
+		Str("camera_id", cameraID).
+		Msg("[unifi] dial talkback")
+
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		Connection: core.Connection{
+			ID:         core.NewID(),
+			FormatName: "rtp",
+			Protocol:   "http+rtp",
+			URL:        creds.SecretString(rawURL),
+		},
+		baseURL:     u,
+		cameraID:    cameraID,
+		apiKey:      apiKey,
+		ctx:         ctx,
+		cancel:      cancel,
+		do:          tcp.Do,
+		activeReady: make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+
+	camera, err := c.getCamera()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	log.Debug().
+		Str("camera_id", cameraID).
+		Bool("has_speaker", camera.FeatureFlags.HasSpeaker).
+		Msg("[unifi] camera metadata")
+
+	if camera.FeatureFlags.HasSpeaker {
+		c.Medias = []*core.Media{
+			{
+				Kind:      core.KindAudio,
+				Direction: core.DirectionSendonly,
+				Codecs: []*core.Codec{
+					{
+						Name:        core.CodecOpus,
+						ClockRate:   48000,
+						Channels:    2,
+						PayloadType: 111,
+					},
+					{
+						Name:        core.CodecPCMU,
+						ClockRate:   8000,
+						PayloadType: 0,
+					},
+					{
+						Name:        core.CodecPCMA,
+						ClockRate:   8000,
+						PayloadType: 8,
+					},
+				},
+			},
+		}
+	}
+
+	return c, nil
+}
+
+func RegisterTalkbackSecrets(rawURL string) {
+	innerURL := strings.TrimPrefix(rawURL, SchemeTalkback+":")
+	if innerURL == rawURL {
+		return
+	}
+
+	u, err := url.Parse(innerURL)
+	if err != nil {
+		return
+	}
+
+	creds.AddSecret(u.Query().Get("api_key"))
+}
+
+func (c *Client) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver, error) {
+	return nil, core.ErrCantGetTrack
+}
+
+func (c *Client) AddTrack(media *core.Media, _ *core.Codec, track *core.Receiver) error {
+	log.Debug().
+		Str("camera_id", c.cameraID).
+		Str("codec", track.Codec.String()).
+		Msg("[unifi] add microphone track")
+
+	sender := core.NewSender(media, track.Codec)
+	sender.Handler = func(packet *rtp.Packet) {
+		output, err := c.ensureActive(track.Codec)
+		if err != nil {
+			return
+		}
+
+		b, err := packet.Marshal()
+		if err != nil {
+			c.finish(err)
+			return
+		}
+
+		_ = output.rtp.SetWriteDeadline(time.Now().Add(core.ConnDeadline))
+		if n, err := output.rtp.Write(b); err == nil {
+			c.Send += n
+		} else {
+			log.Debug().Err(err).Msg("[unifi] write microphone RTP")
+			c.finish(err)
+		}
+	}
+	sender.HandleRTP(track)
+	c.Senders = append(c.Senders, sender)
+
+	return nil
+}
+
+func (c *Client) Start() error {
+	<-c.done
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.err
+}
+
+func (c *Client) Stop() error {
+	log.Debug().Str("camera_id", c.cameraID).Msg("[unifi] stop talkback")
+
+	c.cancel()
+
+	err := c.Connection.Stop()
+
+	c.mu.Lock()
+	c.stopped = true
+	output := c.active
+	c.active = nil
+	c.mu.Unlock()
+
+	if output != nil {
+		if closeErr := output.Close(); err == nil {
+			err = closeErr
+		}
+	}
+
+	c.finish(nil)
+	return err
+}
+
+func (c *Client) ensureActive(inputCodec *core.Codec) (*talkbackOutput, error) {
+	c.activeOnce.Do(func() {
+		c.mu.Lock()
+		stopped := c.stopped
+		c.mu.Unlock()
+
+		var output *talkbackOutput
+		var err error
+		if stopped {
+			err = errStopped
+		} else {
+			log.Debug().
+				Str("camera_id", c.cameraID).
+				Str("codec", inputCodec.String()).
+				Msg("[unifi] open talkback session")
+			output, err = c.openTalkback(inputCodec)
+		}
+
+		c.mu.Lock()
+		stopped = c.stopped
+		if err == nil && stopped {
+			err = errStopped
+		}
+		if err == nil {
+			c.active = output
+		}
+		c.mu.Unlock()
+
+		if err != nil {
+			if output != nil {
+				_ = output.Close()
+			}
+			if !stopped && !errors.Is(err, errStopped) {
+				log.Warn().Err(err).Msg("[unifi] open talkback session")
+				c.finish(err)
+			}
+		}
+
+		close(c.activeReady)
+	})
+
+	<-c.activeReady
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return nil, c.err
+	}
+	if c.stopped || c.active == nil {
+		return nil, errStopped
+	}
+
+	return c.active, nil
+}
+
+func (c *Client) openTalkback(inputCodec *core.Codec) (*talkbackOutput, error) {
+	session, err := c.createTalkbackSession()
+	if err != nil {
+		return nil, err
+	}
+
+	registerSecretURL(session.URL)
+
+	log.Debug().
+		Str("camera_id", c.cameraID).
+		Str("codec", session.Codec).
+		Int("sampling_rate", session.SamplingRate).
+		Int("bits_per_sample", session.BitsPerSample).
+		Str("url", creds.SecretString(session.URL)).
+		Msg("[unifi] talkback session")
+
+	if !strings.EqualFold(session.Codec, "opus") {
+		return nil, fmt.Errorf("unifi: unsupported talkback codec: %s", session.Codec)
+	}
+	if session.SamplingRate == 0 {
+		return nil, errors.New("unifi: talkback samplingRate required")
+	}
+
+	output, err := startFFmpegRTP(inputCodec, session)
+	if err != nil {
+		return nil, err
+	}
+
+	go c.waitOutput(output)
+
+	return output, nil
+}
+
+func (c *Client) waitOutput(output *talkbackOutput) {
+	err := output.cmd.Wait()
+	log.Debug().Err(err).Str("camera_id", c.cameraID).Msg("[unifi] ffmpeg stopped")
+
+	c.mu.Lock()
+	stopped := c.stopped
+	if c.active == output {
+		c.active = nil
+	}
+	c.mu.Unlock()
+
+	_ = output.Close()
+
+	if !stopped {
+		c.finish(err)
+	}
+}
+
+func (c *Client) getCamera() (*publicCamera, error) {
+	var camera publicCamera
+	if err := c.requestJSON(http.MethodGet, c.cameraPath(), nil, &camera); err != nil {
+		return nil, err
+	}
+	return &camera, nil
+}
+
+func (c *Client) createTalkbackSession() (*TalkbackSession, error) {
+	var session TalkbackSession
+	if err := c.requestJSON(http.MethodPost, c.cameraPath()+"/talkback-session", nil, &session); err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+func (c *Client) requestJSON(method, path string, body io.Reader, out any) error {
+	u := *c.baseURL
+	u.Path = path
+	u.RawQuery = ""
+
+	ts := time.Now()
+	log.Debug().
+		Str("method", method).
+		Str("path", path).
+		Msg("[unifi] protect api request")
+
+	req, err := http.NewRequestWithContext(c.ctx, method, u.String(), body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-API-KEY", c.apiKey)
+
+	res, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer tcp.Close(res)
+
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Str("method", method).
+			Str("path", path).
+			Int("status", res.StatusCode).
+			Stringer("duration", time.Since(ts)).
+			Msg("[unifi] protect api response")
+		return err
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		logProtectResponse(method, path, res.StatusCode, time.Since(ts), b)
+		return fmt.Errorf("unifi: %s %s: %s", method, path, res.Status)
+	}
+
+	if err = json.Unmarshal(b, out); err != nil {
+		logProtectResponse(method, path, res.StatusCode, time.Since(ts), b)
+		return err
+	}
+
+	if session, ok := out.(*TalkbackSession); ok {
+		registerSecretURL(session.URL)
+	}
+
+	logProtectResponse(method, path, res.StatusCode, time.Since(ts), b)
+	return nil
+}
+
+func (c *Client) cameraPath() string {
+	return "/proxy/protect/integration/v1/cameras/" + url.PathEscape(c.cameraID)
+}
+
+func logProtectResponse(method, path string, status int, duration time.Duration, body []byte) {
+	log.Debug().
+		Str("method", method).
+		Str("path", path).
+		Int("status", status).
+		Stringer("duration", duration).
+		Msg("[unifi] protect api response")
+
+	if log.Trace().Enabled() {
+		log.Trace().
+			Str("method", method).
+			Str("path", path).
+			Str("body", creds.SecretString(string(body))).
+			Msg("[unifi] protect api response body")
+	}
+}
+
+func registerSecretURL(value string) {
+	if value == "" {
+		return
+	}
+
+	creds.AddSecret(value)
+
+	jsonEscaped := strings.ReplaceAll(value, `/`, `\/`)
+	creds.AddSecret(jsonEscaped)
+
+	htmlEscaped := strings.ReplaceAll(value, `&`, `\u0026`)
+	creds.AddSecret(htmlEscaped)
+	creds.AddSecret(strings.ReplaceAll(htmlEscaped, `/`, `\/`))
+}
+
+func (c *Client) finish(err error) {
+	if err != nil {
+		c.mu.Lock()
+		if c.err == nil {
+			c.err = err
+		}
+		c.mu.Unlock()
+	}
+
+	c.doneOnce.Do(func() {
+		close(c.done)
+	})
+}

--- a/pkg/unifi/talkback_test.go
+++ b/pkg/unifi/talkback_test.go
@@ -225,7 +225,8 @@ func TestTalkbackRejectsUnsupportedCodec(t *testing.T) {
 }
 
 func TestBuildFFmpegCommandOpus(t *testing.T) {
-	command := buildFFmpegCommand("rtp://10.0.0.2:4444", 24000)
+	command, err := buildFFmpegCommand("rtp://10.0.0.2:4444", "opus", 24000)
+	require.NoError(t, err)
 
 	require.Contains(t, command, "ffmpeg -hide_banner -loglevel error")
 	require.Contains(t, command, "-protocol_whitelist file,pipe,udp,rtp")
@@ -234,6 +235,13 @@ func TestBuildFFmpegCommandOpus(t *testing.T) {
 	require.Contains(t, command, "-ar:a 24000")
 	require.Contains(t, command, "-ac:a 1")
 	require.Contains(t, command, "-f rtp rtp://10.0.0.2:4444")
+}
+
+func TestBuildFFmpegCommandUnsupportedCodec(t *testing.T) {
+	command, err := buildFFmpegCommand("rtp://10.0.0.2:4444", "aac", 24000)
+
+	require.EqualError(t, err, "unifi: unsupported talkback codec: aac")
+	require.Empty(t, command)
 }
 
 func TestBuildInputSDPG711(t *testing.T) {

--- a/pkg/unifi/talkback_test.go
+++ b/pkg/unifi/talkback_test.go
@@ -1,0 +1,397 @@
+package unifi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialTalkbackURLAndSecret(t *testing.T) {
+	apiKey := "unifi-talkback-secret-key"
+	server, _ := newProtectServer(t, true, TalkbackSession{})
+	defer server.Close()
+
+	rawURL := SchemeTalkback + ":" + server.URL + "?camera_id=camera1&api_key=" + apiKey
+	client, err := DialTalkback(rawURL)
+	require.NoError(t, err)
+	defer client.Stop()
+
+	require.Equal(t, strings.ReplaceAll(rawURL, apiKey, "***"), creds.SecretString(rawURL))
+
+	b, err := json.Marshal(client)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), apiKey)
+	require.Contains(t, string(b), "api_key=***")
+}
+
+func TestRegisterTalkbackSecrets(t *testing.T) {
+	apiKey := "unifi-register-secret-key"
+	rawURL := SchemeTalkback + ":https://192.168.1.1?camera_id=camera1&api_key=" + apiKey
+
+	RegisterTalkbackSecrets(rawURL)
+
+	require.NotContains(t, creds.SecretString(rawURL), apiKey)
+	require.Contains(t, creds.SecretString(rawURL), "api_key=***")
+}
+
+func TestDialTalkbackAdvertisesMediaWithSpeaker(t *testing.T) {
+	server, _ := newProtectServer(t, true, TalkbackSession{})
+	defer server.Close()
+
+	client, err := DialTalkback(SchemeTalkback + ":" + server.URL + "?camera_id=camera1&api_key=key-with-speaker")
+	require.NoError(t, err)
+	defer client.Stop()
+
+	require.Len(t, client.Medias, 1)
+	require.Equal(t, core.KindAudio, client.Medias[0].Kind)
+	require.Equal(t, core.DirectionSendonly, client.Medias[0].Direction)
+	require.Equal(t, []*core.Codec{
+		{
+			Name:        core.CodecOpus,
+			ClockRate:   48000,
+			Channels:    2,
+			PayloadType: 111,
+		},
+		{
+			Name:        core.CodecPCMU,
+			ClockRate:   8000,
+			PayloadType: 0,
+		},
+		{
+			Name:        core.CodecPCMA,
+			ClockRate:   8000,
+			PayloadType: 8,
+		},
+	}, client.Medias[0].Codecs)
+}
+
+func TestDialTalkbackDoesNotAdvertiseMediaWithoutSpeaker(t *testing.T) {
+	server, _ := newProtectServer(t, false, TalkbackSession{})
+	defer server.Close()
+
+	client, err := DialTalkback(SchemeTalkback + ":" + server.URL + "?camera_id=camera1&api_key=key-no-speaker")
+	require.NoError(t, err)
+	defer client.Stop()
+
+	require.Empty(t, client.Medias)
+}
+
+func TestTalkbackNoSessionDuringPassiveProbe(t *testing.T) {
+	server, posts := newProtectServer(t, true, TalkbackSession{
+		URL:          "rtp://127.0.0.1:6000",
+		Codec:        "opus",
+		SamplingRate: 24000,
+	})
+	defer server.Close()
+
+	client, err := DialTalkback(SchemeTalkback + ":" + server.URL + "?camera_id=camera1&api_key=key-passive")
+	require.NoError(t, err)
+
+	media := client.Medias[0]
+	track := core.NewReceiver(&core.Media{
+		Kind:      core.KindAudio,
+		Direction: core.DirectionRecvonly,
+	}, media.Codecs[0])
+	require.NoError(t, client.AddTrack(media, media.Codecs[0], track))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Start()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	require.Zero(t, posts.Load())
+
+	require.NoError(t, client.Stop())
+	require.NoError(t, <-done)
+	require.Zero(t, posts.Load())
+}
+
+func TestTalkbackStartsOnFirstRTPAndStopsResources(t *testing.T) {
+	restore, ffmpeg := fakeFFmpeg(t)
+	defer restore()
+
+	server, posts := newProtectServer(t, true, TalkbackSession{
+		URL:          "rtp://127.0.0.1:6500",
+		Codec:        "opus",
+		SamplingRate: 24000,
+	})
+	defer server.Close()
+
+	client, err := DialTalkback(SchemeTalkback + ":" + server.URL + "?camera_id=camera1&api_key=key-active")
+	require.NoError(t, err)
+
+	media := client.Medias[0]
+	track := core.NewReceiver(&core.Media{
+		Kind:      core.KindAudio,
+		Direction: core.DirectionRecvonly,
+	}, media.Codecs[0])
+	require.NoError(t, client.AddTrack(media, media.Codecs[0], track))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Start()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	require.Zero(t, posts.Load())
+	require.Empty(t, ffmpeg.Commands())
+
+	track.WriteRTP(&rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			PayloadType:    111,
+			SequenceNumber: 1,
+			Timestamp:      960,
+		},
+		Payload: []byte{0x01, 0x02, 0x03},
+	})
+
+	require.Eventually(t, func() bool {
+		return posts.Load() == 1 && len(ffmpeg.Commands()) == 1 && ffmpeg.writer.writeCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cmd := ffmpeg.Commands()[0]
+	require.Contains(t, cmd.command, "-c:a libopus")
+	require.Contains(t, cmd.command, "-ar:a 24000")
+	require.Contains(t, cmd.command, "-ac:a 1")
+	require.Contains(t, cmd.command, "-f rtp rtp://127.0.0.1:6500")
+	require.Contains(t, cmd.stdin.String(), "m=audio 45000 RTP/AVP 111")
+	require.Contains(t, cmd.stdin.String(), "a=rtpmap:111 opus/48000/2")
+
+	require.NoError(t, client.Stop())
+	require.NoError(t, <-done)
+
+	require.True(t, cmd.closed.Load())
+	require.True(t, ffmpeg.writer.closed.Load())
+}
+
+func TestTalkbackRejectsUnsupportedCodec(t *testing.T) {
+	restore, ffmpeg := fakeFFmpeg(t)
+	defer restore()
+
+	server, _ := newProtectServer(t, true, TalkbackSession{
+		URL:          "rtp://127.0.0.1:6500",
+		Codec:        "aac",
+		SamplingRate: 16000,
+	})
+	defer server.Close()
+
+	client, err := DialTalkback(SchemeTalkback + ":" + server.URL + "?camera_id=camera1&api_key=key-unsupported")
+	require.NoError(t, err)
+	defer client.Stop()
+
+	media := client.Medias[0]
+	track := core.NewReceiver(&core.Media{
+		Kind:      core.KindAudio,
+		Direction: core.DirectionRecvonly,
+	}, media.Codecs[0])
+	require.NoError(t, client.AddTrack(media, media.Codecs[0], track))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Start()
+	}()
+
+	track.WriteRTP(&rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			PayloadType:    111,
+			SequenceNumber: 1,
+			Timestamp:      960,
+		},
+		Payload: []byte{0x01, 0x02, 0x03},
+	})
+
+	require.Eventually(t, func() bool {
+		return len(done) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	err = <-done
+	require.EqualError(t, err, "unifi: unsupported talkback codec: aac")
+	require.Empty(t, ffmpeg.Commands())
+}
+
+func TestBuildFFmpegCommandOpus(t *testing.T) {
+	command := buildFFmpegCommand("rtp://10.0.0.2:4444", 24000)
+
+	require.Contains(t, command, "ffmpeg -hide_banner -loglevel error")
+	require.Contains(t, command, "-protocol_whitelist file,pipe,udp,rtp")
+	require.Contains(t, command, "-c:a libopus")
+	require.Contains(t, command, "-application:a lowdelay")
+	require.Contains(t, command, "-ar:a 24000")
+	require.Contains(t, command, "-ac:a 1")
+	require.Contains(t, command, "-f rtp rtp://10.0.0.2:4444")
+}
+
+func TestBuildInputSDPG711(t *testing.T) {
+	pcmu := buildInputSDP(&core.Codec{Name: core.CodecPCMU, ClockRate: 8000}, 45000)
+	require.Contains(t, pcmu, "m=audio 45000 RTP/AVP 0")
+	require.Contains(t, pcmu, "a=rtpmap:0 PCMU/8000")
+
+	pcma := buildInputSDP(&core.Codec{Name: core.CodecPCMA, ClockRate: 8000, PayloadType: 8}, 45002)
+	require.Contains(t, pcma, "m=audio 45002 RTP/AVP 8")
+	require.Contains(t, pcma, "a=rtpmap:8 PCMA/8000")
+}
+
+func TestProtectResponseLogRedactsSessionURL(t *testing.T) {
+	registerSecretURL("rtp://127.0.0.1:6500")
+	sessionURL := "rtp://127.0.0.1:6500/talkback?token=unifi-session-token&other=1"
+	registerSecretURL(sessionURL)
+
+	body := strings.ReplaceAll(`{"url":"`+sessionURL+`"}`, "/", `\/`)
+	body = strings.ReplaceAll(body, "&", `\u0026`)
+	redacted := creds.SecretString(body)
+
+	require.NotContains(t, redacted, sessionURL)
+	require.NotContains(t, redacted, "unifi-session-token")
+	require.Contains(t, redacted, "***")
+}
+
+func newProtectServer(t *testing.T, hasSpeaker bool, session TalkbackSession) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	var posts atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NotEmpty(t, r.Header.Get("X-API-KEY"))
+		require.Empty(t, r.URL.RawQuery)
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/proxy/protect/integration/v1/cameras/camera1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"featureFlags": map[string]any{
+					"hasSpeaker": hasSpeaker,
+				},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/proxy/protect/integration/v1/cameras/camera1/talkback-session":
+			posts.Add(1)
+			_ = json.NewEncoder(w).Encode(session)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	return server, &posts
+}
+
+func fakeFFmpeg(t *testing.T) (func(), *fakeFFmpegState) {
+	t.Helper()
+
+	oldCommand := newFFmpegCommand
+	oldReserve := reserveRTPPort
+	oldDial := dialRTPPort
+
+	state := &fakeFFmpegState{
+		writer: &fakeRTPWriter{},
+	}
+
+	newFFmpegCommand = func(command string) ffmpegCommand {
+		cmd := &fakeCommand{
+			command: command,
+			done:    make(chan struct{}),
+		}
+		state.mu.Lock()
+		state.commands = append(state.commands, cmd)
+		state.mu.Unlock()
+		return cmd
+	}
+	reserveRTPPort = func() (int, error) {
+		return 45000, nil
+	}
+	dialRTPPort = func(port int) (rtpWriter, error) {
+		require.Equal(t, 45000, port)
+		return state.writer, nil
+	}
+
+	return func() {
+		newFFmpegCommand = oldCommand
+		reserveRTPPort = oldReserve
+		dialRTPPort = oldDial
+	}, state
+}
+
+type fakeFFmpegState struct {
+	mu       sync.Mutex
+	commands []*fakeCommand
+	writer   *fakeRTPWriter
+}
+
+func (s *fakeFFmpegState) Commands() []*fakeCommand {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	commands := make([]*fakeCommand, len(s.commands))
+	copy(commands, s.commands)
+	return commands
+}
+
+type fakeCommand struct {
+	command string
+	stdin   bytes.Buffer
+	done    chan struct{}
+	once    sync.Once
+	started atomic.Bool
+	closed  atomic.Bool
+}
+
+func (c *fakeCommand) StdinPipe() (io.WriteCloser, error) {
+	return nopWriteCloser{&c.stdin}, nil
+}
+
+func (c *fakeCommand) Start() error {
+	c.started.Store(true)
+	return nil
+}
+
+func (c *fakeCommand) Wait() error {
+	<-c.done
+	return nil
+}
+
+func (c *fakeCommand) Close() error {
+	c.closed.Store(true)
+	c.once.Do(func() {
+		close(c.done)
+	})
+	return nil
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (n nopWriteCloser) Close() error {
+	return nil
+}
+
+type fakeRTPWriter struct {
+	closed     atomic.Bool
+	writeCount atomic.Int64
+	buf        bytes.Buffer
+}
+
+func (w *fakeRTPWriter) Write(b []byte) (int, error) {
+	w.writeCount.Add(1)
+	return w.buf.Write(b)
+}
+
+func (w *fakeRTPWriter) Close() error {
+	w.closed.Store(true)
+	return nil
+}
+
+func (w *fakeRTPWriter) SetWriteDeadline(time.Time) error {
+	return nil
+}

--- a/pkg/unifi/talkback_test.go
+++ b/pkg/unifi/talkback_test.go
@@ -184,7 +184,7 @@ func TestTalkbackRejectsUnsupportedCodec(t *testing.T) {
 
 	server, _ := newProtectServer(t, true, TalkbackSession{
 		URL:          "rtp://127.0.0.1:6500",
-		Codec:        "aac",
+		Codec:        "flac",
 		SamplingRate: 16000,
 	})
 	defer server.Close()
@@ -220,7 +220,7 @@ func TestTalkbackRejectsUnsupportedCodec(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	err = <-done
-	require.EqualError(t, err, "unifi: unsupported talkback codec: aac")
+	require.EqualError(t, err, "unifi: unsupported talkback codec: flac")
 	require.Empty(t, ffmpeg.Commands())
 }
 
@@ -237,10 +237,32 @@ func TestBuildFFmpegCommandOpus(t *testing.T) {
 	require.Contains(t, command, "-f rtp rtp://10.0.0.2:4444")
 }
 
-func TestBuildFFmpegCommandUnsupportedCodec(t *testing.T) {
-	command, err := buildFFmpegCommand("rtp://10.0.0.2:4444", "aac", 24000)
+func TestBuildFFmpegCommandAAC(t *testing.T) {
+	command, err := buildFFmpegCommand("udp://10.0.0.2:4444", "aac", 16000)
+	require.NoError(t, err)
 
-	require.EqualError(t, err, "unifi: unsupported talkback codec: aac")
+	require.Contains(t, command, "-c:a aac")
+	require.NotContains(t, command, "-application:a lowdelay")
+	require.Contains(t, command, "-ar:a 16000")
+	require.Contains(t, command, "-ac:a 1")
+	require.Contains(t, command, "-f adts udp://10.0.0.2:4444")
+}
+
+func TestBuildFFmpegCommandVorbis(t *testing.T) {
+	command, err := buildFFmpegCommand("udp://10.0.0.2:4444", "vorbis", 16000)
+	require.NoError(t, err)
+
+	require.Contains(t, command, "-c:a libvorbis")
+	require.NotContains(t, command, "-application:a lowdelay")
+	require.Contains(t, command, "-ar:a 16000")
+	require.Contains(t, command, "-ac:a 1")
+	require.Contains(t, command, "-f ogg udp://10.0.0.2:4444")
+}
+
+func TestBuildFFmpegCommandUnsupportedCodec(t *testing.T) {
+	command, err := buildFFmpegCommand("rtp://10.0.0.2:4444", "flac", 24000)
+
+	require.EqualError(t, err, "unifi: unsupported talkback codec: flac")
 	require.Empty(t, command)
 }
 

--- a/website/.vitepress/config.js
+++ b/website/.vitepress/config.js
@@ -26,7 +26,7 @@ export default defineConfig({
         // second line of Telegram card (black bold), autodetect from site description
         ['meta', { property: 'og:title', content: 'go2rtc - Ultimate camera streaming application' }],
         // third line of Telegram card, autodetect from site description
-        ['meta', { property: 'og:description', content: 'Support alsa, doorbird, dvrip, eseecloud, ffmpeg, gopro, hass, hls, homekit, mjpeg, mp4, mpegts, nest, onvif, ring, roborock, rtmp, rtsp, tapo, vigi, tuya, v4l2, webrtc, wyze, xiaomi.' }],
+        ['meta', { property: 'og:description', content: 'Support alsa, doorbird, dvrip, eseecloud, ffmpeg, gopro, hass, hls, homekit, mjpeg, mp4, mpegts, nest, onvif, ring, roborock, rtmp, rtsp, tapo, vigi, tuya, unifi, v4l2, webrtc, wyze, xiaomi.' }],
         ['meta', { property: 'og:url', content: 'https://go2rtc.org/' }],
         ['meta', { property: 'og:image', content: 'https://go2rtc.org/images/logo.png' }],
         // important for Telegram - the image will be at the bottom and large
@@ -142,6 +142,7 @@ export default defineConfig({
                     {text: 'roborock', link: '/internal/roborock/'},
                     {text: 'tapo', link: '/internal/tapo/'},
                     {text: 'tuya', link: '/internal/tuya/'},
+                    {text: 'unifi', link: '/internal/unifi/'},
                     {text: 'v4l2', link: '/internal/v4l2/'},
                     {text: 'wyze', link: '/internal/wyze/'},
                     {text: 'xiaomi', link: '/internal/xiaomi/'},

--- a/www/schema.json
+++ b/www/schema.json
@@ -178,6 +178,7 @@
               "roborock",
               "tapo",
               "tuya",
+              "unifi",
               "xiaomi",
               "yandex",
               "debug",


### PR DESCRIPTION
This PR adds native UniFi Protect talkback support to go2rtc via a new `unifi-talkback:` source.

The important behavior is that talkback stays passive until a client actually sends microphone audio. Viewing a stream with normal video+audio does not open a UniFi Protect talkback session or activate the camera speaker. When microphone RTP starts flowing through go2rtc’s existing backchannel path, go2rtc creates a Protect talkback session, starts FFmpeg, transcodes the mic audio to the format Protect requested, and streams it to the returned session URL. Only opus codec with 22khz is known to be advertised for the talkback channel (tested with G4 Doorbell Pro and Doorbell Lite; if anyone has different UniFi doorbells, please let me know your experience).

To set it up you need API Key for your local unifi account, and camera IDs.

```sh
export PROTECT='https://192.168.1.1'
export API_KEY="<YOUR UNIFI API KEY>"
curl -sk \
  -H "X-API-KEY: $API_KEY" \
  "$PROTECT/proxy/protect/integration/v1/cameras" \
  > /tmp/unifi-cameras.json
jq -r '.[] | [.id, .name] | @tsv' /tmp/unifi-cameras.json
```

You need to copy the id from the first column to use given camera.

Here's my config I'm using for two-way audio for both my `G4 Doorbell Pro` and `Doorbell Lite`. 

```yaml
streams:
  gate_medium:
    - 'rtsps://192.168.1.1:7441/<rtsp url from unifi protect>?enableSrtp#backchannel=0'
    - 'unifi-talkback:https://192.168.1.1?camera_id=<gate_id>&api_key=<api_key>'
  gate_kiosk:
    - 'ffmpeg:rtsps://192.168.1.1:7441/<rtsp url from unifi protect>?enableSrtp#video=h264#audio=opus'
    - 'unifi-talkback:https://192.168.1.1?camera_id=<gate_id>&api_key=<api_key>'
  door_medium:
    - 'rtsps://192.168.1.1:7441/<rtsp url from unifi protect>?enableSrtp#backchannel=0'
    - 'unifi-talkback:https://192.168.1.1?camera_id=<door_id>&api_key=<api_key>'
  door_kiosk:
    - 'ffmpeg:rtsps://192.168.1.1:7441/<rtsp url from unifi protect>?enableSrtp#video=h264#audio=opus'
    - 'unifi-talkback:https://192.168.1.1?camera_id=<door_id>&api_key=<api_key>'
```

I'm using the passthrough `gate_medium` stream to get the lower-resolution source stream directly, without any re-encoding. In my setup, Protect uses HEVC, which isn't suitable for direct WebRTC playback on the kiosk device.

To solve this, I added a separate `door_kiosk` stream. It ingests the same upstream source but transcodes it into a format that's compatible with the Android tablet over WebRTC (H.264 video + Opus audio).

NOTE: You may not need "medium" stream if your "kiosk" device is powerful enough. I just found out that my Doorbell Lite has 2K resolution and Galaxy Tab A11+ needs several seconds to negotiate live view. I found a medium to be the fastest stream in my case.

Also, the assumption is that the UDMP can comfortably serve two clients from the lower-resolution stream. On the go2rtc VM, the only transcoding performed is:

Video: HEVC → H.264 for the kiosk stream.
Audio: Opus 48 kHz → Opus 22 kHz for talkback, matching what UniFi advertises.

On the home assistant side I'm using `WebRTC Camera` (aka go2rtc) addon with his card config:

```
type: custom:webrtc-camera
mode: webrtc,mse,hls,mjpeg
ui: true
streams:
  - url: rtsp://192.168.50.206:8554/door_kiosk
    name: Live
    mode: webrtc
    media: video
  - url: rtsp://192.168.50.206:8554/door_kiosk
    name: Talk
    mode: webrtc
    media: video,audio,microphone
```

Now, when I click on the card it will switch from Live to Talk and back to Live. In "Talk" mode my voice from mic of my android "kiosk" tablet is heard on the doorbell's speaker. So two-way audio works really well now. 

Disclaimer: this is my first contribution, and the code is AI-assisted, although it works well in my home setup.

I’d really appreciate any feedback, help, or guidance needed to make this mergeable. I know many people are looking forward to having two-way audio from Home Assistant on their UniFi doorbells, so I’m happy to adjust the implementation as needed.

Closes #1760 and #279 (and other unifi doorbell two-way audio related issues)