### PR TITLE
Fix Xiaomi login after phone verification

### DIFF
--- a/pkg/xiaomi/cloud.go
+++ b/pkg/xiaomi/cloud.go
@@ -318,6 +318,10 @@ func (c *Cloud) finishAuth(location string) error {
 	if err != nil {
 		return err
 	}
+	if skipURL := res.Request.URL.Query().Get("skipUrl"); skipURL != "" {
+		res.Body.Close()
+		return c.finishAuth(skipURL)
+	}
 	defer res.Body.Close()
 
 	// LoginWithVerify


### PR DESCRIPTION
Fixes #2063

After phone verification, Xiaomi redirects to a /fe/ page with the actual authentication endpoint stored in its skipUrl query parameter. The HTTP client stops on that page, so finishAuth does not receive the response containing the account credentials.

Follow skipUrl before processing the authentication response.

Related implementation

hass-xiaomi-miot handles the same Xiaomi verification flow by extracting skipUrl from the final /fe/ response URL and requesting it before finalizing authentication:
- Flow: https://github.com/al-one/hass-xiaomi-miot/blob/17945db6b2f1f02249be49dfda14ae650263a2ca/custom_components/xiaomi_miot/core/xiaomi_cloud.py#L606-L612
- skipUrl extraction: https://github.com/al-one/hass-xiaomi-miot/blob/17945db6b2f1f02249be49dfda14ae650263a2ca/custom_components/xiaomi_miot/core/xiaomi_cloud.py#L757-L767

This PR applies the same required follow-up in go2rtc finishAuth with a minimal four-line change.
