### PR TITLE
Add RSA CBC cipher suites for older Axis cameras

### DIFF
--- a/pkg/tcp/request.go
+++ b/pkg/tcp/request.go
@@ -153,6 +153,11 @@ var insecureConfig = &tls.Config{
 		// but cameras can't work without them https://github.com/AlexxIT/go2rtc/issues/1172
 		tls.TLS_RSA_WITH_AES_128_GCM_SHA256, // insecure
 		tls.TLS_RSA_WITH_AES_256_GCM_SHA384, // insecure
+
+		// older Axis firmware (e.g. M5054 on 6.53.4) supports neither ECDHE
+		// nor the GCM suites above, only RSA-key-exchange or DHE CBC suites
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA, // insecure
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA, // insecure
 	},
 }
 


### PR DESCRIPTION
Older Axis cameras fail to connect over `httpx` with `remote error: tls: handshake failure`. Seen on an Axis M5054 running firmware 6.53.4; cameras on the current AXIS OS 12 firmware are not affected, this is specific to older firmware and camera generations.

That firmware negotiates TLS 1.2 but offers no ECDHE support and no GCM suites, so it shares nothing with the current `insecureConfig` list. Probing the camera with `openssl s_client` shows every ECDHE suite rejected (alert 40), `AES128-GCM-SHA256`/`AES256-GCM-SHA384` rejected, and only RSA-key-exchange or DHE CBC suites accepted (`DHE-RSA-AES256-SHA`, `AES256-SHA`). Go's crypto/tls has no DHE support, which leaves the RSA CBC pair as the only route.

This adds `TLS_RSA_WITH_AES_128_CBC_SHA` and `TLS_RSA_WITH_AES_256_CBC_SHA` to the list, the same situation #1172 fixed for cameras that need the RSA GCM suites. Since `insecureConfig` already skips certificate verification for self-signed devices, offering two more legacy suites does not meaningfully change its security posture.

Tested against the M5054: without this change the fetch fails with the handshake error above; with it, `httpx://user:pass@camera/axis-cgi/mjpg/video.cgi` streams normally.
