### PR TITLE
Add Xiaomi IPC017 legacy camera support

### DIFF
--- a/pkg/xiaomi/legacy/client.go
+++ b/pkg/xiaomi/legacy/client.go
@@ -103,16 +103,29 @@ func (c *Client) ReadPacket() (hdr, payload []byte, err error) {
 	if err != nil {
 		return
 	}
-	if c.key != nil {
-		if c.model == ModelAqaraG2 && hdr[0] == tutk.CodecH265 {
-			payload, err = DecodeVideo(payload, c.key)
-		} else {
-			// ModelAqaraG2: audio AAC
-			// ModelIMILABA1: video HEVC, audio PCMA
-			payload, err = crypto.Decode(payload, c.key)
-		}
-	}
+	payload, err = c.decodePayload(hdr[0], payload)
 	return
+}
+
+func (c *Client) decodePayload(codec byte, payload []byte) ([]byte, error) {
+	if c.key == nil {
+		return payload, nil
+	}
+
+	switch {
+	case c.model == ModelIPC017:
+		// IPC017 encrypts video but sends its proprietary PCMA packets as-is.
+		if tutk.IsVideoCodec(codec) {
+			return crypto.Decode(payload, c.key)
+		}
+		return payload, nil
+	case c.model == ModelAqaraG2 && codec == tutk.CodecH265:
+		return DecodeVideo(payload, c.key)
+	default:
+		// ModelAqaraG2: audio AAC
+		// ModelIMILABA1: video HEVC, audio PCMA
+		return crypto.Decode(payload, c.key)
+	}
 }
 
 const (
@@ -149,7 +162,7 @@ func (c *Client) StartMedia(video, audio string) error {
 			c.WriteCommandJSON(0x0704, `{}`), // don't know why
 		)
 
-	case ModelIMILABA1, ModelMijia:
+	case ModelIMILABA1, ModelIPC017, ModelMijia:
 		// 0 - auto, 1 - low, 3 - hd
 		switch video {
 		case "", "hd":
@@ -253,6 +266,7 @@ func DecodeVideo(data, key []byte) ([]byte, error) {
 const (
 	ModelAqaraG2  = "lumi.camera.gwagl01"
 	ModelIMILABA1 = "chuangmi.camera.ipc019e"
+	ModelIPC017   = "chuangmi.camera.ipc017"
 	ModelLoockV1  = "loock.cateye.v01"
 	ModelXiaobai  = "chuangmi.camera.xiaobai"
 	ModelXiaofang = "isa.camera.isc5"
@@ -264,7 +278,7 @@ const (
 
 func Supported(model string) bool {
 	switch model {
-	case ModelAqaraG2, ModelIMILABA1, ModelLoockV1, ModelXiaobai, ModelXiaofang:
+	case ModelAqaraG2, ModelIMILABA1, ModelIPC017, ModelLoockV1, ModelXiaobai, ModelXiaofang:
 		return true
 	}
 	return false

--- a/pkg/xiaomi/legacy/client_test.go
+++ b/pkg/xiaomi/legacy/client_test.go
@@ -1,0 +1,43 @@
+package legacy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/tutk"
+	"github.com/AlexxIT/go2rtc/pkg/xiaomi/crypto"
+)
+
+func TestIPC017DecodePayload(t *testing.T) {
+	key := bytes.Repeat([]byte{0x42}, 32)
+	video := []byte{0, 0, 0, 1, 0x40, 1, 2, 3}
+	encryptedVideo, err := crypto.Encode(video, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &Client{key: key, model: ModelIPC017}
+
+	got, err := client.decodePayload(tutk.CodecH265, encryptedVideo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, video) {
+		t.Fatalf("unexpected decoded video: %x", got)
+	}
+
+	audio := []byte{1, 2, 3, 4}
+	got, err = client.decodePayload(codecXiaobaiPCMA, audio)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, audio) {
+		t.Fatalf("unexpected decoded audio: %x", got)
+	}
+}
+
+func TestSupportedIPC017(t *testing.T) {
+	if !Supported(ModelIPC017) {
+		t.Fatal("IPC017 should be supported")
+	}
+}


### PR DESCRIPTION
# Add Xiaomi IPC017 legacy camera support
<img width="140" height="171" alt="image" src="https://github.com/user-attachments/assets/7aaade39-fe6b-4b33-97a1-bb1f978d039d" />

## Summary

- register `chuangmi.camera.ipc017` IMI Home Security Camera 1080P as a supported Xiaomi legacy camera
- use the IMILAB A1/Mijia media start and quality commands
- decrypt encrypted video packets while leaving the camera's proprietary
  unencrypted PCMA audio packets unchanged
- add regression tests for IPC017 payload handling and model detection

## Background

`chuangmi.camera.ipc017` currently falls back to the Xiaomi legacy client but
is rejected as an unsupported model.

The camera uses the same media control commands as the IMILAB A1/Mijia branch.
Its payload encryption differs slightly: video packets use the Xiaomi
ChaCha20 wrapper, while audio packets with the proprietary Xiaobai PCMA codec
ID are already unencrypted. Applying `crypto.Decode` to both tracks therefore
fails with `unsupported encryption`.

## Validation

- `go test ./pkg/xiaomi/...`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./...`
- tested on a physical `chuangmi.camera.ipc017`, firmware `3.5.8_0097`
- sustained MP4 streaming without `EOF`
- detected output: HEVC, 1920×1080 with `subtype=hd`

Example source, with account and device values redacted:

```yaml
streams:
  camera: xiaomi://<account>:<region>@<camera-ip>?did=<did>&model=chuangmi.camera.ipc017&subtype=hd
```

## Notes

The wider repository test suite was also attempted on Darwin with Go 1.26.
Unrelated existing platform/toolchain failures were observed in FFmpeg,
HomeKit, stream, AAC, credentials, and `go vet` tests. The Xiaomi package
suite and the Linux cross-build pass.
