### PR TITLE
Fix data races on app.Info and the streams map in the HTTP API

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -238,9 +238,15 @@ var mu sync.Mutex
 func apiHandler(w http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	app.Info["host"] = r.Host
+	// copy under the lock: json.Encoder ranges over the map, and another
+	// concurrent request writing app.Info["host"] would be a data race
+	info := make(map[string]any, len(app.Info))
+	for k, v := range app.Info {
+		info[k] = v
+	}
 	mu.Unlock()
 
-	ResponseJSON(w, app.Info)
+	ResponseJSON(w, info)
 }
 
 func exitHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -18,7 +18,7 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 
 	// without source - return all streams list
 	if src == "" && r.Method != "POST" {
-		api.ResponseJSON(w, streams)
+		api.ResponseJSON(w, GetAll())
 		return
 	}
 
@@ -43,7 +43,7 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 
 			stream.RemoveConsumer(cons)
 		} else {
-			api.ResponsePrettyJSON(w, streams[src])
+			api.ResponsePrettyJSON(w, stream)
 		}
 
 	case "PUT":
@@ -98,7 +98,7 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case "DELETE":
-		delete(streams, src)
+		Delete(src)
 
 		if err := app.PatchConfig([]string{"streams", src}, nil); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -113,12 +113,12 @@ func apiStreamsDOT(w http.ResponseWriter, r *http.Request) {
 	dot = append(dot, "digraph {\n"...)
 	if query.Has("src") {
 		for _, name := range query["src"] {
-			if stream := streams[name]; stream != nil {
+			if stream := Get(name); stream != nil {
 				dot = AppendDOT(dot, stream)
 			}
 		}
 	} else {
-		for _, stream := range streams {
+		for _, stream := range GetAll() {
 			dot = AppendDOT(dot, stream)
 		}
 	}

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -155,6 +155,16 @@ func Delete(name string) {
 	delete(streams, name)
 }
 
+func GetAll() map[string]*Stream {
+	streamsMu.Lock()
+	all := make(map[string]*Stream, len(streams))
+	for name, stream := range streams {
+		all[name] = stream
+	}
+	streamsMu.Unlock()
+	return all
+}
+
 func GetAllNames() []string {
 	streamsMu.Lock()
 	names := make([]string, 0, len(streams))


### PR DESCRIPTION
## What

Two independent data races in the HTTP API, both of which abort the whole process:

1. **`internal/api.apiHandler`** writes `app.Info["host"]` under `mu`, unlocks, and then hands the
   *same* map to `ResponseJSON`, which JSON-encodes it — and `encoding/json` ranges over the map.
   Two overlapping `GET /api` requests are enough:
   `fatal error: concurrent map iteration and map write`.

2. **`internal/streams.apiStreams`** touches the package-level `streams` map directly without
   `streamsMu`: `delete(streams, src)` in the `DELETE` branch, plus unlocked reads/iteration in the
   list, single-stream and `.dot` paths. Two overlapping `DELETE /api/streams` give
   `fatal error: concurrent map writes`; one `GET /api/streams` overlapping a `DELETE` gives
   `concurrent map iteration and map write`.

Reported in #2443, with a reproduction script, measurements and the full crash stack.

## Why it matters

`apiHandler` is the only writer of `app.Info` after startup — all the other write sites
(`app.go:67`, `app.go:68`, `config.go:93`, `rtsp.go:34`) run once during `Init`. So the handler
races only against itself, and **two concurrent `GET /api` requests are both necessary and
sufficient** to kill the process. That is reachable without any custom client: `www/index.html`
fetches `api` on page load, so two browser tabs opened at the same moment can do it.

On our deployment (v1.9.14, `revision=b5948cf`, darwin/arm64) a health probe that polled `/api`
without concurrency control crashed go2rtc 9 times in 11 hours. Serialising our probes stopped it
entirely with a byte-identical binary, which isolates the cause.

Measured on the stock v1.9.14 release binary with an otherwise idle instance:

| Load pattern | Result |
| --- | --- |
| 2 threads on `GET /api` | crash in 5/5 runs, after 81–916 requests (0.3–0.5 s) |
| 32 threads on `GET /api` | crash after 16,328 requests (1.8 s) |
| 12 threads on `GET /api`, single-flight | 358,602 requests / 180 s, no crash |
| 12 threads on `GET /api/streams` (reads only) | 769,356 requests / 180 s, no crash |

## How

**`internal/api/api.go`** — take a shallow copy of `app.Info` while the lock is held and encode the
copy. The encoder then iterates a map no other goroutine can reach. `app.Info` holds only
scalars/strings, so a shallow copy is sufficient. Cost is one small map allocation per `/api`
request, on an endpoint that is not on any hot path.

**`internal/streams/api.go` + `internal/streams/streams.go`** — route every access through locked
helpers instead of the raw map:

- `DELETE` branch now calls the existing `Delete(src)` (`streams.go:152`) instead of the builtin
  `delete(streams, src)`, which was bypassing `streamsMu`.
- New `GetAll()` helper returns a locked snapshot of the map, used by the list endpoint and by
  `apiStreamsDOT`.
- The single-stream `GET` branch reuses the `*Stream` it already obtained from `Get(src)` a few
  lines above, instead of re-reading `streams[src]` unlocked.

## Compatibility

No behaviour or API-shape changes:

- `GET /api` returns the same JSON object with the same keys.
- `GET /api/streams` still marshals a `map[string]*Stream`; a snapshot marshals identically.
- `GET /api/streams?src=…` returns the same `*Stream` value (it is the one already fetched via
  `Get(src)` and null-checked immediately above).
- `DELETE /api/streams?src=…` removes the same key and still calls `app.PatchConfig` afterwards.
- `GET /api/streams.dot` produces the same graph; iteration order was already unspecified.

No new imports, no new exported surface except `streams.GetAll()`.

## Notes

- The `dev` branch needs the same `apiHandler` change — there the handler writes three keys per
  request (`host`, `pid`, `system`) inside the lock and still encodes `app.Info` outside it, which
  makes the window larger, not smaller.
- Happy to split this into two PRs (one per race), or to drop the `apiStreamsDOT` hunk, if you
  prefer a narrower change. The `apiHandler` hunk on its own fixes the crash we actually hit in
  production.
