### PR TITLE
ci: bump workflow helper versions to resolve node20-forced-node24 annotation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,101 +15,101 @@ jobs:
     env: { CGO_ENABLED: 0 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with: { go-version: '1.25' }
 
       - name: Build go2rtc_win64
         env: { GOOS: windows, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_win64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_win64, path: go2rtc.exe }
 
       - name: Build go2rtc_win32
         env: { GOOS: windows, GOARCH: 386 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_win32
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_win32, path: go2rtc.exe }
 
       - name: Build go2rtc_win_arm64
         env: { GOOS: windows, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_win_arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_win_arm64, path: go2rtc.exe }
 
       - name: Build go2rtc_linux_amd64
         env: { GOOS: linux, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_amd64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_linux_amd64, path: go2rtc }
 
       - name: Build go2rtc_linux_i386
         env: { GOOS: linux, GOARCH: 386 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_i386
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_linux_i386, path: go2rtc }
 
       - name: Build go2rtc_linux_arm64
         env: { GOOS: linux, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_linux_arm64, path: go2rtc }
 
       - name: Build go2rtc_linux_arm
         env: { GOOS: linux, GOARCH: arm, GOARM: 7 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_arm
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_linux_arm, path: go2rtc }
 
       - name: Build go2rtc_linux_armv6
         env: { GOOS: linux, GOARCH: arm, GOARM: 6 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_armv6
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_linux_armv6, path: go2rtc }
 
       - name: Build go2rtc_linux_mipsel
         env: { GOOS: linux, GOARCH: mipsle }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_linux_mipsel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_linux_mipsel, path: go2rtc }
 
       - name: Build go2rtc_mac_amd64
         env: { GOOS: darwin, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_mac_amd64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_mac_amd64, path: go2rtc }
 
       - name: Build go2rtc_mac_arm64
         env: { GOOS: darwin, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_mac_arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_mac_arm64, path: go2rtc }
 
       - name: Build go2rtc_freebsd_amd64
         env: { GOOS: freebsd, GOARCH: amd64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_freebsd_amd64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_freebsd_amd64, path: go2rtc }
 
       - name: Build go2rtc_freebsd_arm64
         env: { GOOS: freebsd, GOARCH: arm64 }
         run: go build -ldflags "-s -w" -trimpath
       - name: Upload go2rtc_freebsd_arm64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: { name: go2rtc_freebsd_arm64, path: go2rtc }
 
   docker-master:
@@ -117,11 +117,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             name=${{ github.repository }},enable=${{ github.event.repository.fork == false }}
@@ -132,28 +132,28 @@ jobs:
             type=match,pattern=v(.*),group=1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: github.event_name == 'push' && github.event.repository.fork == false
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
@@ -174,11 +174,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta-hw
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             name=${{ github.repository }},enable=${{ github.event.repository.fork == false }}
@@ -192,28 +192,28 @@ jobs:
             type=match,pattern=v(.*),group=1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: github.event_name == 'push' && github.event.repository.fork == false
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/hardware.Dockerfile
@@ -229,11 +229,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta-rk
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             name=${{ github.repository }},enable=${{ github.event.repository.fork == false }}
@@ -247,28 +247,28 @@ jobs:
             type=match,pattern=v(.*),group=1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: github.event_name == 'push' && github.event.repository.fork == false
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/rockchip.Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       GOARCH: ${{ matrix.arch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.24'
 
@@ -70,13 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build and push Hardware
         if: matrix.platform == 'amd64'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/hardware.Dockerfile


### PR DESCRIPTION
Node.js 20 is deprecated. Update the following actions targeting Node.js 20 and forced to run on Node.js 24:

* actions/checkout@v4 => v7
* docker/build-push-action@v5 => v7
* docker/login-action@v3 => v4
* docker/metadata-action@v5 => v6
* docker/setup-buildx-action@v3 => v4
* docker/setup-qemu-action@v3 => v4
* actions/setup-go@v5 => v7
* actions/upload-artifact@v4 => v7

Additionally update the test gh actions as above.