### PR TITLE
h264: wait for a partition head before depayloading

### DIFF
--- a/pkg/h264/rtp.go
+++ b/pkg/h264/rtp.go
@@ -21,7 +21,25 @@ func RTPDepay(codec *core.Codec, handler core.HandlerFunc) core.HandlerFunc {
 
 	buf := make([]byte, 0, 512*1024) // 512K
 
+	// A depayloader attaching to a live stream can land in the middle of a
+	// fragmented NAL unit. codecs.H264Packet appends FU-A fragments without
+	// checking the start bit, so those orphan fragments are assembled and
+	// emitted under a synthesized NAL header - a NAL that looks valid (and
+	// passes IsKeyframe when the fragmented type is 5) but is missing its
+	// head, including the slice header. Consumers then fail to decode it.
+	// RFC 6184 §5.8 requires discarding fragments that follow a lost start,
+	// and pion's own SampleBuilder gates on IsPartitionHead for this reason.
+	// Wait for a partition head before feeding the depayloader anything.
+	synced := false
+
 	return func(packet *rtp.Packet) {
+		if !synced {
+			if !depack.IsPartitionHead(packet.Payload) {
+				return
+			}
+			synced = true
+		}
+
 		//log.Printf("[RTP] codec: %s, nalu: %2d, size: %6d, ts: %10d, pt: %2d, ssrc: %d, seq: %d, %v", codec.Name, packet.Payload[0]&0x1F, len(packet.Payload), packet.Timestamp, packet.PayloadType, packet.SSRC, packet.SequenceNumber, packet.Marker)
 
 		payload, err := depack.Unmarshal(packet.Payload)

--- a/pkg/h264/rtp_test.go
+++ b/pkg/h264/rtp_test.go
@@ -1,0 +1,53 @@
+package h264
+
+import (
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+// fuA builds an FU-A packet carrying one fragment of a fragmented NAL unit.
+func fuA(naluType byte, start, end bool, seq uint16, payload []byte) *rtp.Packet {
+	const fuAType = 28
+	indicator := byte(0x60) | fuAType // nri=3, type=FU-A
+	header := naluType
+	if start {
+		header |= 0x80
+	}
+	if end {
+		header |= 0x40
+	}
+	return &rtp.Packet{
+		Header:  rtp.Header{SequenceNumber: seq, Marker: end},
+		Payload: append([]byte{indicator, header}, payload...),
+	}
+}
+
+// A depayloader that attaches mid-way through a fragmented IDR must not emit a
+// NAL assembled from the leftover fragments. Without a partition-head gate,
+// codecs.H264Packet appends the tail fragments and synthesizes a NAL header,
+// producing a keyframe-shaped NAL whose slice header is missing - undecodable,
+// but indistinguishable from a real keyframe to IsKeyframe.
+func TestRTPDepay_SkipsNALUStartedBeforeAttach(t *testing.T) {
+	codec := &core.Codec{Name: core.CodecH264}
+
+	var got [][]byte
+	depay := RTPDepay(codec, func(packet *core.Packet) {
+		got = append(got, append([]byte(nil), packet.Payload...))
+	})
+
+	// Attach mid-NAL: the start fragment (and everything before it) was never
+	// seen. Only the tail of a fragmented IDR arrives.
+	depay(fuA(NALUTypeIFrame, false, false, 100, []byte{0xaa, 0xbb}))
+	depay(fuA(NALUTypeIFrame, false, true, 101, []byte{0xcc, 0xdd}))
+
+	require.Empty(t, got, "must not emit a NAL whose start fragment was never received")
+
+	// A complete NAL that begins after we attached must still be delivered.
+	depay(fuA(NALUTypeIFrame, true, false, 102, []byte{0x01, 0x02}))
+	depay(fuA(NALUTypeIFrame, false, true, 103, []byte{0x03, 0x04}))
+
+	require.Len(t, got, 1, "a NAL received in full must be emitted")
+}


### PR DESCRIPTION
### Summary

`RTPDepay` (`pkg/h264/rtp.go`) creates a fresh `codecs.H264Packet` and begins feeding it whatever RTP packet arrives first. A consumer that attaches to a live stream partway through a **fragmented** NAL unit therefore starts with FU-A fragments whose **start fragment was never received**.

`codecs.H264Packet` appends FU-A fragments without checking the start bit, and on the end bit it **synthesizes a NAL header** from the fragment type. The result is a NAL unit that never existed on the wire: correctly shaped, but missing its head — including the slice header. When the fragmented type is 5, it also passes `IsKeyframe`, so callers treat it as a valid keyframe and hand it to a decoder that cannot decode it.

### Reproduction

The added test feeds only the tail fragments of a fragmented IDR. On current `main` it emits:

```
[0 0 0 5 101 170 187 204 221]
```

`101` is `0x65` — `nal_ref_idc=3`, `nal_unit_type=5` (IDR) — followed by nothing but the orphan fragment bytes. A synthesized keyframe assembled from a NAL whose beginning was never seen.

### Fix

Skip packets until `IsPartitionHead` reports one, then depayload exactly as before. Packets dropped by this gate could only ever have produced a malformed NAL.

This matches what pion already does elsewhere: `IsPartitionHead` is part of the `Depacketizer` interface, and pion's own `SampleBuilder` refuses to begin a sample that is not a partition head. `RTPDepay` bypasses `SampleBuilder`, so it never gets that protection. RFC 6184 §5.8 likewise requires discarding fragments that follow a lost start.

### Where this shows up

Anything that builds a depayloader per consumer and attaches mid-stream. The snapshot path is the most visible: `/api/frame.jpeg` creates a new keyframe consumer per request, so a request landing mid-IDR gets a head-truncated "keyframe" and ffmpeg fails on it — intermittently, without any error that identifies the cause. On one long-running deployment this produced a few percent of snapshot requests failing with `Invalid data found when processing input` or a 100% decode-error rate, plus occasional solid-grey JPEGs (a decoder concealing a keyframe with no slice header). Live restream and MP4 consumers attach the same way.

I am deliberately *not* claiming this is the sole cause of those production failures — mid-stream packet loss can corrupt an access unit too, and I have not instrumented enough to separate them. The defect above stands on its own at the code level regardless, which is what the test demonstrates.

### Notes

- No behavior change once synced — the gate is one bool check per packet until the first partition head.
- Does not address corruption from loss *after* attach (a sequence-continuity check would be a separate change).
