### PR TITLE
Add support IMILAB/Mijia EC2 battery cameras to xiaomi source

### DIFF
--- a/internal/xiaomi/xiaomi.go
+++ b/internal/xiaomi/xiaomi.go
@@ -95,7 +95,7 @@ func getCameraURL(url *url.URL) (string, error) {
 
 	// It is not known which models need to be awakened.
 	// Probably all the doorbells and all the battery cameras.
-	if strings.Contains(model, ".cateye.") {
+	if strings.Contains(model, ".cateye.") || strings.Contains(model, ".gateway.") {
 		_ = wakeUpCamera(url)
 	}
 

--- a/pkg/xiaomi/legacy/client.go
+++ b/pkg/xiaomi/legacy/client.go
@@ -59,6 +59,7 @@ func NewClient(rawURL string) (*Client, error) {
 		Conn:  conn,
 		key:   key,
 		model: model,
+		mac:   query.Get("mac"),
 	}
 
 	return c, nil
@@ -92,6 +93,7 @@ type Client struct {
 	*tutk.Conn
 	key   []byte
 	model string
+	mac   string
 }
 
 func (c *Client) Version() string {
@@ -104,7 +106,8 @@ func (c *Client) ReadPacket() (hdr, payload []byte, err error) {
 		return
 	}
 	if c.key != nil {
-		if c.model == ModelAqaraG2 && hdr[0] == tutk.CodecH265 {
+		if (c.model == ModelAqaraG2 && hdr[0] == tutk.CodecH265) ||
+			(c.model == ModelIMILABEC2 && tutk.IsVideoCodec(hdr[0])) {
 			payload, err = DecodeVideo(payload, c.key)
 		} else {
 			// ModelAqaraG2: audio AAC
@@ -147,6 +150,35 @@ func (c *Client) StartMedia(video, audio string) error {
 			c.WriteCommandJSON(cmdVideoStart, `{}`),
 			c.WriteCommandJSON(0x0605, `{"channel":%s}`, video),
 			c.WriteCommandJSON(0x0704, `{}`), // don't know why
+		)
+
+	case ModelIMILABEC2:
+		// Measured against the official app's own traffic:
+		//   0 = "HD"     1920x1080, ~865 kbit/s  (best, the default here)
+		//   1 = "Speed"  1280x720,  ~538 kbit/s
+		//   2 = "Fluent" 1920x1080, ~739 kbit/s
+		// The app never exceeds ~865 kbit/s, so 0 really is the camera's cap.
+		// Quality is NOT monotonic in this number.
+		switch video {
+		case "", "hd":
+			video = "0"
+		case "sd":
+			video = "1"
+		case "auto":
+			video = "2"
+		}
+
+		// The gateway ignores commands without "mac" - it can't tell which
+		// of its cameras is meant, so it stays silent and the session dies.
+		// Audio must be started AFTER the video stream is running. The app
+		// sends cmdAudioStart long after cmdVideoStart; sending it earlier
+		// leaves the audio track filled with silence (measured -72 dB).
+		return errors.Join(
+			c.WriteCommandJSON(cmdVideoStop, `{"mac":"%s"}`, c.mac),
+			c.WriteCommandJSON(cmdStreamCtrlReq, `{"mac":"%s","videoquality":%s}`, c.mac, video),
+			c.WriteCommandJSON(cmdVideoStart, `{"mac":"%s","videoquality":%s}`, c.mac, video),
+			c.WriteCommandJSON(cmdVideoStart, `{"mac":"%s","videoquality":%s}`, c.mac, video),
+			c.WriteCommandJSON(cmdAudioStart, `{"mac":"%s"}`, c.mac),
 		)
 
 	case ModelIMILABA1, ModelMijia:
@@ -224,6 +256,9 @@ func (c *Client) StopMedia() error {
 }
 
 func DecodeVideo(data, key []byte) ([]byte, error) {
+	if len(data) < 17 {
+		return data, nil
+	}
 	if string(data[:4]) == "\x00\x00\x00\x01" || data[8] == 0 {
 		return data, nil
 	}
@@ -260,11 +295,15 @@ const (
 	ModelMijia = "chuangmi.camera.v2"
 	// ModelDafang support miss format for new fw and legacy format for old fw
 	ModelDafang = "isa.camera.df3"
+	// ModelIMILABEC2 is a gateway for battery cameras (CMSXJ11A).
+	// Every media command must carry the camera MAC, because one gateway
+	// can serve several cameras. Quality range is 0..2.
+	ModelIMILABEC2 = "chuangmi.gateway.ipc011"
 )
 
 func Supported(model string) bool {
 	switch model {
-	case ModelAqaraG2, ModelIMILABA1, ModelLoockV1, ModelXiaobai, ModelXiaofang:
+	case ModelAqaraG2, ModelIMILABA1, ModelLoockV1, ModelXiaobai, ModelXiaofang, ModelIMILABEC2:
 		return true
 	}
 	return false

--- a/pkg/xiaomi/legacy/producer.go
+++ b/pkg/xiaomi/legacy/producer.go
@@ -57,9 +57,10 @@ type Producer struct {
 const codecXiaobaiPCMA = 1 // chuangmi.camera.xiaobai
 
 func probe(client *Client) ([]*core.Media, error) {
-	_ = client.SetDeadline(time.Now().Add(15 * time.Second))
+	_ = client.SetDeadline(time.Now().Add(30 * time.Second))
 
 	var vcodec, acodec *core.Codec
+	var videoAt time.Time
 
 	for {
 		// 0   5000      codec
@@ -80,6 +81,9 @@ func probe(client *Client) ([]*core.Media, error) {
 		case tutk.CodecH264, tutk.CodecH265:
 			if vcodec == nil {
 				avcc := annexb.EncodeToAVCC(payload)
+				if len(avcc) < 5 {
+					continue
+				}
 				if codec == tutk.CodecH264 {
 					if h264.NALUType(avcc) == h264.NALUTypeSPS {
 						vcodec = h264.AVCCToCodec(avcc)
@@ -107,8 +111,17 @@ func probe(client *Client) ([]*core.Media, error) {
 			}
 		}
 
-		if vcodec != nil && acodec != nil {
-			break
+		if vcodec != nil {
+			if acodec != nil {
+				break
+			}
+			// Some cameras (IMILAB EC2) send audio only on demand. Don't fail
+			// the whole probe just because no audio arrived.
+			if videoAt.IsZero() {
+				videoAt = time.Now()
+			} else if time.Since(videoAt) > 3*time.Second {
+				break
+			}
 		}
 	}
 
@@ -118,11 +131,13 @@ func probe(client *Client) ([]*core.Media, error) {
 			Direction: core.DirectionRecvonly,
 			Codecs:    []*core.Codec{vcodec},
 		},
-		{
+	}
+	if acodec != nil {
+		medias = append(medias, &core.Media{
 			Kind:      core.KindAudio,
 			Direction: core.DirectionRecvonly,
 			Codecs:    []*core.Codec{acodec},
-		},
+		})
 	}
 	return medias, nil
 }


### PR DESCRIPTION
> **Disclosure:** this account belongs to @perseus177, who owns the hardware and
> reviews everything before it is sent, but the text and all the measurements in
> it were produced by Claude Code acting on his behalf. Every number below was
> measured on the real devices, nothing is inferred.

Adds support for the **IMILAB / Mijia EC2** outdoor kit (`CMSXJ11A`) to the
`xiaomi/legacy` source. Refs #1982 — there is currently no `.gateway.` model
supported at all.

### What the device is

The EC2 kit is a battery camera **plus its own gateway**. In the Xiaomi cloud
only the gateway is a device: `chuangmi.gateway.ipc011`, firmware `3.5.8_*`,
`TUTK/18 SDK 3.0.1.50`. The cloud answers `miss_get_vendor` with *no available
vendor support*, so it falls back to `/device/devicepass` and the legacy TUTK
path, which already works — the session establishes and IOCtrl commands are
acked. It just never produced any media.

### Why it did not work

**1. One gateway can serve several cameras, so every media command must carry
the camera MAC.** Without `"mac"` the gateway cannot tell which of its cameras
is meant, silently ignores the request and stays quiet; `probe()` then times
out with `EOF`. Command IDs are exactly the ones already in the code:

| ctrlType | payload |
|---|---|
| `cmdVideoStop` | `{"mac":"<camera MAC>"}` |
| `cmdStreamCtrlReq` | `{"mac":"<camera MAC>","videoquality":N}` |
| `cmdVideoStart` | `{"mac":"<camera MAC>","videoquality":N}` |
| `cmdAudioStart` | `{"mac":"<camera MAC>"}` |

The camera MAC is **not** the gateway MAC and is not in `device_list_page`. It
can be read from the gateway with a local miio call `get_camera_list`, which
also returns `battery`, `pir`, `wifi` and `night` — handy for a battery camera,
and it does not wake it. Exposing it is out of scope for this PR, but it is
where the `mac=` value comes from.

**2. Video and audio use different encryption.** Audio is `crypto.Decode`, but
video uses the `DecodeVideo` scheme (8-byte nonce, flag, two offsets, then an
Annex-B payload with a partially encrypted region) that was previously reserved
for `ModelAqaraG2` + H265. With `crypto.Decode` the video decodes to noise, so
`annexb.EncodeToAVCC` returns nothing and no SPS is ever found.

**3. Audio has to be started after the video stream is running.** The official
app sends `cmdAudioStart` long after `cmdVideoStart`. Sending it earlier leaves
the audio track filled with constant digital silence (measured mean = max =
−72.2 dB, i.e. a fixed value). With the correct order real audio arrives
(−35.9 dB peak on a quiet outdoor scene).

**4. `probe()` required both a video and an audio codec.** This camera sends
audio only on request, so the loop never completed and the 15 s deadline killed
an otherwise working video stream. It now breaks once video is known, allowing
3 s for audio, and omits the audio media when none arrives.

### Quality mapping

`videoquality` is **not** monotonic. Measured against the official app's own
traffic while switching quality (segments split by the captured
`cmdStreamCtrlReq` timestamps):

| app label | `videoquality` | resolution | throughput |
|---|---|---|---|
| Speed | 1 | 1280×720 | 538 kbit/s |
| Fluent | 2 | 1920×1080 | 739 kbit/s |
| HD | **0** | 1920×1080 | **865 / 863 kbit/s** |

`0` measured twice, so it is stable and not sampling noise. The app never
exceeds ~865 kbit/s, so `0` is the camera's ceiling; `subtype` values above 2
change nothing. `""`/`hd` therefore map to `0`.

### Result

```
format : xiaomi/legacy
proto  : tutk+udp
agent  : TUTK/18 SDK 3.0.1.50 (chuangmi.gateway.ipc011)
media  : video, recvonly, H264
media  : audio, recvonly, PCMA/8000
```

Verified end to end: RTSP out of go2rtc gives **1920×1080 H264 + PCM A-law**,
recorded and played back. Cold start is ~16 s because the battery camera has to
be woken and the P2P handshake completed — worth knowing, since Home Assistant's
Generic Camera config flow times out well before that.

### Notes for review

- Two changes in `probe()` (video-only, and the `len(avcc) < 5` guard) and the
  `DecodeVideo` length guard affect **all** `xiaomi/legacy` cameras, not just
  this one. The guards fix a real panic: without them a short payload makes
  `h264.NALUType(avcc)` panic with `index out of range [4] with length 0`.
- The wake-up in `internal/xiaomi` now also fires for `.gateway.` models, not
  only `.cateye.`.
- `Device.HasCamera()` filters `.gateway.` models out of the Web UI list, so
  this camera never appears there and the stream has to be written by hand.
  Not touched here, but it is why the device looks unsupported.
- How the protocol was recovered: capturing the official Mi Home app in an
  Android emulator and de-obfuscating the traffic with `ReverseTransCodePartial`
  from `pkg/tutk`. IOCtrl commands are not encrypted, only obfuscated, so no
  hooking was needed.
