### PR TITLE
ci: update to equals sign separator to resolve hardware.Dockerfile annotation warnings

### DIFF
--- a/docker/hardware.Dockerfile
+++ b/docker/hardware.Dockerfile
@@ -54,7 +54,7 @@ ENTRYPOINT ["/usr/bin/tini", "--"]
 VOLUME /config
 WORKDIR /config
 # https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(Native-GPU-Support)
-ENV NVIDIA_VISIBLE_DEVICES all
-ENV NVIDIA_DRIVER_CAPABILITIES compute,video,utility
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,video,utility
 
 CMD ["go2rtc", "-config", "/config/go2rtc.yaml"]


### PR DESCRIPTION
Update docker/hardware.Dockerfile legacy key/value format with whitespace separator to equals sign separator.