### PR TITLE
Add missing Huffman tables to stream.mjpeg frames, same as frame.jpeg

### DIFF
--- a/pkg/mjpeg/writer.go
+++ b/pkg/mjpeg/writer.go
@@ -20,6 +20,11 @@ type writer struct {
 }
 
 func (w *writer) Write(p []byte) (n int, err error) {
+	// Safari can't decode JPEG without DHT (AVI1 MJPEG from USB cams),
+	// same as api/frame.jpeg already fixes via FixJPEG
+	// - https://github.com/pion/mediadevices/pull/493
+	p = FixJPEG(p)
+
 	w.buf = w.buf[:len(header)]
 	w.buf = append(w.buf, strconv.Itoa(len(p))...)
 	w.buf = append(w.buf, "\r\n\r\n"...)


### PR DESCRIPTION
`api/frame.jpeg` repairs AVI1 frames via `FixJPEG` (adding the standard DHT tables that MJPEG cameras omit), but `api/stream.mjpeg` writes frames through unrepaired.

Apple's JPEG decoder (ImageIO, which Safari uses) fails outright on most DHT-less frames — including real webcam output — while libjpeg-turbo and ffmpeg decode the same files by supplying the standard tables. In Safari that shows as a stream that downloads fine and paints nothing, with no error; Chrome and Firefox render the same stream normally, which makes it hard to attribute: same camera, same endpoint, one browser black. Reproducible outside any stream: take a webcam JPEG (or any `cjpeg` output), strip the `FFC4` segments, and `sips`/Preview refuse it while `djpeg` and `ffmpeg` decode it.

Measured with a Logitech C910 on `ffmpeg:device?video=...&input_format=mjpeg` (`-c copy` passthrough), capturing from `stream.mjpeg` on the same machine a minute apart:

| | parts | `FFC4` segments |
|---|---|---|
| unpatched | 21 | 0 |
| patched | 190 | 760 (4 per frame) |

With this change the stream renders in Safari (Safari 26.5.2 on macOS 15.7.7, and iOS 26.6); Chrome and Firefox are unaffected. Frames that already carry tables pass through untouched, same as in `frame.jpeg`, and `Content-Length` is written after the repair so part framing stays correct.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

