### PR TITLE
pkg/tcp: support SHA-256 / SHA-512-256 RTSP Digest auth (RFC 7616)

### DIFF
--- a/pkg/tcp/auth.go
+++ b/pkg/tcp/auth.go
@@ -2,6 +2,8 @@ package tcp
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -15,6 +17,13 @@ type Auth struct {
 	pass    string
 	header  string
 	h1nonce string
+	// hexFn is the hash used for this Digest session (MD5 by default; SHA-256 /
+	// SHA-512-256 per RFC 7616 when the server's challenge asks for them — e.g.
+	// Hikvision-OEM firmware that offers only algorithm="SHA-256" for RTSP).
+	hexFn func(...string) string
+	// algo is the algorithm token echoed back in the Authorization header.
+	// Empty for plain MD5 to preserve the original wire behaviour.
+	algo string
 }
 
 const (
@@ -50,7 +59,10 @@ func (a *Auth) Read(res *Response) bool {
 		realm := Between(auth, `realm="`, `"`)
 		nonce := Between(auth, `nonce="`, `"`)
 
-		a.h1nonce = HexMD5(a.user, realm, a.pass) + ":" + nonce
+		// Pick the hash from the challenge's algorithm token. Default MD5.
+		a.hexFn, a.algo = digestHash(Between(auth, `algorithm="`, `"`))
+
+		a.h1nonce = a.hexFn(a.user, realm, a.pass) + ":" + nonce
 		a.header = fmt.Sprintf(
 			`Digest username="%s", realm="%s", nonce="%s"`,
 			a.user, realm, nonce,
@@ -74,11 +86,20 @@ func (a *Auth) Write(req *Request) {
 		// important to use String except RequestURL for RtspServer:
 		// https://github.com/AlexxIT/go2rtc/issues/244
 		uri := req.URL.String()
-		h2 := HexMD5(req.Method, uri)
-		response := HexMD5(a.h1nonce, h2)
+		hexFn := a.hexFn
+		if hexFn == nil {
+			hexFn = HexMD5
+		}
+		h2 := hexFn(req.Method, uri)
+		response := hexFn(a.h1nonce, h2)
 		header := a.header + fmt.Sprintf(
 			`, uri="%s", response="%s"`, uri, response,
 		)
+		// Echo algorithm for non-MD5 digests (some firmware validates it);
+		// omitted for MD5 to keep the original wire format byte-for-byte.
+		if a.algo != "" {
+			header += fmt.Sprintf(`, algorithm="%s"`, a.algo)
+		}
 		req.Header.Set("Authorization", header)
 	case AuthTPLink:
 		req.URL.Host = "127.0.0.1"
@@ -129,8 +150,32 @@ func Between(s, sub1, sub2 string) string {
 	return s[:i]
 }
 
+// digestHash maps an RFC 7616 algorithm token to its hash function and the
+// token to echo back in the Authorization header. Unknown/empty tokens fall
+// back to MD5 with no echoed algorithm (original go2rtc behaviour).
+func digestHash(algorithm string) (func(...string) string, string) {
+	switch strings.TrimSuffix(strings.ToUpper(algorithm), "-SESS") {
+	case "SHA-256":
+		return HexSHA256, "SHA-256"
+	case "SHA-512-256":
+		return HexSHA512_256, "SHA-512-256"
+	default:
+		return HexMD5, ""
+	}
+}
+
 func HexMD5(s ...string) string {
 	b := md5.Sum([]byte(strings.Join(s, ":")))
+	return hex.EncodeToString(b[:])
+}
+
+func HexSHA256(s ...string) string {
+	b := sha256.Sum256([]byte(strings.Join(s, ":")))
+	return hex.EncodeToString(b[:])
+}
+
+func HexSHA512_256(s ...string) string {
+	b := sha512.Sum512_256([]byte(strings.Join(s, ":")))
 	return hex.EncodeToString(b[:])
 }
 

--- a/pkg/tcp/auth_test.go
+++ b/pkg/tcp/auth_test.go
@@ -1,0 +1,71 @@
+package tcp
+
+import (
+	"net/textproto"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestDigestAuth drives Read() -> Write() for MD5, SHA-256 and SHA-512-256
+// no-qop Digest challenges. Expected responses were computed independently
+// (Python hashlib) from the same inputs, so this pins the wire output rather
+// than testing the implementation against itself.
+func TestDigestAuth(t *testing.T) {
+	const (
+		user   = "admin"
+		pass   = "password"
+		realm  = "test-realm"
+		nonce  = "abc123nonce"
+		method = "DESCRIBE"
+		rawURL = "rtsp://cam.example:554/Streaming/Channels/101"
+	)
+
+	tests := []struct {
+		name     string
+		algo     string // algorithm token in the challenge ("" => none, i.e. MD5)
+		wantResp string
+		wantEcho string // algorithm= echoed back in the Authorization header ("" => none)
+	}{
+		{"MD5 (no algorithm token)", "", "b85307547e4ed055180deebf2fb535f4", ""},
+		{"SHA-256", "SHA-256", "55a4266fff78e9b046e45bfe98be496009e4e7aad59d6060b5a2504b22304dfa", "SHA-256"},
+		{"SHA-512-256", "SHA-512-256", "93a7bd40530ba627c7462b05011f4afde7265ae35a1dbeec1bdb8ac57b217863", "SHA-512-256"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := NewAuth(url.UserPassword(user, pass))
+
+			challenge := `Digest realm="` + realm + `", nonce="` + nonce + `"`
+			if tt.algo != "" {
+				challenge += `, algorithm="` + tt.algo + `"`
+			}
+			challenge += `, stale="FALSE"`
+
+			res := &Response{Header: textproto.MIMEHeader{}}
+			res.Header.Set("WWW-Authenticate", challenge)
+			if !a.Read(res) {
+				t.Fatal("Read returned false for a Digest challenge")
+			}
+			if a.Method != AuthDigest {
+				t.Fatalf("Method = %d, want AuthDigest", a.Method)
+			}
+
+			u, _ := url.Parse(rawURL)
+			req := &Request{Method: method, URL: u, Header: textproto.MIMEHeader{}}
+			a.Write(req)
+
+			got := req.Header.Get("Authorization")
+			if !strings.Contains(got, `response="`+tt.wantResp+`"`) {
+				t.Errorf("response mismatch\n got:  %s\n want: response=%q", got, tt.wantResp)
+			}
+			if tt.wantEcho == "" {
+				if strings.Contains(got, "algorithm=") {
+					t.Errorf("did not expect algorithm= for MD5, got: %s", got)
+				}
+			} else if !strings.Contains(got, `algorithm="`+tt.wantEcho+`"`) {
+				t.Errorf("expected algorithm=%q in header, got: %s", tt.wantEcho, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

go2rtc's RTSP Digest auth (`pkg/tcp/auth.go`) is hardcoded to MD5. Some IP
cameras — notably Hikvision-OEM firmware (e.g. Prama `PT-NC143D3-WNM`, firmware
V5.8.5) and hardened / STQC-certified units — offer **only** SHA-256 Digest for
RTSP, with no MD5 or Basic option in the web UI:

```
WWW-Authenticate: Digest realm="IP Camera(GH455)", nonce="...", algorithm="SHA-256", stale="FALSE"
```

Against these cameras go2rtc returns `401 Unauthorized` and the stream never
connects. FFmpeg is also MD5-only, so the usual `ffmpeg:` source fallback does
not help either.

## Change

Select the digest hash from the challenge's `algorithm=` token per RFC 7616:

- `MD5` / absent → MD5 — **unchanged; the Authorization header is byte-for-byte
  identical to before**, so existing cameras are unaffected.
- `SHA-256` → SHA-256
- `SHA-512-256` → SHA-512-256

For non-MD5 algorithms the token is echoed back as `algorithm="…"` in the
Authorization header (some firmware validates it); MD5 keeps the original format
with no `algorithm=`. This is the no-qop Digest path already used by
`pkg/tcp/auth.go`.

## Testing

- New `pkg/tcp/auth_test.go` drives `Read()` → `Write()` for MD5, SHA-256 and
  SHA-512-256 and asserts the exact `response=` against vectors computed
  independently (Python `hashlib`). All pass.
- Field-tested end to end: a build with this patch authenticates to a real
  SHA-256-only Hikvision-OEM camera and restreams it into Frigate, where stock
  go2rtc **and** FFmpeg both fail with 401.

## Scope / note

This covers the RTSP Digest path (`pkg/tcp/auth.go`). The HTTP client in
`pkg/tcp/request.go` (`Do`, used for ISAPI / snapshot) has the same MD5-only
limitation and could be extended with the same `digestHash` helper — happy to do
that in a follow-up if wanted. I kept this PR to the path I could verify against
hardware.
