### PR TITLE
Fix xiaomi/cs2 stream restart on pop buffer overflow

### DIFF
--- a/internal/xiaomi/README.md
+++ b/internal/xiaomi/README.md
@@ -62,3 +62,10 @@ You can use a second channel for dual cameras: `channel=2`.
 streams:
   xiaomi1: xiaomi://***&channel=2
 ```
+
+You can change the media buffer size (in packets) if your consumers are slow: `buffer=256` (default).
+
+```yaml
+streams:
+  xiaomi1: xiaomi://***&buffer=1024
+```

--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/tutk"
@@ -55,7 +56,8 @@ func NewClient(rawURL string) (*Client, error) {
 	var conn Conn
 	switch s := query.Get("vendor"); s {
 	case "cs2":
-		conn, err = cs2.Dial(u.Host, query.Get("transport"))
+		popSize, _ := strconv.Atoi(query.Get("buffer"))
+		conn, err = cs2.Dial(u.Host, query.Get("transport"), popSize)
 	case "tutk":
 		conn, err = tutk.Dial(u.Host, query.Get("uid"), "Miss", "client")
 	default:

--- a/pkg/xiaomi/miss/cs2/conn.go
+++ b/pkg/xiaomi/miss/cs2/conn.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-func Dial(host, transport string) (*Conn, error) {
+func Dial(host, transport string, popSize int) (*Conn, error) {
 	conn, err := handshake(host, transport)
 	if err != nil {
 		return nil, err
@@ -20,11 +20,15 @@ func Dial(host, transport string) (*Conn, error) {
 
 	_, isTCP := conn.(*tcpConn)
 
+	if popSize <= 0 {
+		popSize = 256
+	}
+
 	c := &Conn{
 		Conn:  conn,
 		isTCP: isTCP,
 		channels: [4]*dataChannel{
-			newDataChannel(0, 10), nil, newDataChannel(250, 100), nil,
+			newDataChannel(0, 10), nil, newDataChannel(250, popSize), nil,
 		},
 	}
 	go c.worker()
@@ -445,7 +449,16 @@ func (c *dataChannel) Push(b []byte) error {
 		select {
 		case c.popBuf <- c.waitData[:c.waitSize]:
 		default:
-			return fmt.Errorf("pop buffer is full")
+			// Slow consumer or retransmit burst. Drop the oldest packet
+			// instead of killing the whole connection (stream restart).
+			select {
+			case <-c.popBuf:
+			default:
+			}
+			select {
+			case c.popBuf <- c.waitData[:c.waitSize]:
+			default: // consumer raced us, drop the new packet
+			}
 		}
 
 		c.waitData = c.waitData[c.waitSize:]


### PR DESCRIPTION
## Problem

When the media channel pop buffer (hardcoded capacity 100 packets) fills up — e.g. the consumer pipeline is temporarily slower than the camera (CPU throttling, slow downstream client) — `dataChannel.Push` returns a fatal error. This kills the whole camera connection and forces a stream restart with re-probing. Users see repeated warnings:

    miss: read media: cs2: pop buffer is full

and periodic video interruptions (in my setup every ~10 seconds).

## Fix

- Drop the oldest queued packet instead of failing the connection. Consumers already tolerate packet loss (RTP sequence gaps) and decoders resync on the next keyframe — far better than restarting the whole stream.
- Make the pop buffer size configurable via the `buffer` URL param (default 256, previously hardcoded 100), so setups with slow consumers can trade memory for fewer drops, e.g. `xiaomi://...&buffer=1024`.

Tested with a chuangmi.camera.81ac1 (cs2+tcp): the stream no longer restarts under consumer-side slowdowns.