### PR TITLE
nest: close PeerConnection/RTSP client on failed dial (fd + ICE mDNS socket leak)

### DIFF
--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -129,12 +129,17 @@ func rtcConn(nestAPI *API, rawURL, projectID, deviceID string) (*WebRTCClient, e
 		// 3. Create offer with candidates
 		offer, err := conn.CreateCompleteOffer(medias)
 		if err != nil {
+			_ = pc.Close()
 			return nil, err
 		}
 
 		// 4. Exchange SDP via Hass
 		answer, err := nestAPI.ExchangeSDP(projectID, deviceID, offer)
 		if err != nil {
+			// close the failed PeerConnection: it never reaches ICE connectivity
+			// (no answer is set), so pion's connection-state auto-close never fires
+			// and its ICE agent's mDNS sockets (:5353) would leak on every retry.
+			_ = pc.Close()
 			lastErr = err
 			if attempt < maxRetries-1 {
 				time.Sleep(retryDelay)
@@ -146,6 +151,7 @@ func rtcConn(nestAPI *API, rawURL, projectID, deviceID string) (*WebRTCClient, e
 
 		// 5. Set answer with remote medias
 		if err = conn.SetAnswer(answer); err != nil {
+			_ = pc.Close()
 			return nil, err
 		}
 
@@ -166,6 +172,7 @@ func rtspConn(nestAPI *API, rawURL, projectID, deviceID string) (*RTSPClient, er
 		return nil, err
 	}
 	if err := rtspClient.Describe(); err != nil {
+		_ = rtspClient.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
### Summary

`pkg/nest/client.go` leaks connections on error paths:

- **`rtcConn()`** creates a `webrtc.PeerConnection` per dial attempt but never calls `pc.Close()` on any failure. Each abandoned pc keeps its ICE agent's UDP sockets open — including **two mDNS sockets on `:5353`** (one udp4, one udp6, opened by pion's default `MulticastDNSModeQueryOnly`), plus its gathered host-candidate sockets and agent goroutines. These are never reclaimed on their own: the pc never reaches ICE connectivity (no answer is set on the failure path), so pion's connection-state auto-close never fires. Accumulation is unbounded.
- **`rtspConn()`** has the analogous bug: if `Describe()` fails after `Dial()` succeeds, the RTSP client's TCP connection is never closed.

### Impact (observed)

- go2rtc 1.9.14 on a Raspberry Pi 4, `--network host`, Nest WEB_RTC cameras via Device Access / SDM.
- A couple of cameras were powered off. go2rtc redials each roughly every ~2 min, and each dial to a powered-off camera returns `wrong status: 400 Bad Request` from SDM.
- After ~40 min: **124 open UDP sockets on `:5353`** owned by the single go2rtc process, climbing steadily. That matches the leak arithmetic — a persistently-failing dial leaks 3 PeerConnections per cycle × 2 mDNS sockets = 6/cycle, and ~20 dial cycles across the off cameras in ~40 min ≈ 120 sockets.
- On `--network host` alongside other mDNS responders, local mDNS discovery then degraded. (The socket accumulation and its cause are confirmed from source; the downstream "degrades host mDNS" step is an observed correlation on that host.)

### Root cause

In `rtcConn`'s retry loop, `pc` is created and then abandoned on every error path — none closes it. The `ExchangeSDP` failure path is the worst: it `continue`s the loop, which creates a **new** pc next iteration while the previous one leaks.

### Fix

Close the connection on each failure path. Success paths are unchanged — there the returned `WebRTCClient` / `RTSPClient` owns the connection and closes it on teardown (`Stop()` → `Connection.Stop()` closes the pc). `pc.Close()` is idempotent and non-blocking here, and reclaims the whole per-pc fd/goroutine footprint, not just the mDNS sockets.

### Notes

- The retry loop retries a hard SDM `400` up to 3× with backoff; for a persistently-off camera that's wasted work and triples the per-cycle leak. Reusing one pc/offer across the `ExchangeSDP` attempts (the 400 doesn't invalidate the local offer), or not retrying a hard 400 at all, would be a reasonable follow-up — kept out of scope here to keep the fix minimal.
- The Nest dial never needs pion's ICE mDNS (answers come from remote cloud peers that can't offer usable `.local` candidates), so a nest-scoped `SetICEMulticastDNSMode(Disabled)` would avoid opening the `:5353` sockets entirely — but that should be scoped to the nest path only (the shared WebRTC server API also serves browser viewers that legitimately send `.local` host candidates). Not needed to fix this leak; closing the pc is the correct minimal fix.
