### PR TITLE
rtsp: allow GET_PARAMETER as the session keepalive method

### DIFF
--- a/internal/rtsp/README.md
+++ b/internal/rtsp/README.md
@@ -42,6 +42,7 @@ Format: `rtsp...#{param1}#{param2}#{param3}`
 - Ignore audio - `#media=video` or ignore video - `#media=audio`
 - Ignore two-way audio API `#backchannel=0` - important for some glitchy cameras
 - Use WebSocket transport `#transport=ws...`
+- Use GET_PARAMETER keepalive `#keepalive=get_parameter` - for servers that answer OPTIONS but don't refresh the session on it
 
 ### RTSP over WebSocket
 

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -105,6 +105,9 @@ func rtspHandler(rawURL string) (core.Producer, error) {
 		conn.Media = query.Get("media")
 		conn.Timeout = core.Atoi(query.Get("timeout"))
 		conn.Transport = query.Get("transport")
+		if strings.EqualFold(query.Get("keepalive"), "get_parameter") {
+			conn.KeepaliveMethod = rtsp.KeepaliveGetParameter
+		}
 	}
 
 	if log.Trace().Enabled() {

--- a/pkg/rtsp/conn.go
+++ b/pkg/rtsp/conn.go
@@ -24,12 +24,15 @@ type Conn struct {
 	// public
 
 	Backchannel bool
-	Media       string
-	OnClose     func() error
-	PacketSize  uint16
-	SessionName string
-	Timeout     int
-	Transport   string // custom transport support, ex. RTSP over WebSocket
+	// KeepaliveMethod is the RTSP method used to refresh the session,
+	// not to be confused with the unexported keepalive interval below.
+	KeepaliveMethod KeepaliveMethod
+	Media           string
+	OnClose         func() error
+	PacketSize      uint16
+	SessionName     string
+	Timeout         int
+	Transport       string // custom transport support, ex. RTSP over WebSocket
 
 	URL *url.URL
 
@@ -54,16 +57,38 @@ type Conn struct {
 }
 
 const (
-	ProtoRTSP      = "RTSP/1.0"
-	MethodOptions  = "OPTIONS"
-	MethodSetup    = "SETUP"
-	MethodTeardown = "TEARDOWN"
-	MethodDescribe = "DESCRIBE"
-	MethodPlay     = "PLAY"
-	MethodPause    = "PAUSE"
-	MethodAnnounce = "ANNOUNCE"
-	MethodRecord   = "RECORD"
+	ProtoRTSP          = "RTSP/1.0"
+	MethodOptions      = "OPTIONS"
+	MethodGetParameter = "GET_PARAMETER"
+	MethodSetup        = "SETUP"
+	MethodTeardown     = "TEARDOWN"
+	MethodDescribe     = "DESCRIBE"
+	MethodPlay         = "PLAY"
+	MethodPause        = "PAUSE"
+	MethodAnnounce     = "ANNOUNCE"
+	MethodRecord       = "RECORD"
 )
+
+// KeepaliveMethod selects the RTSP method used to refresh the session.
+// RFC 2326 permits either OPTIONS or GET_PARAMETER, and some servers answer
+// 200 OK to OPTIONS without treating it as a refresh, letting the session
+// expire while the client believes it is alive.
+type KeepaliveMethod byte
+
+const (
+	// KeepaliveOptions refreshes the session with OPTIONS. This is the default.
+	KeepaliveOptions KeepaliveMethod = iota
+	// KeepaliveGetParameter refreshes the session with GET_PARAMETER.
+	KeepaliveGetParameter
+)
+
+// String returns the RTSP method name.
+func (m KeepaliveMethod) String() string {
+	if m == KeepaliveGetParameter {
+		return MethodGetParameter
+	}
+	return MethodOptions
+}
 
 type State byte
 
@@ -156,7 +181,7 @@ func (c *Conn) handleKeepalive(ctx context.Context, d time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			req := &tcp.Request{Method: MethodOptions, URL: c.URL}
+			req := &tcp.Request{Method: c.KeepaliveMethod.String(), URL: c.URL}
 			if err := c.WriteRequest(req); err != nil {
 				return
 			}

--- a/pkg/rtsp/keepalive_test.go
+++ b/pkg/rtsp/keepalive_test.go
@@ -1,0 +1,61 @@
+package rtsp
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeepaliveMethodString(t *testing.T) {
+	require.Equal(t, MethodOptions, KeepaliveOptions.String())
+	require.Equal(t, MethodGetParameter, KeepaliveGetParameter.String())
+	// zero value must keep the historic behaviour
+	var zero KeepaliveMethod
+	require.Equal(t, MethodOptions, zero.String())
+}
+
+// TestKeepaliveMethod checks the request the keepalive loop puts on the wire:
+// OPTIONS by default, GET_PARAMETER when the source asks for it. The ticker is
+// driven directly so the test doesn't wait on a real session timeout.
+func TestKeepaliveMethod(t *testing.T) {
+	tests := []struct {
+		name   string
+		method KeepaliveMethod
+		expect string
+	}{
+		{"default", KeepaliveOptions, MethodOptions},
+		{"get_parameter", KeepaliveGetParameter, MethodGetParameter},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			defer client.Close()
+			defer server.Close()
+
+			rawURL := "rtsp://localhost/stream"
+			u, err := url.Parse(rawURL)
+			require.Nil(t, err)
+
+			conn := NewClient(rawURL)
+			conn.URL = u
+			conn.conn = client
+			conn.KeepaliveMethod = test.method
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go conn.handleKeepalive(ctx, time.Millisecond)
+
+			require.Nil(t, server.SetReadDeadline(time.Now().Add(time.Second)))
+
+			line, err := bufio.NewReader(server).ReadString('\n')
+			require.Nil(t, err)
+			require.Equal(t, test.expect+" "+rawURL+" "+ProtoRTSP+"\r\n", line)
+		})
+	}
+}


### PR DESCRIPTION
*Drafted with AI assistance and reviewed line by line by me — I've written production Go, though not recently. Every measurement below was taken against my own hardware.*

## Problem

`MethodOptions` is a string constant:

```go
const MethodOptions = "OPTIONS"   // pkg/rtsp/conn.go
```

and before this change, `handleKeepalive` passed it straight through — no branch, no config field:

```go
req := &tcp.Request{Method: MethodOptions, URL: c.URL}
```

So the session keepalive was always `OPTIONS`.

## What the RFC actually says

RFC 2326 never uses the word "keepalive". What it does say:

- **§10.8 (GET_PARAMETER)** — *"GET_PARAMETER with no entity body may be used to test client or server liveness (\"ping\")."*
- **§10.1 (OPTIONS)** — *"An OPTIONS request may be issued at any time, e.g., if the client is about to try a nonstandard request. It does not influence server state."*
- **§12.37 (Session)** — the `timeout` parameter indicates *"how long the server is prepared to wait between RTSP commands before closing the session due to lack of activity"* (default 60 s).

§12.37 treats any RTSP command as activity, which is why `OPTIONS` works as a keepalive against most servers. But §10.1 states that `OPTIONS` does not influence server state, and a server implementing that literally will not count it. **`GET_PARAMETER` is the only method the RFC explicitly designates for liveness testing.**

Sending only `OPTIONS` is therefore a bet on the more lenient reading, and go2rtc has no way to discover when that bet has failed — a server that ignores it still replies `200 OK`.

## A server that only honours GET_PARAMETER

A Verint Nextiva S1816e-SR (`VVS RTSP Server`, firmware 2.5.2.6) implements the strict reading. Two independent facts:

**1. It supports `GET_PARAMETER`.** It lists the method in its `Public:` header, so sending it is an expected request rather than a workaround:

```
OPTIONS rtsp://<ip>:554/media/1/video/1 RTSP/1.0
->  RTSP/1.0 200 OK
    Public: OPTIONS, DESCRIBE, SETUP, TEARDOWN, PLAY, PAUSE, GET_PARAMETER, SET_PARAMETER
```

**2. Only `GET_PARAMETER` actually refreshes the session.** Measured with a minimal raw RTSP client, one variable changed per run, every keepalive carrying the `Session:` header:

| keepalive sent every 25–30 s | keepalive responses | stream survived |
|---|---|---|
| none | — | died at **167.7 s** |
| `OPTIONS` | `200 OK` ×4 | died at **144.9 s** |
| `OPTIONS` (repeat run) | not captured | died at **167.5 s** |
| **`GET_PARAMETER`** | `200 OK` ×10 | **survived the full 260 s test** |

**Sending `OPTIONS` is indistinguishable from sending nothing** — the session dies at ~145–168 s either way. And because every `OPTIONS` is answered `200 OK`, the client gets no signal that its keepalive is inert. It simply loses the stream every ~2.5 minutes and reconnects, forever.

The same comparison through go2rtc itself, same camera:

| | result |
|---|---|
| current behaviour (`OPTIONS`) | data stops ~t+125 s, `Handle()` returns `read tcp …:554: i/o timeout` |
| `keepalive=get_parameter` | 260 s of continuous RTP, 6879 packets, no reconnect |

Downstream cost while unfixed, monitored via `/api/streams` (`bytes_recv` resetting to zero marks a producer reconnect): **93 reconnects in 20 minutes** across six channels of this encoder, all dropping on the same tick every 150–166 s, ~5.5 s of video lost per cycle (~3.5 % of wall-clock).

## Change

Adds a `KeepaliveMethod` enum whose **zero value is the existing `OPTIONS` behaviour**, selectable per source:

```
rtsp://user:pass@host/path#keepalive=get_parameter
```

Sources that don't set it take the identical code path as before.

## Testing

- `go build ./...` and `go vet ./pkg/rtsp/ ./internal/rtsp/` clean
- `go test -race ./pkg/rtsp/` passes
- New `pkg/rtsp/keepalive_test.go` asserts the exact request line the keepalive loop puts on the wire for both enum values, and pins the zero value to `OPTIONS`. It drives the ticker directly over `net.Pipe`, so it adds **no wall-clock delay** (0.00 s) and needs no hardware.
- No regression against a Reolink camera, a neolink Baichuan bridge, or go2rtc's own RTSP server.

## Notes for review

- The `Method*` const block realignment is **gofmt**, not a hand edit — adding the longer `MethodGetParameter` name reflows the whole block. Reviewing with whitespace hidden shows the real change.
- I first tried **auto-detecting** `GET_PARAMETER` from the server's `Public:` header, by wiring up the (currently unused) `Options()` function into the handshake. It worked against the hardware but **broke `TestMissedControl`**, because it adds a request to the handshake that servers and tests don't expect. I backed it out in favour of the explicit option. Happy to revisit if you'd prefer detection over a flag.
- Adjacent, out of scope: go2rtc-as-server parses inbound `GET_PARAMETER` (`conn.go`, the `"GET_"` prefix case) but only auto-replies to `OPTIONS`, so a client using GET_PARAMETER keepalive against go2rtc gets no response.
