### PR TITLE
homekit: fix streaming from Logitech Circle 2

### DIFF
--- a/pkg/hap/tlv8/tlv8.go
+++ b/pkg/hap/tlv8/tlv8.go
@@ -297,9 +297,12 @@ func unmarshalStruct(b []byte, value reflect.Value) error {
 func unmarshalValue(v []byte, value reflect.Value) error {
 	switch value.Kind() {
 	case reflect.Uint8:
-		if len(v) != 1 {
+		if len(v) < 1 {
 			return errors.New("tlv8: wrong size: " + value.Type().Name())
 		}
+		// some cameras (ex. Logitech Circle 2) encode byte values as uint16le
+		// (audio codec type `01 02 03 00`), so accept any size and take the
+		// low byte (TLV8 integers are little-endian)
 		value.SetUint(uint64(v[0]))
 
 	case reflect.Uint16:

--- a/pkg/homekit/helpers.go
+++ b/pkg/homekit/helpers.go
@@ -93,7 +93,10 @@ func trackToVideo(track *core.Receiver, video0 *camera.VideoCodecConfiguration, 
 			if (maxWidth > 0 && int(s.Width) > maxWidth) || (maxHeight > 0 && int(s.Height) > maxHeight) {
 				continue
 			}
-			if s.Width > attrs.Width || s.Height > attrs.Height {
+			// compare by area: with `Width > || Height >` a 1024x768 entry
+			// would beat 1280x720, and some cameras (Logi Circle 2) reject
+			// a 4:3 mode in SelectedStreamConfiguration with -70410
+			if int(s.Width)*int(s.Height) > int(attrs.Width)*int(attrs.Height) {
 				attrs = s
 			}
 		}

--- a/pkg/homekit/producer.go
+++ b/pkg/homekit/producer.go
@@ -70,19 +70,38 @@ func (c *Client) GetMedias() []*core.Media {
 		return nil
 	}
 
-	char := acc.GetCharacter(camera.TypeSupportedVideoStreamConfiguration)
-	if char == nil {
-		return nil
-	}
-	if err = char.ReadTLV8(&c.videoConfig); err != nil {
-		return nil
-	}
+	// Some cameras (ex. Logitech Circle 2) expose several RTP stream
+	// services and the first one is a stub: streaming status "unavailable"
+	// and a video config carrying no VideoAttrs. acc.GetCharacter() scans
+	// the whole accessory and returns that one. Pick the richest service
+	// that actually parses, like GetFreeStream() does on the stream side.
+	found := false
+	for _, srv := range acc.Services {
+		charVideo := srv.GetCharacter(camera.TypeSupportedVideoStreamConfiguration)
+		charAudio := srv.GetCharacter(camera.TypeSupportedAudioStreamConfiguration)
+		if charVideo == nil || charAudio == nil {
+			continue
+		}
 
-	char = acc.GetCharacter(camera.TypeSupportedAudioStreamConfiguration)
-	if char == nil {
-		return nil
+		var videoConfig camera.SupportedVideoStreamConfiguration
+		if charVideo.ReadTLV8(&videoConfig) != nil || len(videoConfig.Codecs) == 0 ||
+			len(videoConfig.Codecs[0].CodecParams) == 0 {
+			continue
+		}
+
+		var audioConfig camera.SupportedAudioStreamConfiguration
+		if charAudio.ReadTLV8(&audioConfig) != nil || len(audioConfig.Codecs) == 0 ||
+			len(audioConfig.Codecs[0].CodecParams) == 0 {
+			continue
+		}
+
+		if !found || len(videoConfig.Codecs[0].VideoAttrs) > len(c.videoConfig.Codecs[0].VideoAttrs) {
+			c.videoConfig = videoConfig
+			c.audioConfig = audioConfig
+			found = true
+		}
 	}
-	if err = char.ReadTLV8(&c.audioConfig); err != nil {
+	if !found {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes streaming from a **Logitech Circle 2** paired as a `homekit://` source. Three cumulative issues — fixing any one or two of them changes nothing.

Full investigation, TLV dumps and the variant sweep that isolated each field: #2322.

## The three fixes

**1. `pkg/hap/tlv8/tlv8.go` — decoder rejects a 2-byte codec type**

The Circle 2 encodes its audio `CodecType` as `01 02 03 00` — 2 bytes where the spec says 1. `unmarshalValue` enforced `len(v) != 1`, so `char.ReadTLV8(&c.audioConfig)` failed and `GetMedias()` returned `nil`. Silently, since it swallows every error return.

Accepting wider payloads and taking the low byte is consistent with TLV8 integers being little-endian.

**2. `pkg/homekit/producer.go` — the wrong streaming service is read**

The camera exposes two `00000110` services (two simultaneous clients) and the first is a stub:

| | iid | StreamingStatus | SupportedVideoStreamConfiguration |
|---|---|---|---|
| service 1 | 10 / 11 | `AQEC` → 2 (unavailable) | `AREBAQACDAEBAQIBAgMBAAQBAA==` — no `VideoAttrs` |
| service 2 | 17 / 18 | `AQEA` → 0 (available) | 92 bytes, `VideoAttrs` present |

`acc.GetCharacter()` scans the whole accessory and returns the first match — the stub, whose config carries no resolutions. This now picks the richest service that actually parses, mirroring what `GetFreeStream()` already does on the streaming side.

**3. `pkg/homekit/helpers.go` — the selected resolution is rejected by the firmware**

```go
if s.Width > attrs.Width || s.Height > attrs.Height {
```

With `||`, a 1024x768 entry beats 1280x720 by being taller. The Circle 2 rejects 4:3 in `SelectedRTPStreamConfiguration` with `-70410`. Comparing by area fixes it and should be closer to intent on any camera.

## Verification

Logi Circle 2, `md=V-R0008`, firmware 5.6.54, HomeKit-only firmware, Windows host, go2rtc as the sole HAP controller.

Before: `streams: unknown error` on every consumer (MSE, WebRTC, MJPEG, RTSP), no SRTP packets ever received.
After: stream works — 1.66 MB of MP4 in 20 s from `/api/stream.mp4`, H264 1280x720.

Each hypothesis was checked by driving the HAP characteristics directly from Python and sweeping one field at a time:

```
720p + opus + comfort-noise       -> ACCEPTED   StreamingStatus=1
1024x768 + opus + comfort-noise   -> REJECTED   -70410
720p + AAC-ELD + comfort-noise    -> REJECTED   -70410
720p + opus, no comfort-noise     -> REJECTED   -70410
720p + opus + CN, bitrate 1024    -> ACCEPTED
random SSRC instead of camera's   -> ACCEPTED   (not sensitive)
```

The patch was then rebuilt from these three files alone and re-verified, to make sure nothing else from the investigation was load-bearing. Notably **`#bitrate=` is not the fix here** (the answer given in #1180): 299K through 4096K, no effect on this camera.

## Notes

- `go vet ./pkg/homekit/ ./pkg/hap/tlv8/` is clean.
- `go test ./pkg/hap/tlv8/` fails on `TestVideoCodecParams` — but it **fails identically on unmodified `master`** (a separator byte, `00` vs `ff`, on the *marshal* side). Pre-existing and unrelated to these changes, which only touch *unmarshal*.
- Fix 1 relaxes a shared decoder path. It only widens what is accepted; no previously-valid payload changes meaning.
- Likely relevant to #1180 and #2425, though I could not confirm the Circle View shares the same root cause.

## Suggestion, not included here

`Client.PutCharacters()` in `pkg/hap/client.go` reads the HTTP response body and discards it. My camera replied `207 Multi-Status` with `{"aid":1,"iid":22,"status":-70410}` on every attempt, and nothing surfaced it at any log level — that response is what made all three bugs findable. Logging it (or returning it as an error) would make this whole class of camera rejection self-diagnosing. Happy to add it here or in a separate PR if you want it.
