### PR TITLE
Advertise HomeKit H264 parameter sets via sprop-parameter-sets

### DIFF
--- a/pkg/homekit/producer.go
+++ b/pkg/homekit/producer.go
@@ -1,10 +1,13 @@
 package homekit
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/rand"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -137,8 +140,26 @@ func (c *Client) Start() error {
 	deadline := time.NewTimer(core.ConnDeadline)
 
 	if videoTrack != nil {
+		// The accessory only sends SPS/PPS in-band alongside a keyframe, and
+		// keyframes are seconds apart (5s measured on an Aqara G410). HAP has no
+		// GOP control to shorten that. A consumer attaching between keyframes
+		// therefore receives slices referencing a PPS it never saw - ffmpeg
+		// reports "non-existing PPS 0 referenced" and gives up before the next
+		// keyframe, caching the stream as audio-only. Remember the parameter
+		// sets the first time they appear and advertise them out-of-band, so
+		// later consumers can decode from the moment they attach.
+		var sps, pps []byte
+
 		c.videoSession.OnReadRTP = func(packet *rtp.Packet) {
 			deadline.Reset(core.ConnDeadline)
+
+			if sps == nil || pps == nil {
+				collectParameterSets(packet.Payload, &sps, &pps)
+				if sps != nil && pps != nil {
+					videoTrack.Codec.FmtpLine = withParameterSets(videoTrack.Codec.FmtpLine, sps, pps)
+				}
+			}
+
 			videoTrack.WriteRTP(packet)
 			c.Recv += len(packet.Payload)
 		}
@@ -240,4 +261,70 @@ func timekeeper(handler core.HandlerFunc) core.HandlerFunc {
 
 		handler(packet)
 	}
+}
+
+// H264 NAL unit types needed to find parameter sets in an RTP payload.
+const (
+	naluSPS   = 7
+	naluPPS   = 8
+	naluSTAPA = 24
+)
+
+// collectParameterSets extracts H264 SPS/PPS from an RTP payload. Parameter sets
+// are small and arrive either as a single NAL or inside a STAP-A aggregate, so
+// fragmented (FU) payloads are not considered.
+func collectParameterSets(payload []byte, sps, pps *[]byte) {
+	if len(payload) == 0 {
+		return
+	}
+
+	if payload[0]&0x1F != naluSTAPA {
+		storeParameterSet(payload, sps, pps)
+		return
+	}
+
+	b := payload[1:]
+	for len(b) >= 2 {
+		size := int(binary.BigEndian.Uint16(b))
+		b = b[2:]
+		if size == 0 || size > len(b) {
+			return
+		}
+		storeParameterSet(b[:size], sps, pps)
+		b = b[size:]
+	}
+}
+
+func storeParameterSet(nalu []byte, sps, pps *[]byte) {
+	if len(nalu) == 0 {
+		return
+	}
+
+	switch nalu[0] & 0x1F {
+	case naluSPS:
+		if *sps == nil {
+			*sps = append([]byte(nil), nalu...)
+		}
+	case naluPPS:
+		if *pps == nil {
+			*pps = append([]byte(nil), nalu...)
+		}
+	}
+}
+
+// withParameterSets appends sprop-parameter-sets to an fmtp line. It has to go
+// last because h264.GetParameterSet reads up to the next ";" or end of string.
+func withParameterSets(fmtp string, sps, pps []byte) string {
+	if strings.Contains(fmtp, "sprop-parameter-sets=") {
+		return fmtp
+	}
+
+	ps := "sprop-parameter-sets=" +
+		base64.StdEncoding.EncodeToString(sps) + "," +
+		base64.StdEncoding.EncodeToString(pps)
+
+	if fmtp == "" {
+		return ps
+	}
+	return fmtp + ";" + ps
 }

