### PR TITLE
Add Xiaomi Smart Doorbell 1S local streaming support

### DIFF
--- a/internal/xiaomi/xiaomi.go
+++ b/internal/xiaomi/xiaomi.go
@@ -212,6 +212,28 @@ func getVendorName(i byte) string {
 }
 
 func wakeUpCamera(url *url.URL) error {
+	if url.Query().Get("model") == "loock.cateye.v06" {
+		params := fmt.Sprintf(
+			`{"params":{"did":"%s","siid":7,"aiid":1,"in":[]}}`,
+			url.Query().Get("did"),
+		)
+		res, err := cloudUserRequest(url.User, "/miotspec/action", params)
+		if err != nil {
+			return err
+		}
+
+		var result struct {
+			Code int `json:"code"`
+		}
+		if err = json.Unmarshal(res, &result); err != nil {
+			return err
+		}
+		if result.Code != 0 {
+			return fmt.Errorf("xiaomi: start p2p stream: code %d", result.Code)
+		}
+		return nil
+	}
+
 	const params = `{"id":1,"method":"wakeup","params":{"video":"1"}}`
 	did := url.Query().Get("did")
 	_, err := cloudUserRequest(url.User, "/home/rpc/"+did, params)

--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -56,7 +56,12 @@ func NewClient(rawURL string) (*Client, error) {
 	switch s := query.Get("vendor"); s {
 	case "cs2":
 		if model == ModelLoockV6 {
-			conn, err = cs2.DialBroadcast(u.Host, query.Get("transport"))
+			var cs2Conn *cs2.Conn
+			cs2Conn, err = cs2.DialBroadcast(u.Host, query.Get("transport"))
+			if err == nil {
+				cs2Conn.AcceptCommandResponseAsAck()
+			}
+			conn = cs2Conn
 		} else {
 			conn, err = cs2.Dial(u.Host, query.Get("transport"))
 		}

--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -55,7 +55,11 @@ func NewClient(rawURL string) (*Client, error) {
 	var conn Conn
 	switch s := query.Get("vendor"); s {
 	case "cs2":
-		conn, err = cs2.Dial(u.Host, query.Get("transport"))
+		if model == ModelLoockV6 {
+			conn, err = cs2.DialBroadcast(u.Host, query.Get("transport"))
+		} else {
+			conn, err = cs2.Dial(u.Host, query.Get("transport"))
+		}
 	case "tutk":
 		conn, err = tutk.Dial(u.Host, query.Get("uid"), "Miss", "client")
 	default:
@@ -137,6 +141,7 @@ func (c *Client) WriteCommand(data []byte) error {
 const (
 	ModelDafang  = "isa.camera.df3"
 	ModelLoockV2 = "loock.cateye.v02"
+	ModelLoockV6 = "loock.cateye.v06"
 	ModelC200    = "chuangmi.camera.046c04"
 	ModelC300    = "chuangmi.camera.72ac1"
 	// ModelXiaofang looks like it has the same firmware as the ModelDafang.

--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -254,9 +254,10 @@ func (c *Client) ReadPacket() (*Packet, error) {
 	}
 
 	switch c.model {
-	case ModelDafang, ModelXiaofang, ModelLoockV2:
+	case ModelDafang, ModelXiaofang, ModelLoockV2, ModelLoockV6:
 		// Dafang has ts in sec
 		// LoockV2 has ts in msec for video, but zero ts for audio
+		// LoockV6 has zero ts for video and audio
 		pkt.Timestamp = uint64(time.Now().UnixMilli())
 	default:
 		pkt.Timestamp = binary.LittleEndian.Uint64(hdr[16:])

--- a/pkg/xiaomi/miss/cs2/conn.go
+++ b/pkg/xiaomi/miss/cs2/conn.go
@@ -51,6 +51,8 @@ type Conn struct {
 
 	cmdMu  sync.Mutex
 	cmdAck func()
+
+	cmdResponseAck atomic.Bool
 }
 
 const (
@@ -171,6 +173,9 @@ func (c *Conn) worker() {
 					// For UDP we should send ACK.
 					ack := []byte{magic, msgDrwAck, 0, 6, magicDrw, ch, 0, 1, seqHI, seqLO}
 					_, _ = c.Conn.Write(ack)
+					if ch == 0 && c.cmdResponseAck.Load() && c.cmdAck != nil {
+						c.cmdAck()
+					}
 				}
 			}
 
@@ -190,6 +195,10 @@ func (c *Conn) worker() {
 			fmt.Printf("%s: unknown msg: %x\n", "cs2", buf[:n])
 		}
 	}
+}
+
+func (c *Conn) AcceptCommandResponseAsAck() {
+	c.cmdResponseAck.Store(true)
 }
 
 func (c *Conn) Protocol() string {

--- a/pkg/xiaomi/miss/cs2/conn.go
+++ b/pkg/xiaomi/miss/cs2/conn.go
@@ -13,7 +13,15 @@ import (
 )
 
 func Dial(host, transport string) (*Conn, error) {
-	conn, err := handshake(host, transport)
+	return dial(host, transport, false)
+}
+
+func DialBroadcast(host, transport string) (*Conn, error) {
+	return dial(host, transport, true)
+}
+
+func dial(host, transport string, broadcast bool) (*Conn, error) {
+	conn, err := handshake(host, transport, broadcast)
 	if err != nil {
 		return nil, err
 	}
@@ -61,18 +69,28 @@ const (
 	msgCloseAck  = 0xF1
 )
 
-func handshake(host, transport string) (net.Conn, error) {
+func handshake(host, transport string, broadcast bool) (net.Conn, error) {
 	conn, err := newUDPConn(host, 32108)
 	if err != nil {
 		return nil, err
 	}
 
-	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	timeout := 5 * time.Second
+	if broadcast {
+		timeout = 20 * time.Second
+	}
+	_ = conn.SetDeadline(time.Now().Add(timeout))
 
 	req := []byte{magic, msgLanSearch, 0, 0}
-	res, err := conn.(*udpConn).WriteUntil(req, func(res []byte) bool {
+	ok := func(res []byte) bool {
 		return res[1] == msgPunchPkt
-	})
+	}
+	var res []byte
+	if broadcast {
+		res, err = conn.(*udpConn).searchUntil(req, ok)
+	} else {
+		res, err = conn.(*udpConn).WriteUntil(req, ok)
+	}
 	if err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -367,6 +385,86 @@ func (c *udpConn) WriteUntil(req []byte, ok func(res []byte) bool) ([]byte, erro
 			return buf[:n], nil
 		}
 	}
+}
+
+func (c *udpConn) searchUntil(req []byte, ok func(res []byte) bool) ([]byte, error) {
+	addrs := []*net.UDPAddr{
+		{IP: net.IPv4bcast, Port: c.addr.Port},
+		c.addr,
+	}
+	if addr := subnetBroadcast(c.addr.IP, c.addr.Port); addr != nil {
+		addrs = append([]*net.UDPAddr{addr}, addrs...)
+	}
+
+	write := func() error {
+		var firstErr error
+		sent := false
+		for _, addr := range addrs {
+			if _, err := c.UDPConn.WriteToUDP(req, addr); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+			} else {
+				sent = true
+			}
+		}
+		if sent {
+			return nil
+		}
+		return firstErr
+	}
+
+	var t *time.Timer
+	t = time.AfterFunc(1, func() {
+		if err := write(); err == nil && t != nil {
+			t.Reset(time.Second)
+		}
+	})
+	defer t.Stop()
+
+	buf := make([]byte, 1200)
+
+	for {
+		n, addr, err := c.UDPConn.ReadFromUDP(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		if !addr.IP.Equal(c.addr.IP) || n < 16 {
+			continue // skip messages from another IP
+		}
+
+		if ok(buf[:n]) {
+			c.addr.IP = bytes.Clone(addr.IP)
+			c.addr.Port = addr.Port
+			return buf[:n], nil
+		}
+	}
+}
+
+func subnetBroadcast(target net.IP, port int) *net.UDPAddr {
+	target = target.To4()
+	if target == nil {
+		return nil
+	}
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || len(ipNet.Mask) != net.IPv4len || !ipNet.Contains(target) {
+			continue
+		}
+
+		ip := make(net.IP, net.IPv4len)
+		for i := range ip {
+			ip[i] = target[i] | ^ipNet.Mask[i]
+		}
+		return &net.UDPAddr{IP: ip, Port: port}
+	}
+	return nil
 }
 
 func newTCPConn(addr string) (net.Conn, error) {


### PR DESCRIPTION
Disclaimer: This was generated by a mix of AI suggestions and human editing

## Summary

This adds local streaming support for the Xiaomi Smart Doorbell 1S / Loock
CatY (`loock.cateye.v06`) through the existing Xiaomi MISS/CS2 source. The
model is listed as CS2 in #1982, but the existing Loock wake and CS2 discovery
flow cannot start a stream from this firmware.

- Wake CatY with its MIoT `start-p2p-stream` action.
- Add a reusable CS2 broadcast-discovery dial path and select it for CatY.
- Accept a channel-0 command response as the command acknowledgement when
  CatY omits the separate CS2 DRW acknowledgement.
- Replace CatY's zero video and audio timestamps with the local receive time.

All model-specific behavior is gated on `loock.cateye.v06`. Other CS2 models
retain the existing unicast discovery path, five-second timeout, and command
acknowledgement behavior.

## Observed protocol flow

Packet captures from Xiaomi Home show this sequence:

1. Xiaomi Home calls `/miotspec/action` with service 7/action 1
   (`start-p2p-stream`). The legacy `/home/rpc/<did>` `wakeup` request used for
   older Loock models does not make CatY available for streaming.
2. The app broadcasts the CS2 LAN-search packet `F1 30 00 00` to UDP port
   32108. The new `DialBroadcast` path tries the matching subnet-directed
   broadcast, limited broadcast, and the original unicast address. Its longer
   20-second discovery deadline also applies only to CatY in this PR.
3. CatY responds with an `F1 41` punch packet. Echoing it produces `F1 42`
   (UDP ready), after which the existing MISS authentication continues.
4. CatY may return the channel-0 command response without a separate `F1 D1`
   DRW acknowledgement. On CatY connections only, receipt of that response
   also completes the command wait.
5. The existing MISS media path then carries HEVC video and PCMA audio.

`DialBroadcast` is kept generic so other models can opt into broadcast
discovery when verified. This PR selects it only for the tested CatY model.

## Related work

- #1982 lists `loock.cateye.v06` as a CS2 device. This PR supplies the wake and
  connection behavior observed on firmware `4.0.9_2313`.
- #2373 also takes a model-specific approach to doorbell wake methods. Its
  `midr.*` devices use a different legacy RPC; CatY v06 requires the MIoT
  action above.
- #2180 and #2181 concern `loock.cateye.v01`, which uses the legacy/TUTK path
  rather than the v06 CS2 path changed here.

## Validation

- `go test -race ./pkg/xiaomi/miss ./pkg/xiaomi/miss/cs2 ./internal/xiaomi`
- `go vet ./pkg/xiaomi/miss ./pkg/xiaomi/miss/cs2 ./internal/xiaomi`
- Hardware: `loock.cateye.v06`, firmware `4.0.9_2313`
- Live RTSP: HEVC Main, 1920x1080 at 15 fps; PCMA, 8 kHz mono
- FFmpeg decoded 272 video frames during a 20-second real-time test.
- Repeated forced-TCP negotiation produced only `F1 42` UDP-ready responses;
  this firmware did not offer `F1 43` TCP-ready.

## Known testing caveat

The existing MISS probe consumes packets while identifying codecs, so a new
RTSP consumer can initially receive dependent HEVC frames before the next
IDR. CatY sends VPS/SPS/PPS and an IDR about every two seconds: mpv discarded
the undecodable leading frames and synchronized normally, while VLC 3.0.23
could remain stuck on missing POC references even though audio continued.
Buffering or replaying probe packets was intentionally left out of this PR.

This change addresses only CatY protocol compatibility; there are observed and
unrelated reliability problems in the device firmware.

## AI disclosure

This change was developed with OpenAI Codex assistance. Protocol behavior was
derived from packet captures and validated against the physical device.
