### PR TITLE
Fix Reolink Doorbell two-way audio on PCMU firmware

### DIFF
--- a/pkg/rtsp/consumer.go
+++ b/pkg/rtsp/consumer.go
@@ -54,9 +54,17 @@ func (c *Conn) AddTrack(media *core.Media, codec *core.Codec, track *core.Receiv
 	// important to send original codec for valid IsRTP check
 	sender.Handler = c.packetWriter(track.Codec, channel, codec.PayloadType)
 
-	if c.mode == core.ModeActiveProducer && track.Codec.Name == core.CodecPCMA {
+	if c.mode == core.ModeActiveProducer {
 		// Fix Reolink Doorbell https://github.com/AlexxIT/go2rtc/issues/331
-		sender.Handler = pcm.RepackG711(true, sender.Handler)
+		switch track.Codec.Name {
+		case core.CodecPCMA:
+			sender.Handler = pcm.RepackG711(true, sender.Handler)
+		case core.CodecPCMU:
+			// Newer Reolink doorbell firmware negotiates PCMU instead of PCMA.
+			// It needs the same repack, but with monotonic timestamps: with
+			// zeroTS the camera replays frames and the audio doubles.
+			sender.Handler = pcm.RepackG711(false, sender.Handler)
+		}
 	}
 
 	sender.HandleRTP(track)


### PR DESCRIPTION
## Problem

Two-way audio to Reolink doorbells is unintelligible on current firmware — heavily distorted and "robotic", and only picking up speech if you shout. Reported in #2007 (open, `brand/reolink`).

## Cause

`RepackG711` exists precisely to fix this device (#331) — it rebuilds the outbound G.711 stream into 1024-byte frames the camera's audio pipeline expects, instead of the browser's raw 20ms/160-byte RTP. Its doc comment says it handles **"G.711 PCMA/PCMU"**.

But the call site in `pkg/rtsp/consumer.go` only fires for **PCMA**:

```go
if c.mode == core.ModeActiveProducer && track.Codec.Name == core.CodecPCMA {
	// Fix Reolink Doorbell https://github.com/AlexxIT/go2rtc/issues/331
	sender.Handler = pcm.RepackG711(true, sender.Handler)
}
```

Reolink switched the doorbell's backchannel codec from PCMA to **PCMU** in a 2024 firmware update (#987). On that firmware the SDP advertises only `a=rtpmap:0 PCMU/8000` on the `sendonly` track, so the fix written for this exact device is silently skipped and Chrome's raw RTP is forwarded verbatim. The resulting 6.4x framing mismatch is the distortion.

## Fix

Apply the same repack for PCMU — but with **monotonic timestamps**, not zeroed ones.

This second part matters and was found empirically. With `zeroTS = true` (as PCMA uses), the distortion is gone but the camera **replays frames — the doorbell audibly doubles/echoes every word**. Passing `false` so the repacked packets carry monotonic RTP timestamps produces clean, intelligible telephone-quality audio.

That also answers the open question in the code:

```go
// don't know if zero TS important for Reolink Doorbell
// don't have this strange devices for tests
```

At least on PCMU firmware, zeroed timestamps are actively harmful. I've left the PCMA path exactly as-is, since I can't test it.

## Testing

Tested on a **Reolink Video Doorbell (PoE)** on current (PCMU) firmware, via Frigate 0.17.2's embedded go2rtc 1.9.10, talking from Chrome and from Safari/iOS over WebRTC:

- **stock** — distorted, robotic, only audible when shouting
- **repack with `zeroTS=true`** — clear, but every word doubles/echoes out of the doorbell speaker
- **repack with `zeroTS=false`** (this PR) — clear and intelligible at a normal speaking voice

Inbound audio, video, recording and detection are unaffected; verified the RTSP backchannel still negotiates (`audio, sendonly, PCMU/8000`) and all streams stay up.

I only have the one device, so I can't speak for other Reolink models that negotiate PCMU — but the codepath is the same one #331 was written for.

Closes #2007