### PR TITLE
fix(tutk): guard Session16 frame reassembly bounds

### DIFF
--- a/pkg/tutk/session16.go
+++ b/pkg/tutk/session16.go
@@ -180,7 +180,13 @@ func (s *Session16) RecvFrameData() (frameInfo, frameData []byte, err error) {
 
 func (s *Session16) SessionRead(chID byte, cmd []byte) int {
 	if chID != 0 {
+		if len(cmd) < cmdHdrSize {
+			return msgUnknown
+		}
 		return s.handleCh1(cmd)
+	}
+	if len(cmd) < cmdHdrSize {
+		return msgMediaLost
 	}
 
 	// 0  01030800  command + version
@@ -200,12 +206,12 @@ func (s *Session16) SessionRead(chID byte, cmd []byte) int {
 		case 0x03:
 			frameSeq := binary.LittleEndian.Uint16(cmd[4:])
 			chunkSeq := binary.LittleEndian.Uint16(cmd[12:])
+			payloadSize := binary.LittleEndian.Uint32(cmd[8:])
+			hdrSize := binary.LittleEndian.Uint16(cmd[14:])
 			if chunkSeq == 0 {
 				s.waitFSeq = frameSeq
 				s.waitCSeq = 0
 				s.waitData = s.waitData[:0]
-				payloadSize := binary.LittleEndian.Uint32(cmd[8:])
-				hdrSize := binary.LittleEndian.Uint16(cmd[14:])
 				s.waitSize = int(hdrSize) + int(payloadSize)
 			} else if frameSeq != s.waitFSeq || chunkSeq != s.waitCSeq {
 				s.waitCSeq = 0
@@ -220,13 +226,25 @@ func (s *Session16) SessionRead(chID byte, cmd []byte) int {
 
 			s.waitCSeq = 0
 
-			payloadSize := binary.LittleEndian.Uint32(cmd[8:])
+			// Every fragment repeats the frame layout. A malformed fragment can
+			// advertise a larger payload than the frame buffer assembled from the
+			// first fragment; never slice based on that untrusted value.
+			if int(payloadSize)+int(hdrSize) != s.waitSize ||
+				int(payloadSize) > len(s.waitData) ||
+				int(hdrSize) > len(s.waitData) ||
+				len(s.waitData) != s.waitSize {
+				s.waitData = s.waitData[:0]
+				return msgMediaLost
+			}
 			packetData[0] = bytes.Clone(s.waitData[payloadSize:])
 			packetData[1] = bytes.Clone(s.waitData[:payloadSize])
 
 		case 0x04:
 			data := cmd[24:]
 			hdrSize := binary.LittleEndian.Uint16(cmd[14:])
+			if int(hdrSize) > len(data) {
+				return msgMediaLost
+			}
 			packetData[0] = bytes.Clone(data[:hdrSize])
 			packetData[1] = bytes.Clone(data[hdrSize:])
 

--- a/pkg/tutk/session16_test.go
+++ b/pkg/tutk/session16_test.go
@@ -1,0 +1,40 @@
+package tutk
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestSession16RejectsFragmentWithPayloadPastBuffer(t *testing.T) {
+	s := NewSession16(nil, make([]byte, 8))
+	s.waitFSeq = 1
+	s.waitCSeq = 1
+	s.waitSize = 2048
+	s.waitData = make([]byte, 2048)
+
+	cmd := make([]byte, cmdHdrSize)
+	cmd[0] = 0x01
+	cmd[1] = 0x03
+	binary.LittleEndian.PutUint16(cmd[4:], 1)
+	binary.LittleEndian.PutUint32(cmd[8:], 2220)
+	binary.LittleEndian.PutUint16(cmd[12:], 1)
+
+	if got := s.SessionRead(0, cmd); got != msgMediaLost {
+		t.Fatalf("SessionRead() = %d, want msgMediaLost (%d)", got, msgMediaLost)
+	}
+}
+
+func TestSession16RejectsTruncatedMediaHeaders(t *testing.T) {
+	s := NewSession16(nil, make([]byte, 8))
+	if got := s.SessionRead(0, []byte{0x01, 0x03}); got != msgMediaLost {
+		t.Fatalf("SessionRead() = %d, want msgMediaLost (%d)", got, msgMediaLost)
+	}
+
+	cmd := make([]byte, cmdHdrSize)
+	cmd[0] = 0x01
+	cmd[1] = 0x04
+	binary.LittleEndian.PutUint16(cmd[14:], 1)
+	if got := s.SessionRead(0, cmd); got != msgMediaLost {
+		t.Fatalf("SessionRead() = %d, want msgMediaLost (%d)", got, msgMediaLost)
+	}
+}


### PR DESCRIPTION
Closes the accompanying malformed Session16 frame-packet issue.

- validate Session16 command/header lengths before indexing
- validate fragment payload and header sizes against the assembled buffer before slicing
- discard inconsistent frames as media loss
- add a regression test for a payload declaration beyond the assembled buffer

Tested: `go test ./pkg/tutk ./pkg/h265 ./pkg/xiaomi/miss/...`