### PR TITLE
Add camera.ui link to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ PS. Additionally, WebRTC will try to use the 8555 UDP port to transmit encrypted
 
 - [Home Assistant](https://www.home-assistant.io/) [2024.11+](https://www.home-assistant.io/integrations/go2rtc/) - top open-source smart home project
 - [Frigate](https://frigate.video/) [0.12+](https://docs.frigate.video/guides/configuring_go2rtc/) - open-source NVR built around real-time AI object detection
+- [camera.ui](https://www.cameraui.com/) - The modern, local-first platform for professional video surveillance.
 - [Advanced Camera Card](https://github.com/dermotduffy/advanced-camera-card) - custom card for Home Assistant
 - [OpenIPC](https://github.com/OpenIPC/firmware/tree/master/general/package/go2rtc) - alternative IP camera firmware from an open community
 - [wz_mini_hacks](https://github.com/gtxaspec/wz_mini_hacks) - custom firmware for Wyze cameras
@@ -504,7 +505,6 @@ PS. Additionally, WebRTC will try to use the 8555 UDP port to transmit encrypted
 - [MMM-go2rtc](https://github.com/Anonym-tsk/MMM-go2rtc) - MagicMirror² module
 - [ring-mqtt](https://github.com/tsightler/ring-mqtt) - Ring-to-MQTT bridge
 - [lightNVR](https://github.com/opensensor/lightNVR)
-- [camera.ui](https://www.cameraui.com/) - The modern, local-first platform for professional video surveillance.
 
 **Distributions**
 

--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ PS. Additionally, WebRTC will try to use the 8555 UDP port to transmit encrypted
 - [MMM-go2rtc](https://github.com/Anonym-tsk/MMM-go2rtc) - MagicMirror² module
 - [ring-mqtt](https://github.com/tsightler/ring-mqtt) - Ring-to-MQTT bridge
 - [lightNVR](https://github.com/opensensor/lightNVR)
+- [camera.ui](https://www.cameraui.com/) - The modern, local-first platform for professional video surveillance.
 
 **Distributions**
 


### PR DESCRIPTION
Hi Alex,

this adds camera.ui to the "Projects using go2rtc" section. 

camera.ui is a self-hosted video surveillance platform, available as desktop app for mac/windows/linux and as docker/bare-metal server. The whole streaming part runs on go2rtc: camera sources, WebRTC/MSE playback, snapshots, two-way audio, all of it. I maintain a fork with some camera.ui specific changes, a lot of that work already made it back upstream (preload streams, ring/tuya/wyze sources, RTSP UDP transport, backchannel for the RTSP server) and some more is sitting in open PRs.

Thanks for go2rtc, camera.ui wouldn't exist without it ❤️

Github: https://github.com/cameraui/camera.ui