### PR TITLE
nest: request keyframes + advertise sprop-parameter-sets (fix slow/failed consumer opens)

### DIFF
--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -1,12 +1,15 @@
 package webrtc
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/h264"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 	"github.com/pion/webrtc/v4"
@@ -87,13 +90,11 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 			}
 		}
 
-		// Also request periodic keyframes for the Nest source (ModeActiveProducer,
+		// Patched: also request periodic keyframes for the Nest source (ModeActiveProducer,
 		// FormatName "nest/webrtc"). Upstream only does this for PassiveProducer (WHIP/browser
-		// push, which have no other keyframe path). Nest is an active-pull WebRTC source, so
-		// without this its keyframe interval drifts long when idle and RTSP/consumer opens are
-		// slow. Gating on FormatName (not the mode) avoids forcing a 2s IDR on other
-		// ModeActiveProducer WebRTC sources (ring/tuya battery cams etc.) where it'd be
-		// battery- and bandwidth-hostile. PLI is media-plane RTCP: zero SDM API quota impact.
+		// push). Gating on FormatName (not the mode) avoids forcing 2s IDRs on other
+		// ActiveProducer WebRTC sources (ring/tuya battery cams etc.) where it'd be harmful.
+		// Keeps keyframes ~2s fresh so RTSP consumers (Homebridge live view) start fast.
 		if (c.Mode == core.ModePassiveProducer || c.FormatName == "nest/webrtc") && remote.Kind() == webrtc.RTPCodecTypeVideo {
 			go func() {
 				pkts := []rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(remote.SSRC())}}
@@ -106,6 +107,16 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 				}
 			}()
 		}
+
+		// Patched: capture SPS/PPS from the Nest H264 stream and append sprop-parameter-sets to
+		// the codec FmtpLine, so RTSP consumers (Homebridge live view via ffmpeg) learn video
+		// dimensions from the DESCRIBE SDP and start fast instead of waiting for an in-band
+		// keyframe + probe (~3.7s -> near-instant). Google's WebRTC SDP has profile-level-id but
+		// no sprop; SPS/PPS arrive in-band (usually bundled in a STAP-A). Upstream does the
+		// equivalent for H265 (pkg/dvrip). Gated on FormatName like the PLI patch above.
+		captureSprop := c.FormatName == "nest/webrtc" && codec.Name == core.CodecH264 &&
+			!strings.Contains(codec.FmtpLine, "sprop-parameter-sets=")
+		var spropSPS, spropPPS []byte
 
 		for {
 			b := make([]byte, ReceiveMTU)
@@ -123,6 +134,42 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 
 			if len(packet.Payload) == 0 {
 				continue
+			}
+
+			if captureSprop {
+				save := func(nal []byte) {
+					if len(nal) == 0 {
+						return
+					}
+					switch nal[0] & 0x1F {
+					case h264.NALUTypeSPS:
+						spropSPS = append([]byte(nil), nal...)
+					case h264.NALUTypePPS:
+						spropPPS = append([]byte(nil), nal...)
+					}
+				}
+				if pl := packet.Payload; pl[0]&0x1F == 24 { // STAP-A: bundled NALs
+					for bb := pl[1:]; len(bb) >= 2; {
+						sz := int(binary.BigEndian.Uint16(bb))
+						bb = bb[2:]
+						if sz < 1 || sz > len(bb) {
+							break
+						}
+						save(bb[:sz])
+						bb = bb[sz:]
+					}
+				} else {
+					save(pl)
+				}
+				if spropSPS != nil && spropPPS != nil {
+					if codec.FmtpLine != "" {
+						codec.FmtpLine += ";"
+					}
+					codec.FmtpLine += "sprop-parameter-sets=" +
+						base64.StdEncoding.EncodeToString(spropSPS) + "," +
+						base64.StdEncoding.EncodeToString(spropPPS)
+					captureSprop = false
+				}
 			}
 
 			track.WriteRTP(packet)

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -87,10 +87,19 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 			}
 		}
 
