### PR TITLE
fix(hap): HAP plumbing gaps blocking HomeKit Secure Video spec support

### DIFF
--- a/internal/homekit/server.go
+++ b/internal/homekit/server.go
@@ -257,20 +257,20 @@ func (s *server) GetCharacteristic(conn net.Conn, aid uint8, iid uint64) any {
 	return char.Value
 }
 
-func (s *server) SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value any) {
+func (s *server) SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value any) (any, int) {
 	log.Trace().Str("stream", s.stream).Msgf("[homekit] set char aid=%d iid=0x%x value=%v", aid, iid, value)
 
 	char := s.accessory.GetCharacterByID(iid)
 	if char == nil {
 		log.Warn().Msgf("[homekit] set unknown characteristic: %d", iid)
-		return
+		return nil, hap.StatusResourceNotExist
 	}
 
 	switch char.Type {
 	case camera.TypeSetupEndpoints:
 		var offer camera.SetupEndpointsRequest
 		if err := tlv8.UnmarshalBase64(value, &offer); err != nil {
-			return
+			return nil, hap.StatusInvalidValue
 		}
 
 		consumer := homekit.NewConsumer(conn, srtp2.Server)
@@ -280,18 +280,20 @@ func (s *server) SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value a
 	case camera.TypeSelectedStreamConfiguration:
 		var conf camera.SelectedStreamConfiguration
 		if err := tlv8.UnmarshalBase64(value, &conf); err != nil {
-			return
+			return nil, hap.StatusInvalidValue
 		}
 
 		log.Trace().Str("stream", s.stream).Msgf("[homekit] stream id=%x cmd=%d", conf.Control.SessionID, conf.Control.Command)
 
 		switch conf.Control.Command {
 		case camera.SessionCommandEnd:
+			// ending an unknown session stays a success so a repeated
+			// teardown is idempotent
 			for _, consumer := range s.conns {
 				if consumer, ok := consumer.(*homekit.Consumer); ok {
 					if consumer.SessionID() == conf.Control.SessionID {
 						_ = consumer.Stop()
-						return
+						return nil, hap.StatusSuccess
 					}
 				}
 			}
@@ -299,19 +301,20 @@ func (s *server) SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value a
 		case camera.SessionCommandStart:
 			consumer := s.consumer
 			if consumer == nil {
-				return
+				// start without a preceding Setup Endpoints write
+				return nil, hap.StatusInvalidValue
 			}
 
 			if !consumer.SetConfig(&conf) {
 				log.Warn().Msgf("[homekit] wrong config")
-				return
+				return nil, hap.StatusInvalidValue
 			}
 
 			s.AddConn(consumer)
 
 			stream := streams.Get(s.stream)
 			if err := stream.AddConsumer(consumer); err != nil {
-				return
+				return nil, hap.StatusResourceBusy
 			}
 
 			go func() {
@@ -322,6 +325,8 @@ func (s *server) SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value a
 			}()
 		}
 	}
+
+	return nil, hap.StatusSuccess
 }
 
 func (s *server) GetImage(conn net.Conn, width, height int) []byte {

--- a/pkg/hap/accessory.go
+++ b/pkg/hap/accessory.go
@@ -26,6 +26,11 @@ var PRPW = []string{"pr", "pw"}
 var EVPRPW = []string{"ev", "pr", "pw"}
 var EVPR = []string{"ev", "pr"}
 
+// WR is a write response characteristic: the controller sets "r" in the write
+// request and reads the result back from the same response.
+var WR = []string{"pr", "pw", "wr"}
+var EVWR = []string{"ev", "pr", "pw", "wr"}
+
 type Accessory struct {
 	AID      uint8      `json:"aid"` // 150 unique accessories per bridge
 	Services []*Service `json:"services"`

--- a/pkg/hap/accessory.go
+++ b/pkg/hap/accessory.go
@@ -31,34 +31,58 @@ type Accessory struct {
 	Services []*Service `json:"services"`
 }
 
-func (a *Accessory) InitIID() {
-	serviceN := map[string]byte{}
-	for _, service := range a.Services {
-		if len(service.Type) > 3 {
-			panic(service.Type)
-		}
+// minLegacyIID is the smallest IID the positional ANSSSCCC layout can produce:
+// AID and the service instance are both at least 1, and the smallest service
+// type in use is two hex digits. Sequentially allocated IIDs are counted up
+// from 1 and so can never reach it, which is what lets both schemes coexist in
+// one accessory.
+const minLegacyIID = 0x11000000
 
+// InitIID assigns instance IDs. Types of three hex digits or fewer keep the
+// positional layout go2rtc has always published, because controllers cache the
+// accessory database and renumbering invalidates every existing pairing. The
+// four hex digit types added by the HomeKit Secure Video open source spec do
+// not fit that layout and are numbered sequentially instead, so adding them to
+// an accessory leaves the IIDs of its existing services untouched.
+func (a *Accessory) InitIID() {
+	var seq uint64
+	serviceN := map[string]byte{}
+
+	for _, service := range a.Services {
 		n := serviceN[service.Type] + 1
 		serviceN[service.Type] = n
 
-		if n > 15 {
-			panic(n)
+		legacy := fitsLegacyIID(service.Type) && n <= 15
+		if legacy {
+			// ServiceID = ANSSS000
+			s := fmt.Sprintf("%x%x%03s000", a.AID, n, service.Type)
+			service.IID, _ = strconv.ParseUint(s, 16, 64)
+		} else {
+			seq++
+			service.IID = seq
 		}
-
-		// ServiceID   = ANSSS000
-		s := fmt.Sprintf("%x%x%03s000", a.AID, n, service.Type)
-		service.IID, _ = strconv.ParseUint(s, 16, 64)
 
 		for _, character := range service.Characters {
-			if len(character.Type) > 3 {
-				panic(character.Type)
+			// A sequentially numbered service has no positional base to offset
+			// its characteristics from, so they follow it.
+			if legacy && fitsLegacyIID(character.Type) {
+				// CharacterID = ANSSSCCC
+				character.IID, _ = strconv.ParseUint(character.Type, 16, 64)
+				character.IID += service.IID
+			} else {
+				seq++
+				character.IID = seq
 			}
-
-			// CharacterID = ANSSSCCC
-			character.IID, _ = strconv.ParseUint(character.Type, 16, 64)
-			character.IID += service.IID
 		}
 	}
+
+	if seq >= minLegacyIID {
+		panic("hap: too many sequential IIDs")
+	}
+}
+
+func fitsLegacyIID(typ string) bool {
+	return len(typ) <= 3
 }
 
 func (a *Accessory) GetService(servType string) *Service {

--- a/pkg/hap/accessory_test.go
+++ b/pkg/hap/accessory_test.go
@@ -1,0 +1,185 @@
+package hap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLegacyIID pins the IIDs of the accessory shape go2rtc has always
+// published. Controllers cache the accessory database, so these values must
+// not change or every existing pairing is invalidated.
+func TestLegacyIID(t *testing.T) {
+	acc := &Accessory{
+		AID: DeviceAID,
+		Services: []*Service{
+			ServiceAccessoryInformation("manuf", "model", "name", "serial", "firmware"),
+			{
+				Type: "110",
+				Characters: []*Character{
+					{Type: "120"},
+					{Type: "114"},
+					{Type: "115"},
+					{Type: "116"},
+					{Type: "B0"},
+					{Type: "117"},
+					{Type: "118"},
+				},
+			},
+			{
+				Type:       "112",
+				Characters: []*Character{{Type: "11A"}},
+			},
+		},
+	}
+	acc.InitIID()
+
+	require.Equal(t, uint64(0x1103E000), acc.Services[0].IID)
+	require.Equal(t, uint64(0x1103E014), acc.Services[0].Characters[0].IID)
+	require.Equal(t, uint64(0x1103E052), acc.Services[0].Characters[5].IID)
+
+	require.Equal(t, uint64(0x11110000), acc.Services[1].IID)
+	require.Equal(t, uint64(0x11110120), acc.Services[1].Characters[0].IID)
+	require.Equal(t, uint64(0x11110118), acc.Services[1].Characters[6].IID)
+
+	require.Equal(t, uint64(0x11112000), acc.Services[2].IID)
+	require.Equal(t, uint64(0x1111211A), acc.Services[2].Characters[0].IID)
+}
+
+// TestSpecIID covers the services added by the HomeKit Secure Video open
+// source spec. Their types are four hex digits wide, which the legacy
+// positional layout cannot encode.
+func TestSpecIID(t *testing.T) {
+	acc := &Accessory{
+		AID: DeviceAID,
+		Services: []*Service{
+			ServiceAccessoryInformation("manuf", "model", "name", "serial", "firmware"),
+			{
+				Type: "8033", // camera-webrtc-stream-management
+				Characters: []*Character{
+					{Type: "8053"}, // webrtc-solicit-offer
+					{Type: "8054"}, // webrtc-provide-answer
+					{Type: "8059"}, // webrtc-supported-video-stream-tiers
+				},
+			},
+			{
+				Type: "8031", // camera-multi-tier-rtp-stream-management
+				Characters: []*Character{
+					{Type: "8043"}, // supported-video-stream-tiers
+					{Type: "805B"}, // sensor-uuid
+				},
+			},
+		},
+	}
+
+	require.NotPanics(t, acc.InitIID)
+
+	seen := map[uint64]string{}
+	for _, service := range acc.Services {
+		require.NotZero(t, service.IID)
+
+		if prev, ok := seen[service.IID]; ok {
+			t.Fatalf("service %s reuses IID %d of %s", service.Type, service.IID, prev)
+		}
+		seen[service.IID] = service.Type
+
+		for _, character := range service.Characters {
+			require.NotZero(t, character.IID)
+
+			if prev, ok := seen[character.IID]; ok {
+				t.Fatalf("characteristic %s reuses IID %d of %s", character.Type, character.IID, prev)
+			}
+			seen[character.IID] = character.Type
+		}
+	}
+
+	// 3 services + 6 accessory information + 5 spec characteristics
+	require.Len(t, seen, 14)
+}
+
+// TestGetCharacterByID guards the lookup used to dispatch reads and writes,
+// which relies only on IID uniqueness.
+func TestGetCharacterByID(t *testing.T) {
+	acc := &Accessory{
+		AID: DeviceAID,
+		Services: []*Service{
+			{Type: "8033", Characters: []*Character{{Type: "8053"}, {Type: "8054"}}},
+		},
+	}
+	acc.InitIID()
+
+	char := acc.Services[0].Characters[1]
+	require.Equal(t, char, acc.GetCharacterByID(char.IID))
+	require.Nil(t, acc.GetCharacterByID(0))
+}
+
+// TestMixedIID is the upgrade path: enabling the HomeKit Secure Video services
+// on an accessory that is already paired must not move the IIDs of the
+// services it already had, or every controller's cached database is stale.
+func TestMixedIID(t *testing.T) {
+	legacy := func() []*Service {
+		return []*Service{
+			ServiceAccessoryInformation("manuf", "model", "name", "serial", "firmware"),
+			{Type: "110", Characters: []*Character{{Type: "120"}, {Type: "118"}}},
+			{Type: "112", Characters: []*Character{{Type: "11A"}}},
+		}
+	}
+
+	before := &Accessory{AID: DeviceAID, Services: legacy()}
+	before.InitIID()
+
+	after := &Accessory{AID: DeviceAID, Services: append(legacy(), &Service{
+		Type: "8033",
+		Characters: []*Character{
+			{Type: "8053"},
+			{Type: "8054"},
+		},
+	})}
+	after.InitIID()
+
+	for i, service := range before.Services {
+		require.Equal(t, service.IID, after.Services[i].IID, "service %s moved", service.Type)
+
+		for j, character := range service.Characters {
+			require.Equal(
+				t, character.IID, after.Services[i].Characters[j].IID,
+				"characteristic %s moved", character.Type,
+			)
+		}
+	}
+
+	// the spec service and its characteristics are numbered below every
+	// possible positional IID, so they cannot collide with the legacy ones
+	spec := after.Services[len(after.Services)-1]
+	require.Equal(t, uint64(1), spec.IID)
+	require.Equal(t, uint64(2), spec.Characters[0].IID)
+	require.Equal(t, uint64(3), spec.Characters[1].IID)
+
+	seen := map[uint64]bool{}
+	for _, service := range after.Services {
+		require.Less(t, spec.Characters[1].IID, uint64(minLegacyIID))
+		require.False(t, seen[service.IID])
+		seen[service.IID] = true
+
+		for _, character := range service.Characters {
+			require.False(t, seen[character.IID], "IID %d reused", character.IID)
+			seen[character.IID] = true
+		}
+	}
+}
+
+// TestSpecCharacterOnLegacyService covers a four hex digit characteristic added
+// to a service that keeps its positional IID.
+func TestSpecCharacterOnLegacyService(t *testing.T) {
+	acc := &Accessory{
+		AID: DeviceAID,
+		Services: []*Service{
+			{Type: "110", Characters: []*Character{{Type: "120"}, {Type: "8041"}}},
+		},
+	}
+	acc.InitIID()
+
+	require.Equal(t, uint64(0x11110000), acc.Services[0].IID)
+	require.Equal(t, uint64(0x11110120), acc.Services[0].Characters[0].IID)
+	require.Equal(t, uint64(1), acc.Services[0].Characters[1].IID)
+}

--- a/pkg/hap/camera/accessory_test.go
+++ b/pkg/hap/camera/accessory_test.go
@@ -2,7 +2,6 @@ package camera
 
 import (
 	"encoding/base64"
-	"strings"
 	"testing"
 
 	"github.com/AlexxIT/go2rtc/pkg/hap"
@@ -10,11 +9,11 @@ import (
 )
 
 func TestNilCharacter(t *testing.T) {
-	var res SetupEndpoints
+	var res SetupEndpointsResponse
 	char := &hap.Character{}
 	err := char.ReadTLV8(&res)
-	require.NotNil(t, err)
-	require.NotNil(t, strings.Contains(err.Error(), "can't read value"))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "can't read value")
 }
 
 type testTLV8 struct {

--- a/pkg/hap/character.go
+++ b/pkg/hap/character.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/AlexxIT/go2rtc/pkg/hap/tlv8"
 )
@@ -30,10 +31,13 @@ type Character struct {
 	//ValidVal []any  `json:"valid-values,omitempty"`
 
 	listeners map[io.Writer]bool
+	mu        sync.Mutex
 }
 
 func (c *Character) AddListener(w io.Writer) {
-	// TODO: sync.Mutex
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.listeners == nil {
 		c.listeners = map[io.Writer]bool{}
 	}
@@ -41,6 +45,9 @@ func (c *Character) AddListener(w io.Writer) {
 }
 
 func (c *Character) RemoveListener(w io.Writer) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	delete(c.listeners, w)
 
 	if len(c.listeners) == 0 {
@@ -49,7 +56,19 @@ func (c *Character) RemoveListener(w io.Writer) {
 }
 
 func (c *Character) NotifyListeners(ignore io.Writer) error {
-	if c.listeners == nil {
+	// snapshot the listeners so no lock is held while writing to a connection:
+	// a slow peer would otherwise block every subscribe and unsubscribe, and a
+	// writer that unsubscribes itself would deadlock
+	c.mu.Lock()
+	listeners := make([]io.Writer, 0, len(c.listeners))
+	for w := range c.listeners {
+		if w != ignore {
+			listeners = append(listeners, w)
+		}
+	}
+	c.mu.Unlock()
+
+	if len(listeners) == 0 {
 		return nil
 	}
 
@@ -58,10 +77,7 @@ func (c *Character) NotifyListeners(ignore io.Writer) error {
 		return err
 	}
 
-	for w := range c.listeners {
-		if w == ignore {
-			continue
-		}
+	for _, w := range listeners {
 		if _, err = w.Write(data); err != nil {
 			// error not a problem - just remove listener
 			c.RemoveListener(w)

--- a/pkg/hap/hds/hds_test.go
+++ b/pkg/hap/hds/hds_test.go
@@ -13,7 +13,7 @@ func TestEncryption(t *testing.T) {
 	key := []byte(core.RandString(16, 0))
 	salt := core.RandString(32, 0)
 
-	c, err := Client(nil, key, salt, true)
+	c, err := NewConn(nil, key, salt, true)
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
@@ -23,7 +23,7 @@ func TestEncryption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, n)
 
-	c, err = Client(nil, key, salt, false)
+	c, err = NewConn(nil, key, salt, false)
 	c.rd = bufio.NewReader(buf)
 	require.NoError(t, err)
 

--- a/pkg/hap/helpers.go
+++ b/pkg/hap/helpers.go
@@ -53,6 +53,15 @@ const (
 
 	PermissionUser  = 0
 	PermissionAdmin = 1
+
+	// HAP status codes for characteristic reads and writes
+	StatusSuccess               = 0
+	StatusInsufficientPrivilege = -70401
+	StatusResourceBusy          = -70403
+	StatusReadOnly              = -70404
+	StatusWriteOnly             = -70405
+	StatusResourceNotExist      = -70409
+	StatusInvalidValue          = -70410
 )
 
 const DeviceAID = 1 // TODO: fix someday

--- a/pkg/hap/tlv8/tlv8.go
+++ b/pkg/hap/tlv8/tlv8.go
@@ -122,25 +122,24 @@ func appendValue(b []byte, tag byte, value reflect.Value) ([]byte, error) {
 		v := math.Float32bits(float32(value.Float()))
 		return append(b, tag, 4, byte(v), byte(v>>8), byte(v>>16), byte(v>>24)), nil
 
-	case reflect.String:
-		v := value.String()
-		l := len(v) // support "big" string
-		for ; l > 255; l -= 255 {
-			b = append(b, tag, 255)
-			b = append(b, v[:255]...)
-			v = v[255:]
+	case reflect.Bool:
+		var v byte
+		if value.Bool() {
+			v = 1
 		}
-		b = append(b, tag, byte(l))
-		return append(b, v...), nil
+		return append(b, tag, 1, v), nil
+
+	case reflect.String:
+		return appendPayload(b, tag, []byte(value.String())), nil
 
 	case reflect.Array:
 		if value.Type().Elem().Kind() == reflect.Uint8 {
 			n := value.Len()
-			b = append(b, tag, byte(n))
+			v := make([]byte, n)
 			for i := 0; i < n; i++ {
-				b = append(b, byte(value.Index(i).Uint()))
+				v[i] = byte(value.Index(i).Uint())
 			}
-			return b, nil
+			return appendPayload(b, tag, v), nil
 		}
 
 	case reflect.Slice:
@@ -155,16 +154,35 @@ func appendValue(b []byte, tag byte, value reflect.Value) ([]byte, error) {
 		return b, nil
 
 	case reflect.Struct:
-		b = append(b, tag, 0)
-		i := len(b)
-		if b, err = appendStruct(b, value); err != nil {
+		v, err := appendStruct(nil, value)
+		if err != nil {
 			return nil, err
 		}
-		b[i-1] = byte(len(b) - i) // set struct size
-		return b, nil
+		return appendPayload(b, tag, v), nil
 	}
 
 	return nil, errors.New("tlv8: not implemented: " + value.Kind().String())
+}
+
+// appendPayload writes v as one or more TLVs sharing the same tag, splitting
+// payloads over 255 bytes into consecutive fragments. Unmarshal reassembles
+// them by concatenating same-tag TLVs of length 255.
+//
+// A payload whose length is an exact non-zero multiple of 255 ends on a full
+// fragment, so a reader cannot tell it ended except by running out of data.
+// HAP terminates those with a zero-length TLV, but this codec already reads a
+// zero-length TLV as a list separator, so such a value is only unambiguous as
+// the last item of its list. This matches how strings have always been encoded
+// here (see TestBytes, which round-trips exactly 255 bytes).
+func appendPayload(b []byte, tag byte, v []byte) []byte {
+	l := len(v)
+	for ; l > 255; l -= 255 {
+		b = append(b, tag, 255)
+		b = append(b, v[:255]...)
+		v = v[255:]
+	}
+	b = append(b, tag, byte(l))
+	return append(b, v...)
 }
 
 func UnmarshalBase64(in any, out any) error {
@@ -298,6 +316,12 @@ func unmarshalStruct(b []byte, value reflect.Value) error {
 
 func unmarshalValue(v []byte, value reflect.Value) error {
 	switch value.Kind() {
+	case reflect.Bool:
+		if len(v) != 1 {
+			return errors.New("tlv8: wrong size: " + value.Type().Name())
+		}
+		value.SetBool(v[0] != 0)
+
 	case reflect.Uint8:
 		if len(v) != 1 {
 			return errors.New("tlv8: wrong size: " + value.Type().Name())

--- a/pkg/hap/tlv8/tlv8.go
+++ b/pkg/hap/tlv8/tlv8.go
@@ -56,8 +56,10 @@ func Marshal(v any) ([]byte, error) {
 }
 
 // separator the most confusing meaning in the documentation.
-// It can have a value of 0x00 or 0xFF or even 0x05.
-const separator = 0xFF
+// Readers must accept any zero-length TLV as a separator, but real
+// implementations all write 0x00: see the captured fixtures from Aqara G3,
+// Homebridge and Scrypted in pkg/hap/camera/accessory_test.go.
+const separator = 0x00
 
 func appendSlice(b []byte, value reflect.Value) ([]byte, error) {
 	for i := 0; i < value.Len(); i++ {

--- a/pkg/hap/tlv8/tlv8_test.go
+++ b/pkg/hap/tlv8/tlv8_test.go
@@ -118,7 +118,7 @@ func TestSlice1(t *testing.T) {
 		} `tlv8:"3"`
 	}
 
-	s := `030b010280070202380403011e ff00 030b010200050202d00203011e`
+	s := `030b010280070202380403011e 0000 030b010200050202d00203011e`
 	b1, err := hex.DecodeString(strings.ReplaceAll(s, " ", ""))
 	require.NoError(t, err)
 
@@ -140,7 +140,7 @@ func TestSlice2(t *testing.T) {
 		Framerate uint8  `tlv8:"3"`
 	}
 
-	s := `010280070202380403011e ff00 010200050202d00203011e`
+	s := `010280070202380403011e 0000 010200050202d00203011e`
 	b1, err := hex.DecodeString(strings.ReplaceAll(s, " ", ""))
 	require.NoError(t, err)
 
@@ -153,4 +153,30 @@ func TestSlice2(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, b1, b2)
+}
+
+// Readers must accept any zero-length TLV as a list separator, whatever byte
+// the remote implementation picked. Encoding uses 0x00 (see const separator).
+func TestSeparatorLeniency(t *testing.T) {
+	type Item struct {
+		Width  uint16 `tlv8:"1"`
+		Height uint16 `tlv8:"2"`
+	}
+
+	for _, sep := range []string{"0000", "ff00", "0500"} {
+		t.Run(sep, func(t *testing.T) {
+			s := `01028007 02023804` + sep + `01020005 02023804`
+			b, err := hex.DecodeString(strings.ReplaceAll(s, " ", ""))
+			require.NoError(t, err)
+
+			var v []Item
+			err = Unmarshal(b, &v)
+			require.NoError(t, err)
+
+			require.Equal(t, []Item{
+				{Width: 1920, Height: 1080},
+				{Width: 1280, Height: 1080},
+			}, v)
+		})
+	}
 }

--- a/pkg/hap/tlv8/tlv8_test.go
+++ b/pkg/hap/tlv8/tlv8_test.go
@@ -2,6 +2,7 @@ package tlv8
 
 import (
 	"encoding/hex"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -155,6 +156,72 @@ func TestSlice2(t *testing.T) {
 	require.Equal(t, b1, b2)
 }
 
+func TestBool(t *testing.T) {
+	type Struct struct {
+		True  bool `tlv8:"1"`
+		False bool `tlv8:"2"`
+	}
+
+	src := Struct{True: true, False: false}
+
+	b, err := Marshal(src)
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 1, 1, 2, 1, 0}, b)
+
+	var dst Struct
+	err = Unmarshal(b, &dst)
+	require.NoError(t, err)
+
+	require.Equal(t, src, dst)
+}
+
+func TestBigNestedStruct(t *testing.T) {
+	type Inner struct {
+		Data string `tlv8:"1"`
+	}
+	type Outer struct {
+		In Inner `tlv8:"2"`
+	}
+
+	src := Outer{In: Inner{Data: strings.Repeat("x", 300)}}
+
+	b, err := Marshal(src)
+	require.NoError(t, err)
+
+	// nested value is 304 bytes, so it must be split into a 255-byte
+	// fragment plus a 49-byte remainder, both tagged 2
+	require.Equal(t, byte(2), b[0])
+	require.Equal(t, byte(255), b[1])
+	require.Equal(t, byte(2), b[257])
+	require.Equal(t, byte(49), b[258])
+
+	var dst Outer
+	err = Unmarshal(b, &dst)
+	require.NoError(t, err)
+
+	require.Equal(t, src, dst)
+}
+
+func TestBigArray(t *testing.T) {
+	type Struct struct {
+		Data [300]byte `tlv8:"1"`
+	}
+
+	var src Struct
+	for i := range src.Data {
+		src.Data[i] = byte(i)
+	}
+
+	b, err := Marshal(src)
+	require.NoError(t, err)
+
+	var dst Struct
+	err = Unmarshal(b, &dst)
+	require.NoError(t, err)
+
+	require.Equal(t, src, dst)
+}
+
 // Readers must accept any zero-length TLV as a list separator, whatever byte
 // the remote implementation picked. Encoding uses 0x00 (see const separator).
 func TestSeparatorLeniency(t *testing.T) {
@@ -177,6 +244,30 @@ func TestSeparatorLeniency(t *testing.T) {
 				{Width: 1920, Height: 1080},
 				{Width: 1280, Height: 1080},
 			}, v)
+		})
+	}
+}
+
+// TestExact255Fragment documents the boundary described on appendPayload: a
+// value that fills its last fragment round-trips as the final item, and a
+// following same-tag item would be absorbed into it.
+func TestExact255Fragment(t *testing.T) {
+	type Struct struct {
+		Data string `tlv8:"1"`
+	}
+
+	for _, n := range []int{254, 255, 256, 510} {
+		t.Run(strconv.Itoa(n), func(t *testing.T) {
+			src := Struct{Data: strings.Repeat("y", n)}
+
+			b, err := Marshal(src)
+			require.NoError(t, err)
+
+			var dst Struct
+			err = Unmarshal(b, &dst)
+			require.NoError(t, err)
+
+			require.Equal(t, src, dst)
 		})
 	}
 }

--- a/pkg/homekit/server.go
+++ b/pkg/homekit/server.go
@@ -31,7 +31,10 @@ type ServerPair interface {
 type ServerAccessory interface {
 	GetAccessories(conn net.Conn) []*hap.Accessory
 	GetCharacteristic(conn net.Conn, aid uint8, iid uint64) any
-	SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value any)
+	// SetCharacteristic returns the write response value, used only for
+	// characteristics with the write response permission, and a HAP status
+	// code (hap.StatusSuccess when the write succeeded).
+	SetCharacteristic(conn net.Conn, aid uint8, iid uint64, value any) (any, int)
 	GetImage(conn net.Conn, width, height int) []byte
 }
 
@@ -65,25 +68,69 @@ func ServerHandler(server Server) HandlerFunc {
 			case "PUT":
 				var v struct {
 					Value []struct {
-						AID   uint8  `json:"aid"`
-						IID   uint64 `json:"iid"`
-						Value any    `json:"value"`
+						AID      uint8  `json:"aid"`
+						IID      uint64 `json:"iid"`
+						Value    any    `json:"value"`
+						Response bool   `json:"r"`
 					} `json:"characteristics"`
 				}
 				if err := json.NewDecoder(req.Body).Decode(&v); err != nil {
 					return nil, err
 				}
 
-				for _, char := range v.Value {
-					server.SetCharacteristic(conn, char.AID, char.IID, char.Value)
+				type result struct {
+					aid    uint8
+					iid    uint64
+					value  any
+					status int
+					wanted bool
 				}
 
-				res := &http.Response{
-					StatusCode: http.StatusNoContent,
-					Proto:      "HTTP",
-					ProtoMajor: 1,
-					ProtoMinor: 1,
+				results := make([]result, 0, len(v.Value))
+				var withResponse, withError bool
+
+				for _, char := range v.Value {
+					value, status := server.SetCharacteristic(conn, char.AID, char.IID, char.Value)
+
+					results = append(results, result{
+						aid: char.AID, iid: char.IID, value: value, status: status, wanted: char.Response,
+					})
+
+					if status != hap.StatusSuccess {
+						withError = true
+					} else if char.Response {
+						withResponse = true
+					}
 				}
+
+				// a plain successful write has no body at all
+				if !withResponse && !withError {
+					res := &http.Response{
+						StatusCode: http.StatusNoContent,
+						Proto:      "HTTP",
+						ProtoMajor: 1,
+						ProtoMinor: 1,
+					}
+					return res, nil
+				}
+
+				// anything other than a plain success is reported per
+				// characteristic, so every entry carries a status - including
+				// the ones that succeeded
+				var body hap.JSONCharacters
+				for _, r := range results {
+					char := hap.JSONCharacter{AID: r.aid, IID: r.iid, Status: r.status}
+					if r.status == hap.StatusSuccess && r.wanted {
+						char.Value = r.value
+					}
+					body.Value = append(body.Value, char)
+				}
+
+				res, err := makeResponse(hap.MimeJSON, body)
+				if err != nil {
+					return nil, err
+				}
+				res.StatusCode = http.StatusMultiStatus
 				return res, nil
 			}
 

--- a/pkg/homekit/server_test.go
+++ b/pkg/homekit/server_test.go
@@ -1,0 +1,139 @@
+package homekit
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/hap"
+	"github.com/stretchr/testify/require"
+)
+
+type testResult struct {
+	value  any
+	status int
+}
+
+type testServer struct {
+	value  any
+	status int
+	writes int
+	perIID map[uint64]testResult
+}
+
+func (s *testServer) GetPair(string) []byte                         { return nil }
+func (s *testServer) AddPair(string, []byte, byte)                  {}
+func (s *testServer) DelPair(string)                                {}
+func (s *testServer) GetAccessories(net.Conn) []*hap.Accessory      { return nil }
+func (s *testServer) GetCharacteristic(net.Conn, uint8, uint64) any { return nil }
+func (s *testServer) GetImage(net.Conn, int, int) []byte            { return nil }
+
+func (s *testServer) SetCharacteristic(_ net.Conn, _ uint8, iid uint64, _ any) (any, int) {
+	s.writes++
+	if s.perIID != nil {
+		if r, ok := s.perIID[iid]; ok {
+			return r.value, r.status
+		}
+	}
+	return s.value, s.status
+}
+
+// put drives ServerHandler over a pipe with a raw HTTP request, the same way a
+// paired controller does over the encrypted HAP connection.
+func put(t *testing.T, srv Server, body string) *http.Response {
+	t.Helper()
+
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = client.Close() })
+
+	go func() {
+		_ = ServerHandler(srv)(server)
+		_ = server.Close()
+	}()
+
+	req := fmt.Sprintf(
+		"PUT /characteristics HTTP/1.1\r\nContent-Type: %s\r\nContent-Length: %d\r\n\r\n%s",
+		hap.MimeJSON, len(body), body,
+	)
+	_, err := client.Write([]byte(req))
+	require.NoError(t, err)
+
+	res, err := http.ReadResponse(bufio.NewReader(client), nil)
+	require.NoError(t, err)
+
+	return res
+}
+
+// TestWriteNoResponse is the regression guard for every characteristic go2rtc
+// already supported: a plain successful write must stay 204 with no body.
+func TestWriteNoResponse(t *testing.T) {
+	srv := &testServer{value: "ignored", status: hap.StatusSuccess}
+
+	res := put(t, srv, `{"characteristics":[{"aid":1,"iid":16,"value":"AQE="}]}`)
+
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+	require.Equal(t, 1, srv.writes)
+
+	b, _ := io.ReadAll(res.Body)
+	require.Empty(t, b)
+}
+
+func TestWriteResponse(t *testing.T) {
+	srv := &testServer{value: "AQIDBA==", status: hap.StatusSuccess}
+
+	res := put(t, srv, `{"characteristics":[{"aid":1,"iid":16,"value":"AQE=","r":true}]}`)
+
+	require.Equal(t, http.StatusMultiStatus, res.StatusCode)
+
+	b, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"characteristics":[{"aid":1,"iid":16,"status":0,"value":"AQIDBA=="}]}`, string(b))
+}
+
+func TestWriteError(t *testing.T) {
+	srv := &testServer{status: hap.StatusInvalidValue}
+
+	res := put(t, srv, `{"characteristics":[{"aid":1,"iid":16,"value":"AQE=","r":true}]}`)
+
+	require.Equal(t, http.StatusMultiStatus, res.StatusCode)
+
+	b, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"characteristics":[{"aid":1,"iid":16,"status":-70410}]}`, string(b))
+}
+
+// TestWriteErrorWithoutResponseRequest - a failure must be reported even when
+// the controller did not ask for a write response.
+func TestWriteErrorWithoutResponseRequest(t *testing.T) {
+	srv := &testServer{status: hap.StatusInsufficientPrivilege}
+
+	res := put(t, srv, `{"characteristics":[{"aid":1,"iid":16,"value":"AQE="}]}`)
+
+	require.Equal(t, http.StatusMultiStatus, res.StatusCode)
+
+	b, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"characteristics":[{"aid":1,"iid":16,"status":-70401}]}`, string(b))
+}
+
+// TestWriteMixed - HAP requires every entry of a multi-status response to
+// carry a status, including the ones that succeeded.
+func TestWriteMixed(t *testing.T) {
+	srv := &testServer{perIID: map[uint64]testResult{
+		16: {value: "T0s=", status: hap.StatusSuccess},
+		17: {status: hap.StatusReadOnly},
+	}}
+
+	res := put(t, srv, `{"characteristics":[{"aid":1,"iid":16,"value":"AQE=","r":true},{"aid":1,"iid":17,"value":"AQE="}]}`)
+
+	require.Equal(t, http.StatusMultiStatus, res.StatusCode)
+
+	b, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"characteristics":[`+
+		`{"aid":1,"iid":16,"status":0,"value":"T0s="},`+
+		`{"aid":1,"iid":17,"status":-70404}]}`, string(b))
+}


### PR DESCRIPTION
## What is the goal?

Five limits in the HAP layer block Apple's HomeKit Secure Video open source spec. This fixes them; no new services yet. Each one is a defect on its own today.

## References

* **Issue:** https://github.com/AlexxIT/go2rtc/issues/2297

## How is it being implemented?

- `InitIID` no longer panics on the spec's four hex digit types (`8033`, `8043`). Types that still fit keep the positional layout, so enabling new services does not renumber a paired accessory's IIDs.
- Write response: `PUT /characteristics` decodes `"r"` and replies `204` on plain success, `207` with per-characteristic statuses otherwise. Changes the `ServerAccessory` signature.
- TLV8 fragments nested structs and byte arrays past 255 bytes, which previously truncated modulo 256, and supports `bool`.
- `Character.listeners` gets a mutex.

## Caveats

`pkg/hap/camera` and `pkg/hap/hds` tests had not compiled since earlier renames, hiding their coverage. Repairing them exposed 9 failing golden subtests, all one cause: the TLV8 list separator. Fixtures from Aqara G3, Homebridge and Scrypted encode it as a zero-length type `0x00` — 43 occurrences, zero of `0xFF` — matching HAP's `kTLVType_Separator`. Changed to `0x00`; decoding already accepted either. **That call is yours, hence the draft.**

`"ev"` subscriptions are still discarded, so the spec's Notify characteristics stay blocked. Needs its own change.

## How is it tested?

Automated tests, `-race`, and 386/arm-v7 builds. `master` is already red independently, so I compared: 10 failing packages before → 7 after, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHwNjaLsmc59sgiy6ZeNig