--- a/pkg/homekit/producer_test.go
+++ b/pkg/homekit/producer_test.go
@@ -1,0 +1,165 @@
+package homekit
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/h264"
+	"github.com/stretchr/testify/require"
+)
+
+// Real parameter sets from an Aqara G410 doorbell, captured off the wire.
+var (
+	testSPS = []byte{
+		0x27, 0x4d, 0x00, 0x33, 0xe7, 0x40, 0x32, 0x01, 0x2f, 0x4d, 0x40, 0x40,
+		0x40, 0x7c, 0x00, 0x00, 0x03, 0x00, 0x04, 0x00, 0x00, 0x03, 0x00, 0xa0,
+		0xd4, 0x00, 0x1a, 0x08, 0x00, 0x01, 0x38, 0x60, 0xdf, 0xff, 0xc0, 0xa0,
+	}
+	testPPS = []byte{0x28, 0xee, 0x3c, 0x80}
+)
+
+// stapA builds a STAP-A aggregation packet, the form HomeKit accessories use to
+// deliver SPS and PPS ahead of a keyframe.
+func stapA(nalus ...[]byte) []byte {
+	b := []byte{24} // STAP-A
+	for _, nalu := range nalus {
+		b = binary.BigEndian.AppendUint16(b, uint16(len(nalu)))
+		b = append(b, nalu...)
+	}
+	return b
+}
+
+func TestCollectParameterSets(t *testing.T) {
+	tests := []struct {
+		name     string
+		payloads [][]byte
+		sps, pps []byte
+	}{
+		{
+			name:     "stap-a with both",
+			payloads: [][]byte{stapA(testSPS, testPPS)},
+			sps:      testSPS,
+			pps:      testPPS,
+		},
+		{
+			name:     "single nalu each",
+			payloads: [][]byte{testSPS, testPPS},
+			sps:      testSPS,
+			pps:      testPPS,
+		},
+		{
+			name:     "stap-a with unrelated nalu first",
+			payloads: [][]byte{stapA([]byte{0x09, 0x10}, testSPS, testPPS)},
+			sps:      testSPS,
+			pps:      testPPS,
+		},
+		{
+			name: "fragmented payloads ignored",
+			// FU-A carrying an IDR - parameter sets are never fragmented, and
+			// misreading the fragment header would yield garbage.
+			payloads: [][]byte{{28, 0x85, 0x00}},
+		},
+		{
+			name:     "keyframe only, no parameter sets",
+			payloads: [][]byte{{0x25, 0xb8, 0x20}},
+		},
+		{
+			name:     "empty payload",
+			payloads: [][]byte{{}},
+		},
+		{
+			name: "truncated stap-a does not panic",
+			// declares a 500 byte NAL but supplies 2
+			payloads: [][]byte{{24, 0x01, 0xf4, 0x67, 0x42}},
+		},
+		{
+			name:     "stap-a with zero length nalu",
+			payloads: [][]byte{{24, 0x00, 0x00, 0x67}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sps, pps []byte
+			for _, p := range tt.payloads {
+				collectParameterSets(p, &sps, &pps)
+			}
+			require.Equal(t, tt.sps, sps)
+			require.Equal(t, tt.pps, pps)
+		})
+	}
+}
+
+func TestCollectParameterSetsKeepsFirst(t *testing.T) {
+	var sps, pps []byte
+	collectParameterSets(stapA(testSPS, testPPS), &sps, &pps)
+
+	// A later keyframe repeats the parameter sets. They must not be replaced,
+	// otherwise the fmtp line would churn while consumers are attaching.
+	other := append([]byte(nil), testSPS...)
+	other[1] = 0x64
+	collectParameterSets(stapA(other, testPPS), &sps, &pps)
+
+	require.Equal(t, testSPS, sps)
+}
+
+func TestCollectParameterSetsCopiesPayload(t *testing.T) {
+	payload := stapA(testSPS, testPPS)
+
+	var sps, pps []byte
+	collectParameterSets(payload, &sps, &pps)
+
+	// RTP payload buffers are reused by the reader, so the parameter sets must
+	// be copied rather than aliased.
+	for i := range payload {
+		payload[i] = 0xff
+	}
+
+	require.Equal(t, testSPS, sps)
+	require.Equal(t, testPPS, pps)
+}
+
+func TestWithParameterSets(t *testing.T) {
+	const profile = "profile-level-id=4D0028"
+
+	fmtp := withParameterSets(profile, testSPS, testPPS)
+	require.Equal(t, profile+";sprop-parameter-sets=J00AM+dAMgEvTUBAQHwAAAMABAAAAwCg1AAaCAABOGDf/8Cg,KO48gA==", fmtp)
+
+	// already present - must not be appended twice
+	require.Equal(t, fmtp, withParameterSets(fmtp, testSPS, testPPS))
+
+	// no existing fmtp line
+	require.Equal(t, "sprop-parameter-sets=J00AM+dAMgEvTUBAQHwAAAMABAAAAwCg1AAaCAABOGDf/8Cg,KO48gA==",
+		withParameterSets("", testSPS, testPPS))
+}
+
+// The fmtp line only helps if the code that consumes it can read it back, so
+// assert the round trip through the h264 helper used by RTPDepay.
+func TestParameterSetsRoundTrip(t *testing.T) {
+	fmtp := withParameterSets("profile-level-id=4D0028", testSPS, testPPS)
+
+	sps, pps := h264.GetParameterSet(fmtp)
+	require.Equal(t, testSPS, sps)
+	require.Equal(t, testPPS, pps)
+}
+
+// Advertising the parameter sets changes what GetProfileLevelID reports, because
+// it prefers the SPS over the literal profile-level-id. The G410 negotiates
+// level 4.0 over HAP but its SPS says level 5.1, which is outside the set
+// GetProfileLevelID accepts, so it falls back to its own default of 4.1. This
+// is benign - 4.1 is what go2rtc already advertises for HLS - but it is a
+// visible change, so pin it.
+func TestProfileLevelIDDerivedFromSPS(t *testing.T) {
+	const profile = "profile-level-id=4D0028"
+
+	require.Equal(t, "4D0028", h264.GetProfileLevelID(profile))
+	require.Equal(t, "4D0029", h264.GetProfileLevelID(withParameterSets(profile, testSPS, testPPS)))
+}
+
+// Without the parameter sets, RTPDepay has nothing to prepend to an IDR - the
+// condition that left consumers unable to decode.
+func TestParameterSetsAbsentWithoutPatch(t *testing.T) {
+	sps, pps := h264.GetParameterSet("profile-level-id=4D0028")
+	require.Nil(t, sps)
+	require.Nil(t, pps)
+}


