### PR TITLE
fix(h265): guard RepairAVCC against truncated AVCC packets

### DIFF
--- a/pkg/h265/avcc.go
+++ b/pkg/h265/avcc.go
@@ -16,6 +16,14 @@ func RepairAVCC(codec *core.Codec, handler core.HandlerFunc) core.HandlerFunc {
 	ps := h264.JoinNALU(vds, sps, pps)
 
 	return func(packet *rtp.Packet) {
+		// AVCC needs a four-byte length prefix followed by a NALU header.
+		// Some cameras intermittently emit an empty/truncated video packet.
+		// Dropping that packet keeps one malformed source from panicking the
+		// sender goroutine and terminating the whole go2rtc process.
+		if packet == nil || len(packet.Payload) < 5 {
+			return
+		}
+
 		switch NALUType(packet.Payload) {
 		case NALUTypeIFrame, NALUTypeIFrame2, NALUTypeIFrame3:
 			clone := *packet
@@ -31,7 +39,18 @@ func AVCCToCodec(avcc []byte) *core.Codec {
 	buf := bytes.NewBufferString("profile-id=1")
 
 	for {
-		size := 4 + int(binary.BigEndian.Uint32(avcc))
+		n := len(avcc)
+		if n < 5 {
+			break
+		}
+
+		naluSize := binary.BigEndian.Uint32(avcc)
+		// An H.265 NAL unit has a two-byte header. Reject zero-length,
+		// one-byte, and over-declared units before inspecting their type.
+		if naluSize < 2 || naluSize > uint32(n-4) {
+			break
+		}
+		size := 4 + int(naluSize)
 
 		switch NALUType(avcc) {
 		case NALUTypeVPS:
@@ -45,11 +64,7 @@ func AVCCToCodec(avcc []byte) *core.Codec {
 			buf.WriteString(base64.StdEncoding.EncodeToString(avcc[4:size]))
 		}
 
-		if size < len(avcc) {
-			avcc = avcc[size:]
-		} else {
-			break
-		}
+		avcc = avcc[size:]
 	}
 
 	return &core.Codec{

--- a/pkg/h265/h265_test.go
+++ b/pkg/h265/h265_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,4 +29,37 @@ func TestDecodeSPS2(t *testing.T) {
 	require.NotNil(t, sps)
 	require.Equal(t, uint16(640), sps.Width())
 	require.Equal(t, uint16(360), sps.Height())
+}
+
+func TestRepairAVCCDropsTruncatedPacket(t *testing.T) {
+	codec := &core.Codec{Name: core.CodecH265}
+	called := 0
+	handler := RepairAVCC(codec, func(*rtp.Packet) {
+		called++
+	})
+
+	handler(nil)
+	for size := 0; size < 5; size++ {
+		handler(&rtp.Packet{Payload: make([]byte, size)})
+	}
+	require.Zero(t, called)
+
+	// Two-byte H.265 IDR NALU with a four-byte AVCC length prefix.
+	handler(&rtp.Packet{Payload: []byte{0, 0, 0, 2, 0x26, 0x01}})
+	require.Equal(t, 1, called)
+}
+
+func TestAVCCToCodecDropsTruncatedPacket(t *testing.T) {
+	for _, avcc := range [][]byte{
+		nil,
+		{0, 0, 0, 0},
+		{0, 0, 0, 0, 0x40},
+		{0, 0, 0, 1, 0x40},
+		{0, 0, 0, 2, 0x40},
+	} {
+		require.NotPanics(t, func() {
+			codec := AVCCToCodec(avcc)
+			require.Equal(t, core.CodecH265, codec.Name)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- drop nil or truncated packets before H.265 `RepairAVCC` reads the NAL type
- validate AVCC NAL lengths before slicing in `AVCCToCodec`
- add regression coverage for nil, short, under-sized, and over-declared AVCC payloads

This prevents a malformed packet from one source from panicking the sender goroutine and terminating the entire go2rtc process.

## Validation

```text
go test ./pkg/h265
ok github.com/AlexxIT/go2rtc/pkg/h265
```

A diagnostic build ran three simultaneous Xiaomi Smart Camera 4K (`chuangmi.camera.079ac1`) H.265 sources for 3h 19m. It safely dropped 102 malformed packets from all three sources with zero panics or restarts after patched startup.

Fixes #2418

Related: #1652, #2082, #2234, #2255, #2280.
