### PR TITLE
Add per-stream RTSP handshake timeout

### DIFF
--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -104,6 +104,7 @@ func rtspHandler(rawURL string) (core.Producer, error) {
 		conn.Backchannel = query.Get("backchannel") == "1"
 		conn.Media = query.Get("media")
 		conn.Timeout = core.Atoi(query.Get("timeout"))
+		conn.HandshakeTimeout = core.Atoi(query.Get("handshake_timeout"))
 		conn.Transport = query.Get("transport")
 	}
 

--- a/pkg/rtsp/client_test.go
+++ b/pkg/rtsp/client_test.go
@@ -25,6 +25,19 @@ func TestTimeout(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrDeadlineExceeded)
 }
 
+func TestHandshakeTimeout(t *testing.T) {
+	oldTimeout := Timeout
+	defer func() { Timeout = oldTimeout }()
+
+	Timeout = 5 * time.Second
+
+	conn := &Conn{}
+	require.Equal(t, 5*time.Second, conn.handshakeTimeout())
+
+	conn.HandshakeTimeout = 15
+	require.Equal(t, 15*time.Second, conn.handshakeTimeout())
+}
+
 func TestMissedControl(t *testing.T) {
 	Timeout = time.Millisecond
 

--- a/pkg/rtsp/conn.go
+++ b/pkg/rtsp/conn.go
@@ -23,13 +23,14 @@ type Conn struct {
 
 	// public
 
-	Backchannel bool
-	Media       string
-	OnClose     func() error
-	PacketSize  uint16
-	SessionName string
-	Timeout     int
-	Transport   string // custom transport support, ex. RTSP over WebSocket
+	Backchannel      bool
+	Media            string
+	OnClose          func() error
+	PacketSize       uint16
+	SessionName      string
+	Timeout          int
+	HandshakeTimeout int
+	Transport        string // custom transport support, ex. RTSP over WebSocket
 
 	URL *url.URL
 
@@ -51,6 +52,13 @@ type Conn struct {
 
 	udpConn []*net.UDPConn
 	udpAddr []*net.UDPAddr
+}
+
+func (c *Conn) handshakeTimeout() time.Duration {
+	if c.HandshakeTimeout > 0 {
+		return time.Second * time.Duration(c.HandshakeTimeout)
+	}
+	return Timeout
 }
 
 const (
@@ -345,7 +353,7 @@ func (c *Conn) WriteRequest(req *tcp.Request) error {
 
 	c.Fire(req)
 
-	if err := c.conn.SetWriteDeadline(time.Now().Add(Timeout)); err != nil {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.handshakeTimeout())); err != nil {
 		return err
 	}
 
@@ -353,7 +361,7 @@ func (c *Conn) WriteRequest(req *tcp.Request) error {
 }
 
 func (c *Conn) ReadRequest() (*tcp.Request, error) {
-	if err := c.conn.SetReadDeadline(time.Now().Add(Timeout)); err != nil {
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.handshakeTimeout())); err != nil {
 		return nil, err
 	}
 	return tcp.ReadRequest(c.reader)
@@ -394,7 +402,7 @@ func (c *Conn) WriteResponse(res *tcp.Response) error {
 
 	c.Fire(res)
 
-	if err := c.conn.SetWriteDeadline(time.Now().Add(Timeout)); err != nil {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.handshakeTimeout())); err != nil {
 		return err
 	}
 
@@ -402,7 +410,7 @@ func (c *Conn) WriteResponse(res *tcp.Response) error {
 }
 
 func (c *Conn) ReadResponse() (*tcp.Response, error) {
-	if err := c.conn.SetReadDeadline(time.Now().Add(Timeout)); err != nil {
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.handshakeTimeout())); err != nil {
 		return nil, err
 	}
 	return tcp.ReadResponse(c.reader)


### PR DESCRIPTION
## Summary

This adds a per-stream RTSP handshake timeout for RTSP producers.

The existing `#timeout=` option controls the timeout used while an RTSP
connection is already active, but the initial RTSP handshake
(`DESCRIBE`, `SETUP`, etc.) still uses the package-wide default timeout
of 5 seconds.

For RTSP sources that need more than 5 seconds to become available,
this causes go2rtc to fail the initial `DESCRIBE` and return
`404 Not Found` to the downstream client.

This change adds a new optional query parameter:

```yaml
streams:
  slow_camera:
    - rtsp://192.0.2.10:8554/camera#handshake_timeout=30
```

`handshake_timeout` is specified in seconds and applies only to that
specific RTSP connection.

If it is not set, the existing global default remains unchanged, so
current configurations keep the same behavior.

## Motivation

I encountered this while integrating a battery-powered camera through
an on-demand RTSP pipeline.

The camera is intentionally kept asleep when it is not being viewed.
An RTSP proxy uses an on-demand hook to start the camera bridge only
when an RTSP client requests the stream.

The flow is approximately:

```text
go2rtc -> RTSP proxy -> on-demand process -> camera bridge -> battery camera
```

Waking the camera and making the RTSP stream available can take more
than 5 seconds.

With the current behavior, the initial RTSP handshake times out before
the on-demand source becomes available:

```text
default handshake timeout (5s) -> DESCRIBE fails -> 404 Not Found
```

The existing `#timeout=` option does not solve this case because it
controls the timeout of an already active RTSP connection rather than
the initial handshake.

## Usage

The timeout can be configured for an individual RTSP producer:

```yaml
streams:
  slow_camera:
    - rtsp://192.0.2.10:8554/camera#handshake_timeout=30
```

Other RTSP streams remain unaffected.

For example:

```yaml
streams:
  normal_camera:
    - rtsp://192.0.2.20:554/stream

  slow_on_demand_camera:
    - rtsp://192.0.2.10:8554/camera#handshake_timeout=30
```

Only `slow_on_demand_camera` uses the extended handshake timeout.

## Testing

The change was tested against a real on-demand RTSP source.

Observed results:

```text
default timeout:
  fails after approximately 5.1s

handshake_timeout=15:
  fails after approximately 15.1s when the source is not ready yet

handshake_timeout=30:
  succeeds; the stream became available after approximately 16.6s
```

The RTSP stream was successfully opened through go2rtc once the
on-demand source became available.

Unit tests were also run:

```text
github.com/AlexxIT/go2rtc/internal/rtsp  [no test files]
github.com/AlexxIT/go2rtc/pkg/rtsp       ok
```

## Compatibility

The default behavior is unchanged.

If `handshake_timeout` is not configured, the existing package-wide
RTSP timeout is still used.

The setting is per connection, so increasing the handshake timeout for
a slow RTSP source does not affect other RTSP producers.