### PR DESCRIPTION
### Problem

`videoToMedia` builds the HomeKit H264 codec with only `profile-level-id`, so `sprop-parameter-sets` is never set:

```go
mediaCodec := &core.Codec{
    Name:      videoCodecs[codec.CodecType],
    ClockRate: 90000,
    FmtpLine:  "profile-level-id=" + profile,
}
```

`RTPDepay` then derives an empty parameter set from that fmtp line, so its "fix IFrame without SPS,PPS" path prepends nothing:

```go
sps, pps := GetParameterSet(codec.FmtpLine)
ps := JoinNALU(sps, pps)          // empty for HomeKit
...
case NALUTypeIFrame:
    buf = append(buf, ps...)      // no-op
```

HomeKit accessories send SPS/PPS in-band alongside a keyframe, and keyframes can be seconds apart — I measured exactly 5.00s intervals on an Aqara G410, and `SelectedStreamConfiguration` carries no GOP setting to shorten it. A consumer attaching between keyframes therefore receives slices referencing a PPS it never saw:

```
[h264] non-existing PPS 0 referenced
[h264] no frame!
```

ffmpeg gives up before the next keyframe arrives, so the stream gets probed as audio-only and every later consumer sees:

```
streams: codecs not matched: audio:AAC, audio:OPUS => video:JPEG, video:RAW, video:H264, video:H265
```

Because that result is cached, the camera stays broken until something reloads it. In Home Assistant it surfaces as a camera that intermittently renders a grey frame, and as `/api/frame.jpeg` hanging indefinitely.

### Fix

Remember the parameter sets the first time they appear on the video session and append them to the codec fmtp line, so consumers attaching later can decode immediately rather than waiting for the next keyframe.

### Results on an Aqara G410

The RTSP SDP now carries the parameter sets:

```
a=fmtp:96 profile-level-id=4D0028;sprop-parameter-sets=J00AM+dAMgEvTUBAQHwAAAMABAAAAwCg1AAaCAABOGDf/8Cg,KO48gA==
```

| | before | after |
|---|---|---|
| `ffprobe` runs | intermittent `width=0`, `non-existing PPS` | 5/5 report `h264 1600x1200` |
| `codecs not matched` | recurring | none |
| `/api/frame.jpeg` | hung indefinitely | returns |

### Two things worth flagging

**`GetProfileLevelID` output changes.** It prefers the SPS once `sprop-parameter-sets` is present. This camera negotiates level 4.0 over HAP but its SPS reports level 5.1, which is outside the set `GetProfileLevelID` accepts, so it falls back to its own default of 4.1 — `4D0028` becomes `4D0029`. Benign here (4.1 is already what's advertised for HLS) but it is a visible change, so there's a test pinning it.

**Possible data race.** The parameter sets are written on the SRTP read goroutine while consumers read `codec.FmtpLine` at attach time. It's a single write of an immutable string and matches existing looseness elsewhere, but `-race` would flag it. Happy to guard it if you'd prefer.

### Test

12 cases covering STAP-A and single-NAL extraction, fragmented payloads being ignored, malformed aggregates not panicking, first-seen sets winning, and the payload being copied rather than aliased. The one that matters is the round trip through `h264.GetParameterSet` — the fmtp line is only useful if `RTPDepay` can read it back.
