### PR TITLE
fix(xiaomi): re-login cloud on 401 to recover without restart

### DIFF
--- a/internal/xiaomi/xiaomi.go
+++ b/internal/xiaomi/xiaomi.go
@@ -81,7 +81,20 @@ func cloudRequest(userID, region, apiURL, params string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cloud.Request(GetBaseURL(region), apiURL, params, nil)
+	res, err := cloud.Request(GetBaseURL(region), apiURL, params, nil)
+	if err != nil && strings.Contains(err.Error(), "401") {
+		// serviceToken expired: drop the cached Cloud and force a re-login
+		// via passToken before retrying the request once.
+		cloudsMu.Lock()
+		delete(clouds, userID)
+		cloudsMu.Unlock()
+		cloud, err = getCloud(userID)
+		if err != nil {
+			return nil, err
+		}
+		return cloud.Request(GetBaseURL(region), apiURL, params, nil)
+	}
+	return res, err
 }
 
 func cloudUserRequest(user *url.Userinfo, apiURL, params string) ([]byte, error) {


### PR DESCRIPTION
## Problem

After running for a while (typically a few hours), Xiaomi cameras stop working with a `401 Unauthorized` error from the Xiaomi cloud API, and **the only way to recover is to restart the entire go2rtc process**.

Reported in #2111, #2129 (closed as duplicate of #2111) and several other issues (#2187, #2234, #2237, #2273).

## Root cause

`internal/xiaomi/xiaomi.go:getCloud` caches `*xiaomi.Cloud` in `clouds[userID]` and returns it forever. The `serviceToken` cookie inside that cached session is short-lived and expires after a few hours.

`pkg/xiaomi/cloud.go:Cloud.Request` returns the HTTP status as an error (`errors.New(res.Status)`) but nothing invalidates the cached `Cloud` on `401`, so every subsequent cloud call (device list, `miss_get_vendor`, `devicepass`, `wakeup`) keeps failing with `401` until the process is restarted and the `clouds` map is rebuilt from scratch.

Note: the `passToken` stored in config (written by the WebUI login flow) is long-lived, so a fresh `LoginWithToken` always succeeds — we just need to actually call it again.

## Fix

In `cloudRequest`, when the cloud response contains `401`:

1. Drop the cached `Cloud` for this `userID` from the `clouds` map.
2. Call `getCloud` again — it falls through to `LoginWithToken` with the long-lived `passToken` and gets a fresh `serviceToken`.
3. Retry the original request once.

This makes the camera recover automatically without a process restart. The change is minimal and limited to a single helper that all cloud requests funnel through, so the behavior change is consistent across device list / `miss_get_vendor` / `devicepass` / `wakeup`.

## Test

- Xiaomi camera configured with `passToken` from WebUI.
- Before the patch: after some uptime, opening the stream returned `401 Unauthorized` and required restarting go2rtc.
- After the patch: same scenario, the first stream open after token expiry triggers one extra re-login and then succeeds transparently.

## Related issues

Refs #2111, #2129.