-		if c.Mode == core.ModePassiveProducer && remote.Kind() == webrtc.RTPCodecTypeVideo {
+		// Also request periodic keyframes for the Nest source (ModeActiveProducer,
+		// FormatName "nest/webrtc"). Upstream only does this for PassiveProducer (WHIP/browser
+		// push, which have no other keyframe path). Nest is an active-pull WebRTC source, so
+		// without this its keyframe interval drifts long when idle and RTSP/consumer opens are
+		// slow. Gating on FormatName (not the mode) avoids forcing a 2s IDR on other
+		// ModeActiveProducer WebRTC sources (ring/tuya battery cams etc.) where it'd be
+		// battery- and bandwidth-hostile. PLI is media-plane RTCP: zero SDM API quota impact.
+		if (c.Mode == core.ModePassiveProducer || c.FormatName == "nest/webrtc") && remote.Kind() == webrtc.RTPCodecTypeVideo {
 			go func() {
 				pkts := []rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(remote.SSRC())}}
-				for range time.NewTicker(time.Second * 2).C {
+				t := time.NewTicker(time.Second * 2)
+				defer t.Stop()
+				for range t.C {
 					if err := pc.WriteRTCP(pkts); err != nil {
 						return
 					}


### PR DESCRIPTION
Two small, self-contained improvements to the Nest (`nest:`) WebRTC source, both gated on `FormatName == "nest/webrtc"` so nothing else is affected. Together they make Nest cameras usable as a warm RTSP/HLS/consumer source — right now a consumer that joins a Nest stream can wait a long time to start, or fail to determine the video size at all.

### 1. Request periodic keyframes for the Nest source

`OnTrack` in `pkg/webrtc/conn.go` already sends an RTCP `PictureLossIndication` every 2s to keep the source emitting keyframes — but only for `ModePassiveProducer` (WHIP/browser push). Nest is an active-pull source (`ModeActiveProducer`), so it was excluded, and an idle Nest camera lets its keyframe interval drift long. Any consumer that joins mid-GOP (RTSP live view, an on-demand `frame.jpeg`, MSE) then waits up to a full keyframe interval to start.

This enables the existing keyframe-request loop for the Nest source, gated on `FormatName` (not the mode) so other `ModeActiveProducer` WebRTC sources — e.g. battery cameras where a forced 2s IDR would be power/bandwidth hostile — are untouched. PLI is media-plane RTCP, so there's no impact on the Nest/SDM API command quota.

Measured on a Nest doorbell: keyframe interval ~3.3s → ~1.8s; on-demand `frame.jpeg` grabs drop from several seconds to ~1s.

Also added `defer t.Stop()` on the ticker (the existing pattern relies on GC of an unreferenced ticker — fine on Go ≥1.23, but explicit is safer).

### 2. Advertise `sprop-parameter-sets` in the RTSP SDP

The Nest source's H264 codec `FmtpLine` comes from Google's WebRTC SDP answer, which carries `profile-level-id` but no `sprop-parameter-sets` (WebRTC sends SPS/PPS in-band). The RTSP server copies `FmtpLine` verbatim into `DESCRIBE`, so an RTSP consumer gets no SPS/PPS in the SDP and can't determine the video dimensions until an in-band keyframe arrives — which forces a large `-probesize` for ffmpeg, or fails outright at a small one.

This captures SPS (NAL 7) / PPS (NAL 8) from the incoming H264 RTP in the `OnTrack` receive loop — handling STAP-A, which is how libwebrtc typically bundles SPS+PPS+IDR — and appends `sprop-parameter-sets` to the codec `FmtpLine` once. Every consumer that clones the codec (RTSP) or reads `GetParameterSet` (MSE/MP4) then benefits. This mirrors what `pkg/dvrip` already does for H265.

Verified in a live `DESCRIBE` after the change:
```
a=fmtp:97 ...;profile-level-id=64001f;sprop-parameter-sets=Z00AIJ...,aO48gA==
```

### Notes / honesty

- Both are gated on `FormatName == "nest/webrtc"`; no behavior change for any other source.
- `Codec.Match` ignores `FmtpLine`, so appending sprop can't affect media matching/renegotiation.
- The `FmtpLine` append happens on the receive goroutine and is written once; with the keyframe request above, SPS/PPS are captured before any consumer's `DESCRIBE`. A `-race` build could flag a consumer connecting during the sub-2s warm-up window; the existing H265 append in `pkg/dvrip` is unguarded in the same way. Happy to wrap it in a small mutex or capture-into-locals-then-assign if preferred.
- These don't make stream-copy opens *instant*: ffmpeg still aligns copy output to the next keyframe, so the ~2s keyframe interval (now bounded by patch 1) remains the floor. The win is that the interval is bounded and the SDP is complete, so consumers start predictably instead of hanging.

Context: I'm using this to serve Nest cameras to Apple HomeKit via Homebridge over local RTSP, so a single warm go2rtc stream is shared instead of each viewer opening its own concurrent Google WebRTC stream (Nest enforces a concurrent-stream limit). Both patches were needed to make that path reliable.
