### PR TITLE
hardware: bind vaapi filter device for FFmpeg 8

### DIFF
--- a/internal/ffmpeg/hardware/hardware.go
+++ b/internal/ffmpeg/hardware/hardware.go
@@ -58,7 +58,11 @@ func MakeHardware(args *ffmpeg.Args, engine string, defaults map[string]string) 
 			args.Codecs[i] = defaults[name+"/"+engine]
 
 			if !args.HasFilters("drawtext=") {
-				args.Input = "-hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_flags allow_profile_mismatch " + args.Input
+				// `-init_hw_device`/`-filter_hw_device` - bind a device to the
+				// filter graph, so `hwupload` works when the input isn't
+				// hardware decoded. Required since FFmpeg 8, which no longer
+				// derives the filter device from `-hwaccel` alone.
+				args.Input = "-init_hw_device vaapi=vaapi0 -filter_hw_device vaapi0 -hwaccel vaapi -hwaccel_output_format vaapi -hwaccel_flags allow_profile_mismatch " + args.Input
 
 				if name == "h264" {
 					fixPixelFormat(args)
@@ -82,7 +86,7 @@ func MakeHardware(args *ffmpeg.Args, engine string, defaults map[string]string) 
 				args.InsertFilter("format=vaapi|nv12,hwupload")
 			} else {
 				// enable software pixel for drawtext, scale and transpose
-				args.Input = "-hwaccel vaapi -hwaccel_output_format nv12 -hwaccel_flags allow_profile_mismatch " + args.Input
+				args.Input = "-init_hw_device vaapi=vaapi0 -filter_hw_device vaapi0 -hwaccel vaapi -hwaccel_output_format nv12 -hwaccel_flags allow_profile_mismatch " + args.Input
 
 				args.AddFilter("hwupload")
 			}


### PR DESCRIPTION
# hardware: bind vaapi filter device for FFmpeg 8

## Problem

`#hardware=vaapi` transcoding is broken on FFmpeg 8. The VAAPI branch of
`MakeHardware` inserts a `format=vaapi|nv12,hwupload` filter but relies on
`-hwaccel vaapi` to provide the device to the **filter graph**. FFmpeg 8 no
longer derives the filter device from `-hwaccel` alone, so `hwupload` fails
whenever the input isn't hardware-decoded (e.g. an RTSP restream):

```
[hwupload] A hardware device reference is required to upload frames to.
[AVFilterGraph] Error initializing filters
Error opening output files: Invalid argument
```

Note the hardware **probe** commands already work, because they explicitly
`-init_hw_device vaapi` — the transcode path just didn't.

## Fix

Explicitly initialise and bind a filter device in the VAAPI branch, matching
the probes:

```
-init_hw_device vaapi=vaapi0 -filter_hw_device vaapi0 -hwaccel vaapi ...
```

Applied to both VAAPI sub-branches (with and without `drawtext`).

## Testing

Reproduced and A/B-tested on an Intel N150 (iHD driver), FFmpeg 8.0.1, same
input stream (`ffmpeg:virtual?video#video=h264#hardware=vaapi`):

| build | result |
|---|---|
| master | `[hwupload] A hardware device reference is required` → stream fails |
| this PR | `h264 1920x1080` — encodes fine |

Also verified end-to-end transcoding a live H265 doorbell stream to H264 for a
browser that can't decode HEVC.

## Question

`-init_hw_device vaapi=vaapi0` auto-selects the DRM node (same as the probe
commands). If you'd rather thread through an explicit device path, happy to
adjust.
