### PR TITLE
fix ffmpeg binary path with spaces on Windows

### DIFF
--- a/pkg/ffmpeg/ffmpeg.go
+++ b/pkg/ffmpeg/ffmpeg.go
@@ -54,7 +54,15 @@ func (a *Args) HasFilters(filters ...string) bool {
 func (a *Args) String() string {
 	b := bytes.NewBuffer(make([]byte, 0, 512))
 
-	b.WriteString(a.Bin)
+	// quote binary path with spaces (ex. C:\Program Files\ffmpeg.exe),
+	// so shell.QuoteSplit keeps it as a single argument
+	if strings.Contains(a.Bin, " ") {
+		b.WriteByte('"')
+		b.WriteString(a.Bin)
+		b.WriteByte('"')
+	} else {
+		b.WriteString(a.Bin)
+	}
 
 	if a.Global != "" {
 		b.WriteByte(' ')

--- a/pkg/ffmpeg/ffmpeg_test.go
+++ b/pkg/ffmpeg/ffmpeg_test.go
@@ -1,0 +1,25 @@
+package ffmpeg
+
+import (
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/shell"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinWithSpaces(t *testing.T) {
+	args := Args{
+		Bin:    `C:\Program Files\Symcon\ffmpeg.exe`,
+		Global: "-hide_banner",
+		Input:  "-i rtsp://example.com",
+		Output: "-f mjpeg -",
+	}
+
+	s := args.String()
+	require.Equal(t, `"C:\Program Files\Symcon\ffmpeg.exe" -hide_banner -i rtsp://example.com -f mjpeg -`, s)
+
+	// shell.QuoteSplit is how internal/exec parses this string back
+	split := shell.QuoteSplit(s)
+	require.Equal(t, `C:\Program Files\Symcon\ffmpeg.exe`, split[0])
+	require.Equal(t, "-hide_banner", split[1])
+}


### PR DESCRIPTION
The ffmpeg source builds a flat command string ("exec:" + Args.String()) that internal/exec re-parses with shell.QuoteSplit. Since Args.String() wrote the binary path unquoted, a path containing spaces (for example C:\Program Files\ffmpeg\ffmpeg.exe) was split at the first space:

    [api.mjpeg] add consumer error=streams: exec: "C:\Program": executable file not found in %PATH%

Quote the path in Args.String() when it contains a space, the same way filters are already quoted, so QuoteSplit keeps it as one argument.

I tested and verified the fix on Windows and also added a small test.