### PR TITLE
HKSV: Fix default pin differing from schema

### DIFF
--- a/pkg/hap/helpers.go
+++ b/pkg/hap/helpers.go
@@ -57,6 +57,9 @@ const (
 
 const DeviceAID = 1 // TODO: fix someday
 
+// DefaultPIN is the HomeKit pairing PIN used when none is configured.
+const DefaultPIN = "19550224"
+
 type JSONAccessories struct {
 	Value []*Accessory `json:"accessories"`
 }

--- a/pkg/hksv/README.md
+++ b/pkg/hksv/README.md
@@ -69,7 +69,7 @@ func main() {
 
     srv, err := hksv.NewServer(hksv.Config{
         StreamName: "my-camera",
-        Pin:        "27041991",
+        Pin:        "19550224",
         HKSV:       true,
         MotionMode: "detect",
         Streams:    &myStreamProvider{},
@@ -105,7 +105,7 @@ func main() {
 ```go
 srv, err := hksv.NewServer(hksv.Config{
     StreamName: "my-camera",
-    Pin:        "27041991",
+    Pin:        "19550224",
     HKSV:       true,
     MotionMode: "detect",
 
@@ -124,7 +124,7 @@ srv, err := hksv.NewServer(hksv.Config{
 ```go
 srv, err := hksv.NewServer(hksv.Config{
     StreamName: "basic-cam",
-    Pin:        "27041991",
+    Pin:        "19550224",
     HKSV:       false, // no HKSV recording
 
     Streams:    &myStreamProvider{},
@@ -139,7 +139,7 @@ srv, err := hksv.NewServer(hksv.Config{
 ```go
 srv, err := hksv.NewServer(hksv.Config{
     StreamName: "proxied-cam",
-    Pin:        "27041991",
+    Pin:        "19550224",
     ProxyURL:   "homekit://192.168.1.100:51827?device_id=AA:BB:CC:DD:EE:FF&...",
 
     Logger: logger,
@@ -152,7 +152,7 @@ srv, err := hksv.NewServer(hksv.Config{
 ```go
 srv, err := hksv.NewServer(hksv.Config{
     StreamName: "my-doorbell",
-    Pin:        "27041991",
+    Pin:        "19550224",
     CategoryID: "doorbell", // creates doorbell accessory
     HKSV:       true,
     MotionMode: "detect",
@@ -376,7 +376,7 @@ func (h *srtpLiveStreamHandler) StopStream(sessionID string, ct hksv.ConnTracker
 type Config struct {
     // Required
     StreamName string           // stream identifier (used for lookups)
-    Pin        string           // HomeKit pairing PIN, e.g. "27041991" (default)
+    Pin        string           // HomeKit pairing PIN, e.g. "19550224" (default)
     Port       uint16           // HAP HTTP port
     Logger     zerolog.Logger   // structured logger
     Streams    StreamProvider   // stream registry (required for HKSV/live/motion)
@@ -562,7 +562,7 @@ var entries []*mdns.ServiceEntry
 for _, name := range cameras {
     srv, _ := hksv.NewServer(hksv.Config{
         StreamName: name,
-        Pin:        "27041991",
+        Pin:        "19550224",
         HKSV:       true,
         MotionMode: "detect",
         Streams:    provider,
@@ -637,7 +637,7 @@ go build -o hksv-camera ./pkg/hksv/example
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-url` | (required) | RTSP stream URL |
-| `-pin` | `27041991` | HomeKit pairing PIN |
+| `-pin` | `19550224` | HomeKit pairing PIN |
 | `-port` | `0` (auto) | HAP HTTP port |
 | `-motion` | `detect` | Motion mode: `detect`, `continuous`, `api` |
 | `-threshold` | `2.0` | Motion sensitivity (lower = more sensitive) |

--- a/pkg/hksv/example/main.go
+++ b/pkg/hksv/example/main.go
@@ -9,7 +9,7 @@
 //	go run ./pkg/hksv/example -url rtsp://admin:pass@192.168.1.100:554/h264
 //
 // Then open the Home app on your iPhone/iPad, tap "+" → "Add Accessory",
-// and scan the QR code or enter the PIN manually (default: 270-41-991).
+// and scan the QR code or enter the PIN manually (default: 1955-0224).
 package main
 
 import (
@@ -33,7 +33,7 @@ import (
 
 func main() {
 	streamURL := flag.String("url", "", "RTSP stream URL (required)")
-	pin := flag.String("pin", "27041991", "HomeKit pairing PIN")
+	pin := flag.String("pin", hap.DefaultPIN, "HomeKit pairing PIN")
 	port := flag.Int("port", 0, "HAP HTTP port (0 = auto)")
 	motion := flag.String("motion", "detect", "Motion mode: detect, continuous, api")
 	threshold := flag.Float64("threshold", 2.0, "Motion detection threshold (lower = more sensitive)")

--- a/pkg/hksv/hksv.go
+++ b/pkg/hksv/hksv.go
@@ -7,7 +7,7 @@
 //
 //	srv, err := hksv.NewServer(hksv.Config{
 //	    StreamName: "camera1",
-//	    Pin:        "27041991",
+//	    Pin:        "19550224",
 //	    HKSV:       true,
 //	    MotionMode: "detect",
 //	    Streams:    myStreamProvider,
@@ -91,7 +91,7 @@ type ConnTracker interface {
 // Config for creating an HKSV server.
 type Config struct {
 	StreamName      string
-	Pin             string   // HomeKit pairing PIN (e.g., "27041991")
+	Pin             string   // HomeKit pairing PIN (e.g., "19550224")
 	Name            string   // mDNS display name (auto-generated if empty)
 	DeviceID        string   // MAC-like device ID (auto-generated if empty)
 	DevicePrivate   string   // ed25519 private key hex (auto-generated if empty)
@@ -150,7 +150,7 @@ type Server struct {
 // NewServer creates a new HKSV server with the given configuration.
 func NewServer(cfg Config) (*Server, error) {
 	if cfg.Pin == "" {
-		cfg.Pin = "27041991"
+		cfg.Pin = hap.DefaultPIN
 	}
 
 	pin, err := hap.SanitizePin(cfg.Pin)

--- a/pkg/hksv/hksv_test.go
+++ b/pkg/hksv/hksv_test.go
@@ -186,6 +186,13 @@ func TestNewServer_DefaultPin(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, srv)
+
+	data, err := srv.MarshalJSON()
+	require.NoError(t, err)
+
+	var v map[string]any
+	require.NoError(t, json.Unmarshal(data, &v))
+	require.Equal(t, "195-50-224", v["setup_code"])
 }
 
 func TestNewServer_InvalidPin(t *testing.T) {


### PR DESCRIPTION
## Summary

Restore the default HomeKit pairing PIN to `19550224`, matching [www/schema](https://github.com/AlexxIT/go2rtc/blob/c245815e75e2a5fd60b4290f12bfc04e55a984d3/www/schema.json#L285) (`homekit.*.pin.default`) and the existing documentation.

This fixes `hap: VerifyClientAuthenticator` errors caused by the HKSV server using a different default PIN.

- Move the shared default to `hap.DefaultPIN`
- Update HKSV and example defaults
- Add regression coverage for the default setup code

---

### AI disclosure

This implementation was developed with assistance from ChatGPT 5.6 Sol running under GitHub Copilot. Its architecture, acceptance criteria, and engineering standards were human-directed. The final branch was reviewed, tested, and exercised on physical cameras.