### PR TITLE
nest: keep extending stream sessions and stop sharing session state between streams

### DIFF
--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -26,7 +26,10 @@ type API struct {
 	StreamToken          string
 	StreamExtensionToken string
 
+	key string // credentials cache key, used to refresh the OAuth token
+
 	extendTimer *time.Timer
+	extendStop  chan struct{}
 }
 
 type Auth struct {
@@ -49,8 +52,12 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 	key := clientID + ":" + clientSecret + ":" + refreshToken
 	now := time.Now()
 
+	// The cache only stores the OAuth token. Each caller gets its own API
+	// instance, because the Stream* fields hold per-stream session state -
+	// multiple cameras sharing one instance overwrite each other's session
+	// and only the last one gets extended.
 	if api := cache[key]; api != nil && now.Before(api.ExpiresAt) {
-		return api, nil
+		return &API{Token: api.Token, ExpiresAt: api.ExpiresAt, key: key}, nil
 	}
 
 	data := url.Values{
@@ -89,7 +96,7 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 
 	cache[key] = api
 
-	return api, nil
+	return &API{Token: api.Token, ExpiresAt: api.ExpiresAt, key: key}, nil
 }
 
 func (a *API) GetDevices(projectID string) ([]DeviceInfo, error) {
@@ -228,23 +235,12 @@ func (a *API) ExchangeSDP(projectID, deviceID, offer string) (string, error) {
 }
 
 func (a *API) refreshToken() error {
-	// Get the cached API with matching token to get credentials
-	var refreshKey string
-	cacheMu.Lock()
-	for key, api := range cache {
-		if api.Token == a.Token {
-			refreshKey = key
-			break
-		}
-	}
-	cacheMu.Unlock()
-
-	if refreshKey == "" {
+	if a.key == "" {
 		return errors.New("nest: unable to find cached credentials")
 	}
 
-	// Parse credentials from cache key
-	parts := strings.Split(refreshKey, ":")
+	// Parse credentials from the cache key
+	parts := strings.SplitN(a.key, ":", 3)
 	if len(parts) != 3 {
 		return errors.New("nest: invalid cache key format")
 	}
@@ -469,11 +465,30 @@ func (a *API) StartExtendStreamTimer() {
 		return
 	}
 
-	a.extendTimer = time.NewTimer(time.Until(a.StreamExpiresAt) - time.Minute)
+	// Google expires sessions after ~5 minutes; each successful extension
+	// returns a new expiresAt, so keep extending until the stream stops.
+	timer := time.NewTimer(time.Until(a.StreamExpiresAt) - time.Minute)
+	stop := make(chan struct{})
+	a.extendTimer = timer
+	a.extendStop = stop
+
 	go func() {
-		<-a.extendTimer.C
-		if err := a.ExtendStream(); err != nil {
-			return
+		for {
+			select {
+			case <-timer.C:
+				// The OAuth token lives ~1 hour, sessions can live longer
+				if time.Now().After(a.ExpiresAt.Add(-30 * time.Second)) {
+					if err := a.refreshToken(); err != nil {
+						return
+					}
+				}
+				if err := a.ExtendStream(); err != nil {
+					return
+				}
+				timer.Reset(time.Until(a.StreamExpiresAt) - time.Minute)
+			case <-stop:
+				return
+			}
 		}
 	}()
 }
@@ -482,5 +497,9 @@ func (a *API) StopExtendStreamTimer() {
 	if a.extendTimer != nil {
 		a.extendTimer.Stop()
 		a.extendTimer = nil
+	}
+	if a.extendStop != nil {
+		close(a.extendStop)
+		a.extendStop = nil
 	}
 }


### PR DESCRIPTION
Hi Alex, thank you for go2rtc — it has been rock solid for me across many camera types. I believe I found the reason Nest streams drop every 5–10 minutes (#723, #908) and would like to offer a fix.

**What I observed.** Two Nest cameras (same Device Access project) on the `nest:` source reconnect every ~5 or ~10 minutes, both at the same moment. Each renegotiation starts a stream with fresh H264 parameter sets, so downstream RTSP consumers (Frigate's ffmpeg in my case) wedge on `non-existing PPS 0 referenced / no frame!` until their watchdog restarts them — about 70 short outages a day.

**Cause 1 — the extension timer is one-shot.** `StartExtendStreamTimer` arms a single timer, calls `ExtendStream` once and the goroutine exits. Since Google grants ~5-minute sessions, every stream inevitably dies at ~10 minutes (initial 5 + one extension), even though `ExtendStream` already stores the new `expiresAt` from the response. Fixed by looping: after each successful extension the timer is re-armed from the new expiry, and the OAuth token (1 h lifetime) is refreshed shortly before it expires so long-lived sessions keep extending past the first hour. A stop channel ends the loop cleanly from `StopExtendStreamTimer`.

**Cause 2 — session state is shared between streams.** `NewAPI` caches the `*API` object per credentials, but `ExchangeSDP`/`ExtendStream` keep per-stream session state (`StreamSessionID`, `StreamExpiresAt`, `StreamToken`, …) on that same object. With several cameras on one project the sessions overwrite each other, the `if a.extendTimer != nil` guard leaves only one timer for all of them (extending only the last-connected camera's session), and `Stop()` on any one stream kills that shared timer for the rest. Fixed by caching only the OAuth token: every `Dial` now gets its own `API` instance (the token is still reused across streams, so no extra token requests). `refreshToken` now uses the stored credentials key instead of scanning the cache for a matching token value, which also survives the token being rotated by another instance.

**Result.** With both fixes my two cameras have held a single uninterrupted session each (previously: a renegotiation every 5–10 minutes, matching the reports in #723/#908 to the second).

Happy to adjust anything — naming, commit message, or dropping the token-refresh part if you would prefer it as a separate change.
