### PR TITLE
Fix Xiaomi CS2 audio payload writes

### DIFF
--- a/pkg/xiaomi/miss/cs2/conn.go
+++ b/pkg/xiaomi/miss/cs2/conn.go
@@ -265,7 +265,7 @@ func (c *Conn) WritePacket(hdr, payload []byte) error {
 	c.seqCh3++
 	binary.BigEndian.PutUint32(req[8:], n)
 	copy(req[offset:], hdr)
-	copy(req[offset+hdrSize:], hdr)
+	copy(req[offset+hdrSize:], payload)
 
 	_, err := c.Conn.Write(req)
 	return err

--- a/pkg/xiaomi/miss/cs2/conn_write_test.go
+++ b/pkg/xiaomi/miss/cs2/conn_write_test.go
@@ -1,0 +1,38 @@
+package cs2
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+)
+
+func TestWritePacketIncludesPayload(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	header := bytes.Repeat([]byte{0x11}, hdrSize)
+	payload := []byte{0xBA, 0x03, 0x10, 0x20, 0x30, 0x40}
+	conn := &Conn{Conn: client}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- conn.WritePacket(header, payload)
+	}()
+
+	packet := make([]byte, 12+hdrSize+len(payload))
+	if _, err := io.ReadFull(server, packet); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+
+	if got := packet[12 : 12+hdrSize]; !bytes.Equal(got, header) {
+		t.Fatalf("media header mismatch: %x", got)
+	}
+	if got := packet[12+hdrSize:]; !bytes.Equal(got, payload) {
+		t.Fatalf("audio payload mismatch: got %x, want %x", got, payload)
+	}
+}


### PR DESCRIPTION
## Summary

- copy the encrypted audio payload into Xiaomi CS2 media packets
- add a regression test that verifies both the media header and payload on the wire

## Root cause

`WritePacket` allocates space for `hdrSize + len(payload)`, but the second `copy` used `hdr` again. As a result, the camera received encrypted media-header bytes followed by zero padding instead of the encrypted Opus payload, which produced extremely loud static during two-way audio.

## User impact

This restores the speaker payload for Xiaomi cameras using the MISS/CS2 transport. The fix was verified end-to-end with `xiaomi.camera.083ac1` on go2rtc 1.9.14 through Scrypted and HomeKit; two-way audio works after applying this change.

Fixes #2175.

## Validation

- `go test ./pkg/xiaomi/miss/cs2`
- `go test ./pkg/xiaomi/miss/...`
- `go build -trimpath .`
- manual end-to-end test on `xiaomi.camera.083ac1`

`go test ./...` was also run on Windows; unrelated existing failures remain in FFmpeg expectations and platform/build-tag-dependent packages. The focused Xiaomi CS2 tests pass.
