### PR TITLE
Fix consumer leak in keyframe handler when client disconnects

### DIFF
--- a/internal/mjpeg/mjpeg.go
+++ b/internal/mjpeg/mjpeg.go
@@ -83,10 +83,23 @@ func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// handle when the client drops the connection, otherwise WriteTo below
+	// blocks until a keyframe arrives - which never happens for sources that
+	// don't emit one - leaking the consumer and holding the producer open
+	stopped := make(chan struct{})
+	go func() {
+		select {
+		case <-r.Context().Done():
+			_ = cons.Stop()
+		case <-stopped:
+		}
+	}()
+
 	once := &core.OnceBuffer{} // init and first frame
 	_, _ = cons.WriteTo(once)
 	b = once.Buffer()
 
+	close(stopped)
 	stream.RemoveConsumer(cons)
 
 	switch cons.CodecName() {

--- a/internal/mjpeg/mjpeg_test.go
+++ b/internal/mjpeg/mjpeg_test.go
@@ -1,0 +1,111 @@
+package mjpeg
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/internal/streams"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// silentProducer offers an H264 video track and then never sends anything, the
+// behaviour of a source that cannot produce a keyframe. HomeKit cameras hit this
+// when the accessory stops after a partial access unit.
+type silentProducer struct {
+	medias   []*core.Media
+	receiver *core.Receiver
+}
+
+func newSilentProducer() *silentProducer {
+	return &silentProducer{
+		medias: []*core.Media{
+			{
+				Kind:      core.KindVideo,
+				Direction: core.DirectionRecvonly,
+				Codecs: []*core.Codec{
+					{Name: core.CodecH264, ClockRate: 90000, PayloadType: 96},
+				},
+			},
+		},
+	}
+}
+
+func (p *silentProducer) GetMedias() []*core.Media { return p.medias }
+
+func (p *silentProducer) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver, error) {
+	if p.receiver == nil {
+		p.receiver = core.NewReceiver(media, codec)
+	}
+	return p.receiver, nil
+}
+
+func (p *silentProducer) Start() error { return nil }
+
+func (p *silentProducer) Stop() error {
+	if p.receiver != nil {
+		p.receiver.Close()
+	}
+	return nil
+}
+
+func consumerCount(t *testing.T, stream *streams.Stream) int {
+	t.Helper()
+
+	b, err := json.Marshal(stream)
+	require.NoError(t, err)
+
+	var info struct {
+		Consumers []json.RawMessage `json:"consumers"`
+	}
+	require.NoError(t, json.Unmarshal(b, &info))
+	return len(info.Consumers)
+}
+
+// handlerKeyframe blocks in cons.WriteTo waiting for a keyframe. If the client
+// goes away first - or the source never produces one - the handler must still
+// release the consumer, otherwise the stream keeps a consumer forever and
+// stopProducers never closes the upstream connection. On a battery powered
+// camera that pins the device awake indefinitely.
+func TestKeyframeHandlerReleasesConsumerOnClientDisconnect(t *testing.T) {
+	log = zerolog.Nop()
+
+	streams.HandleFunc("silent", func(string) (core.Producer, error) {
+		return newSilentProducer(), nil
+	})
+
+	stream, err := streams.New("test_silent_cam", "silent:cam")
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+	t.Cleanup(func() { streams.Delete("test_silent_cam") })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/api/frame.jpeg?src=test_silent_cam", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handlerKeyframe(rec, req)
+	}()
+
+	// the consumer attaches while waiting for a keyframe that never arrives
+	require.Eventually(t, func() bool {
+		return consumerCount(t, stream) == 1
+	}, 5*time.Second, 10*time.Millisecond, "consumer never attached")
+
+	// the client gives up, as Home Assistant does at its 10s image timeout
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after the client disconnected")
+	}
+
+	require.Equal(t, 0, consumerCount(t, stream), "consumer leaked after client disconnect")
+}


### PR DESCRIPTION
### Problem

`handlerKeyframe` blocks in `cons.WriteTo()` waiting for a keyframe, with no reference to the request context:

```go
if err := stream.AddConsumer(cons); err != nil { ... }

once := &core.OnceBuffer{}
_, _ = cons.WriteTo(once)   // blocks
b = once.Buffer()

stream.RemoveConsumer(cons) // never reached
```

If the HTTP client goes away first, or the source never produces a keyframe at all, `WriteTo` never returns and `RemoveConsumer` is never called. The consumer stays in the stream's list forever, so `stopProducers()` never fires and the upstream producer connection is held open indefinitely.

### Why it matters

Easy to hit with sources that can't reliably deliver a keyframe to a consumer attaching mid-GOP. Each aborted request then leaks another consumer, and because the leaked consumers keep the producer alive, the next request is slower — so the failure compounds.

On a battery powered camera the held-open session prevents the device from sleeping. I found this on an Aqara G410 doorbell, where Home Assistant's 10s image timeout aborted `/api/frame.jpeg` repeatedly and left the HomeKit session pinned open with `bytes_recv` static — the doorbell was streaming nothing and never sleeping, flattening the battery.

Observed on the same hardware, one aborted request each:

| | consumers afterwards |
|---|---|
| unpatched | 1, still attached 24s later |
| patched | 0 |

### Fix

Watch `r.Context()` and stop the consumer when the client drops, so `WriteTo` unblocks and the existing `RemoveConsumer` call is always reached. This mirrors the existing pattern in `internal/mp4/mp4.go`, comment included.

### Test

`TestKeyframeHandlerReleasesConsumerOnClientDisconnect` uses a producer that offers an H264 track then never sends anything, and cancels the request context while the handler waits. It fails against current master (handler never returns, consumer stays attached) and passes with the fix.

Refs #1733, #896
