### PR TITLE
Mask HomeKit pairing key in API output and logs

### DIFF
--- a/internal/homekit/homekit.go
+++ b/internal/homekit/homekit.go
@@ -3,6 +3,7 @@ package homekit
 import (
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
@@ -10,6 +11,7 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/srtp"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
 	"github.com/AlexxIT/go2rtc/pkg/hap"
 	"github.com/AlexxIT/go2rtc/pkg/hap/camera"
 	"github.com/AlexxIT/go2rtc/pkg/homekit"
@@ -33,6 +35,17 @@ func Init() {
 	log = app.GetLogger("homekit")
 
 	streams.HandleFunc("homekit", streamHandler)
+
+	// Mask pairing keys for sources already present in the config. streamHandler
+	// only runs when a stream is first dialled, and the API will happily return
+	// the source URL before that happens.
+	for _, sources := range streams.GetAllSources() {
+		for _, source := range sources {
+			if strings.HasPrefix(source, "homekit") {
+				maskClientPrivate(source)
+			}
+		}
+	}
 
 	api.HandleFunc("api/homekit", apiHomekit)
 	api.HandleFunc("api/homekit/accessories", apiHomekitAccessories)
@@ -134,6 +147,13 @@ func streamHandler(rawURL string) (core.Producer, error) {
 	}
 
 	rawURL, rawQuery, _ := strings.Cut(rawURL, "#")
+
+	// A paired source URL carries the controller's long term private key, and
+	// the URL is echoed verbatim by the streams API and in log lines. Register
+	// the key so it is masked, otherwise anything able to reach the API can
+	// read it and pair itself against the accessory.
+	maskClientPrivate(rawURL)
+
 	client, err := homekit.Dial(rawURL, srtp.Server)
 	if client != nil && rawQuery != "" {
 		query := streams.ParseQuery(rawQuery)
@@ -143,6 +163,20 @@ func streamHandler(rawURL string) (core.Producer, error) {
 	}
 
 	return client, err
+}
+
+// maskClientPrivate registers the controller private key from a homekit source
+// URL with the credential masker. Only client_private is sensitive - device_id
+// and client_id are identifiers, and device_public is the accessory's public
+// key.
+func maskClientPrivate(rawURL string) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return
+	}
+	if key := u.Query().Get("client_private"); key != "" {
+		creds.AddSecret(key)
+	}
 }
 
 func resolve(host string) *server {

--- a/internal/homekit/homekit_test.go
+++ b/internal/homekit/homekit_test.go
@@ -1,0 +1,46 @@
+package homekit
+
+import (
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/creds"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaskClientPrivate(t *testing.T) {
+	const key = "f939d73d4147d82d243b21c343844ecf787508a41da684ce40fc4b5fd837ab93"
+	const rawURL = "homekit://192.168.1.104:34737?device_id=93:92:E5:A4:ED:F8" +
+		"&device_public=7e57eefed8282925c908c9806419c02b6914254867b265edbbb4c008" +
+		"&client_id=c13bf795-6e9b-b5ab-94f3-26cdf02174bb" +
+		"&client_private=" + key
+
+	// not registered yet, so it passes through untouched
+	require.Contains(t, creds.SecretString(rawURL), key)
+
+	maskClientPrivate(rawURL)
+
+	masked := creds.SecretString(rawURL)
+	require.NotContains(t, masked, key, "private key still present after masking")
+	require.Contains(t, masked, "client_private=***")
+
+	// identifiers and the accessory public key are not secrets and must survive,
+	// otherwise the API output becomes useless for diagnosing a stream
+	require.Contains(t, masked, "device_id=93:92:E5:A4:ED:F8")
+	require.Contains(t, masked, "client_id=c13bf795-6e9b-b5ab-94f3-26cdf02174bb")
+	require.Contains(t, masked, "device_public=7e57eefed8282925c908c9806419c02b6914254867b265edbbb4c008")
+}
+
+func TestMaskClientPrivateIgnoresJunk(t *testing.T) {
+	// must not panic or register an empty secret, which would mask everything
+	for _, s := range []string{
+		"",
+		"homekit://192.168.1.104:34737",
+		"homekit://192.168.1.104:34737?client_private=",
+		"://nonsense",
+	} {
+		maskClientPrivate(s)
+	}
+
+	const probe = "nothing-secret-here"
+	require.Equal(t, probe, creds.SecretString(probe))
+}


### PR DESCRIPTION
### Problem

A paired `homekit` source URL carries `client_private`, the controller's long term private key:

```
homekit://192.168.1.104:34737?device_id=…&device_public=…&client_id=…&client_private=<key>
```

The streams API returns producer URLs verbatim, so `GET /api/streams` hands that key to anything able to reach the API — no credentials required, since the API is unauthenticated by default. With it you can pair yourself against the accessory as a controller.

### Why the existing masking doesn't catch it

`creds.AddSecret` already feeds `SecretResponse` and `SecretWriter`, and de157eb1 (#2051) added a regex stripping URL userinfo:

```go
userinfoRegexp = regexp.MustCompile(`://[` + userinfo + `]+@`)
```

That covers `://user:pass@host`, but HomeKit credentials are query parameters, so the regex doesn't reach them. And the only caller of `AddSecret` outside the creds package is `internal/app/storage.go`, so source URL parameters were never registered.

### Fix

Register `client_private` with the masker, so it renders as `client_private=***` in API responses and log lines.

Registration happens in two places, deliberately:

- in `streamHandler`, when a stream is dialled
- at `Init`, for sources already present in the config

The second matters because `streamHandler` only runs on first use, and the API will return a source URL long before the stream has ever been dialled. `streams.Init` runs before `homekit.Init`, so `GetAllSources()` is populated by then.

Only `client_private` is registered. `device_id` and `client_id` are identifiers and `device_public` is the accessory's public key — masking those would make the API output useless for diagnosing a stream without protecting anything.

### Verified

On an Aqara G410, before and after:

```
before:  "url": "homekit://192.168.1.104:34737?…&client_private=f939d73d…"
after:   "url": "homekit://192.168.1.104:34737?…&client_private=***"
```

and zero occurrences of the raw key remaining in the go2rtc log.

### Tests

`TestMaskClientPrivate` asserts the key is masked while the identifiers and public key survive. `TestMaskClientPrivateIgnoresJunk` covers empty and malformed URLs, in particular that an empty `client_private=` is not registered — registering an empty secret would otherwise mask every string.
