### PR TITLE
Add RFC 7616 algorithm negotiation to RTSP digest auth

### DIFF
--- a/pkg/tcp/auth.go
+++ b/pkg/tcp/auth.go
@@ -2,19 +2,35 @@ package tcp
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strings"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 
 type Auth struct {
-	Method  byte
-	user    string
-	pass    string
-	header  string
-	h1nonce string
+	Method byte
+	user   string
+	pass   string
+	header string // Basic-only; Digest builds Authorization per request
+
+	algorithm string // verbatim from the winning challenge; empty = implicit MD5
+	realm     string
+	nonce     string
+	opaque    string
+	qop       string // "auth" if offered; otherwise empty (legacy no-qop formula)
+	cnonce    string
+	nc        uint32
+	ha1       string // cached in Read, reused by every Write on this connection
+}
+
+type digestChallenge struct {
+	algorithm, realm, nonce, opaque, qop string
 }
 
 const (
@@ -24,6 +40,8 @@ const (
 	AuthDigest
 	AuthTPLink // https://drmnsamoliu.github.io/video.html
 )
+
+var digestParamRE = regexp.MustCompile(`(\w+)\s*=\s*(?:"([^"]*)"|([^,\s]+))`)
 
 func NewAuth(user *url.Userinfo) *Auth {
 	a := new(Auth)
@@ -35,31 +53,128 @@ func NewAuth(user *url.Userinfo) *Auth {
 	return a
 }
 
+func parseDigestChallenge(value string) *digestChallenge {
+	if !strings.HasPrefix(value, "Digest") {
+		return nil
+	}
+	c := &digestChallenge{}
+	for _, match := range digestParamRE.FindAllStringSubmatch(value, -1) {
+		key := strings.ToLower(match[1])
+		val := match[2]
+		if val == "" {
+			val = match[3]
+		}
+		switch key {
+		case "algorithm":
+			c.algorithm = val
+		case "realm":
+			c.realm = val
+		case "nonce":
+			c.nonce = val
+		case "opaque":
+			c.opaque = val
+		case "qop":
+			c.qop = val
+		}
+	}
+	if c.realm == "" || c.nonce == "" {
+		return nil
+	}
+	return c
+}
+
+func algorithmRank(token string) int {
+	switch {
+	case token == "" || strings.EqualFold(token, "MD5"):
+		return 1
+	case strings.EqualFold(token, "MD5-sess"):
+		return 2
+	case strings.EqualFold(token, "SHA-256"):
+		return 3
+	case strings.EqualFold(token, "SHA-256-sess"):
+		return 4
+	default:
+		return 0
+	}
+}
+
+func algorithmBase(algorithm string) string {
+	if n := len(algorithm); n >= 5 && strings.EqualFold(algorithm[n-5:], "-sess") {
+		return algorithm[:n-5]
+	}
+	return algorithm
+}
+
+func hexHash(algorithm string, parts ...string) string {
+	material := []byte(strings.Join(parts, ":"))
+	if strings.EqualFold(algorithmBase(algorithm), "SHA-256") {
+		sum := sha256.Sum256(material)
+		return hex.EncodeToString(sum[:])
+	}
+	sum := md5.Sum(material)
+	return hex.EncodeToString(sum[:])
+}
+
+func qopOffersAuth(qop string) bool {
+	for _, opt := range strings.Split(qop, ",") {
+		if strings.EqualFold(strings.TrimSpace(opt), "auth") {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *Auth) Read(res *Response) bool {
-	auth := res.Header.Get("WWW-Authenticate")
-	if len(auth) < 6 {
+	values := res.Header.Values("WWW-Authenticate")
+	if len(values) == 0 {
 		return false
 	}
 
-	switch auth[:6] {
-	case "Basic ":
-		a.header = "Basic " + B64(a.user, a.pass)
-		a.Method = AuthBasic
-		return true
-	case "Digest":
-		realm := Between(auth, `realm="`, `"`)
-		nonce := Between(auth, `nonce="`, `"`)
+	var best *digestChallenge
+	bestRank := 0
+	for _, value := range values {
+		c := parseDigestChallenge(value)
+		if c == nil {
+			continue
+		}
+		rank := algorithmRank(c.algorithm)
+		if rank > bestRank {
+			best = c
+			bestRank = rank
+		}
+	}
 
-		a.h1nonce = HexMD5(a.user, realm, a.pass) + ":" + nonce
-		a.header = fmt.Sprintf(
-			`Digest username="%s", realm="%s", nonce="%s"`,
-			a.user, realm, nonce,
-		)
+	if best != nil {
+		a.algorithm = best.algorithm
+		a.realm = best.realm
+		a.nonce = best.nonce
+		a.opaque = best.opaque
+		a.qop = ""
+		if qopOffersAuth(best.qop) {
+			a.qop = "auth"
+		}
+		rank := algorithmRank(a.algorithm)
+		if a.qop != "" || rank == 2 || rank == 4 {
+			a.cnonce = core.RandString(32, 64)
+			a.nc = 0
+		}
+		if rank == 2 || rank == 4 {
+			a.ha1 = hexHash(a.algorithm, hexHash(a.algorithm, a.user, a.realm, a.pass), a.nonce, a.cnonce)
+		} else {
+			a.ha1 = hexHash(a.algorithm, a.user, a.realm, a.pass)
+		}
 		a.Method = AuthDigest
 		return true
-	default:
-		return false
 	}
+
+	for _, value := range values {
+		if strings.HasPrefix(value, "Basic") {
+			a.header = "Basic " + B64(a.user, a.pass)
+			a.Method = AuthBasic
+			return true
+		}
+	}
+	return false
 }
 
 func (a *Auth) Write(req *Request) {
@@ -74,11 +189,32 @@ func (a *Auth) Write(req *Request) {
 		// important to use String except RequestURL for RtspServer:
 		// https://github.com/AlexxIT/go2rtc/issues/244
 		uri := req.URL.String()
-		h2 := HexMD5(req.Method, uri)
-		response := HexMD5(a.h1nonce, h2)
-		header := a.header + fmt.Sprintf(
-			`, uri="%s", response="%s"`, uri, response,
-		)
+		h2 := hexHash(a.algorithm, req.Method, uri)
+		var header string
+		if a.qop == "" {
+			response := hexHash(a.algorithm, a.ha1, a.nonce, h2)
+			header = fmt.Sprintf(
+				`Digest username="%s", realm="%s", nonce="%s", uri="%s", response="%s"`,
+				a.user, a.realm, a.nonce, uri, response,
+			)
+			if a.algorithm != "" {
+				header += ", algorithm=" + a.algorithm
+			}
+			if a.opaque != "" {
+				header += fmt.Sprintf(`, opaque="%s"`, a.opaque)
+			}
+		} else {
+			a.nc++
+			nc := fmt.Sprintf("%08x", a.nc)
+			response := hexHash(a.algorithm, a.ha1, a.nonce, nc, a.cnonce, a.qop, h2)
+			header = fmt.Sprintf(
+				`Digest username="%s", realm="%s", nonce="%s", uri="%s", algorithm=%s, qop=auth, nc=%s, cnonce="%s", response="%s"`,
+				a.user, a.realm, a.nonce, uri, a.algorithm, nc, a.cnonce, response,
+			)
+			if a.opaque != "" {
+				header += fmt.Sprintf(`, opaque="%s"`, a.opaque)
+			}
+		}
 		req.Header.Set("Authorization", header)
 	case AuthTPLink:
 		req.URL.Host = "127.0.0.1"

--- a/pkg/tcp/auth_test.go
+++ b/pkg/tcp/auth_test.go
@@ -1,0 +1,187 @@
+package tcp
+
+import (
+	"fmt"
+	"net/textproto"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const (
+	benchUser     = "bench"
+	benchPass     = "correct-horse"
+	benchMD5Realm = "go2rtc-bench-md5"
+	benchSHARealm = "go2rtc-bench-sha256"
+	benchMD5Nonce = "11111111111111111111111111111111"
+	benchSHANonce = "22222222222222222222222222222222"
+	benchURI      = "rtsp://host.docker.internal:18554/stream"
+	benchMD5Resp  = "228bc516fa4f435af2972451f91111fa"
+	benchSHAResp  = "49ca071b729baa998e6fe57a2d25ba5952a40fe6f47e2044be367ae6b464b859"
+)
+
+func TestHexHashMD5BenchResponse(t *testing.T) {
+	ha1 := hexHash("MD5", benchUser, benchMD5Realm, benchPass)
+	ha2 := hexHash("MD5", "DESCRIBE", benchURI)
+	got := hexHash("MD5", ha1, benchMD5Nonce, ha2)
+	if got != benchMD5Resp {
+		t.Fatalf("MD5 response = %s, want %s", got, benchMD5Resp)
+	}
+}
+
+func TestHexHashSHA256BenchResponse(t *testing.T) {
+	ha1 := hexHash("SHA-256", benchUser, benchSHARealm, benchPass)
+	ha2 := hexHash("SHA-256", "DESCRIBE", benchURI)
+	got := hexHash("SHA-256", ha1, benchSHANonce, ha2)
+	if got != benchSHAResp {
+		t.Fatalf("SHA-256 response = %s, want %s", got, benchSHAResp)
+	}
+}
+
+func TestAlgorithmRank(t *testing.T) {
+	cases := []struct {
+		token string
+		rank  int
+	}{
+		{"", 1},
+		{"MD5", 1},
+		{"md5", 1},
+		{"MD5-sess", 2},
+		{"md5-SESS", 2},
+		{"SHA-256", 3},
+		{"sha-256", 3},
+		{"SHA-256-sess", 4},
+		{"sha-256-SESS", 4},
+		{"SHA-512-256", 0},
+		{"unknown", 0},
+	}
+	for _, tc := range cases {
+		if got := algorithmRank(tc.token); got != tc.rank {
+			t.Errorf("algorithmRank(%q) = %d, want %d", tc.token, got, tc.rank)
+		}
+	}
+	if !(algorithmRank("SHA-256-sess") > algorithmRank("SHA-256") &&
+		algorithmRank("SHA-256") > algorithmRank("MD5-sess") &&
+		algorithmRank("MD5-sess") > algorithmRank("MD5") &&
+		algorithmRank("MD5") > algorithmRank("SHA-512-256")) {
+		t.Fatal("algorithmRank does not order known tokens above unimplemented ones")
+	}
+}
+
+func TestReadSelectsStrongestDigest(t *testing.T) {
+	md5Chal := fmt.Sprintf(
+		`Digest realm="%s", nonce="%s", algorithm=MD5`,
+		benchMD5Realm, benchMD5Nonce,
+	)
+	shaChal := fmt.Sprintf(
+		`Digest realm="%s", nonce="%s", algorithm=SHA-256`,
+		benchSHARealm, benchSHANonce,
+	)
+	orders := [][]string{
+		{md5Chal, shaChal},
+		{shaChal, md5Chal},
+	}
+	for _, values := range orders {
+		a := NewAuth(url.UserPassword(benchUser, benchPass))
+		res := &Response{Header: textproto.MIMEHeader{
+			"Www-Authenticate": values,
+		}}
+		if !a.Read(res) {
+			t.Fatalf("Read failed for order %q", values)
+		}
+		if a.Method != AuthDigest {
+			t.Fatalf("Method = %d, want AuthDigest", a.Method)
+		}
+		if a.algorithm != "SHA-256" || a.realm != benchSHARealm || a.nonce != benchSHANonce {
+			t.Fatalf("selected algorithm=%q realm=%q nonce=%q, want SHA-256/%s/%s (order %q)",
+				a.algorithm, a.realm, a.nonce, benchSHARealm, benchSHANonce, values)
+		}
+		reqURL, err := url.Parse(benchURI)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := &Request{Method: "DESCRIBE", URL: reqURL, Header: textproto.MIMEHeader{}}
+		a.Write(req)
+		auth := req.Header.Get("Authorization")
+		want := fmt.Sprintf(`response="%s"`, benchSHAResp)
+		if !strings.Contains(auth, want) {
+			t.Fatalf("Authorization = %q, want SHA-256 response %s", auth, benchSHAResp)
+		}
+	}
+}
+
+func TestWriteImplicitMD5MatchesLegacyHeader(t *testing.T) {
+	user, pass := "user", "pass"
+	realm := "testrealm"
+	nonce := "dcd98b7102dd2f0e8b11d0f600bfb0c093"
+	uri := "rtsp://cam.example/stream"
+
+	a := NewAuth(url.UserPassword(user, pass))
+	res := &Response{Header: textproto.MIMEHeader{
+		"Www-Authenticate": []string{
+			fmt.Sprintf(`Digest realm="%s", nonce="%s"`, realm, nonce),
+		},
+	}}
+	if !a.Read(res) {
+		t.Fatal("Read failed")
+	}
+	if a.algorithm != "" || a.qop != "" || a.opaque != "" {
+		t.Fatalf("implicit MD5 fields: algorithm=%q qop=%q opaque=%q", a.algorithm, a.qop, a.opaque)
+	}
+
+	reqURL, err := url.Parse(uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &Request{Method: "DESCRIBE", URL: reqURL, Header: textproto.MIMEHeader{}}
+	a.Write(req)
+
+	h2 := HexMD5("DESCRIBE", uri)
+	response := HexMD5(HexMD5(user, realm, pass)+":"+nonce, h2)
+	want := fmt.Sprintf(
+		`Digest username="%s", realm="%s", nonce="%s", uri="%s", response="%s"`,
+		user, realm, nonce, uri, response,
+	)
+	got := req.Header.Get("Authorization")
+	if got != want {
+		t.Fatalf("legacy header mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestWriteBenchVectors(t *testing.T) {
+	cases := []struct {
+		name, challenge, want string
+	}{
+		{
+			name:      "md5",
+			challenge: fmt.Sprintf(`Digest realm="%s", nonce="%s", algorithm=MD5`, benchMD5Realm, benchMD5Nonce),
+			want:      benchMD5Resp,
+		},
+		{
+			name:      "sha256",
+			challenge: fmt.Sprintf(`Digest realm="%s", nonce="%s", algorithm=SHA-256`, benchSHARealm, benchSHANonce),
+			want:      benchSHAResp,
+		},
+	}
+	reqURL, err := url.Parse(benchURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := NewAuth(url.UserPassword(benchUser, benchPass))
+			res := &Response{Header: textproto.MIMEHeader{
+				"Www-Authenticate": []string{tc.challenge},
+			}}
+			if !a.Read(res) {
+				t.Fatal("Read failed")
+			}
+			req := &Request{Method: "DESCRIBE", URL: reqURL, Header: textproto.MIMEHeader{}}
+			a.Write(req)
+			auth := req.Header.Get("Authorization")
+			if !strings.Contains(auth, fmt.Sprintf(`response="%s"`, tc.want)) {
+				t.Fatalf("Authorization = %q, want response %s", auth, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
RTSP digest authentication currently reads only the first `WWW-Authenticate` header (`Header.Get`) and always hashes HA1/HA2/response with MD5. It never parses the challenge's `algorithm=` directive.

RFC 7616 allows a server to offer MD5, MD5-sess, SHA-256, and SHA-256-sess, including as separate `WWW-Authenticate` values. This change:

- Reads every `WWW-Authenticate` challenge instead of only the first header
- Selects the strongest supported algorithm
- Hashes HA1/HA2/response with that algorithm, including `-sess` and `qop=auth` when offered
- When the challenge omits `algorithm` and `qop`, emits the previous five-field `Authorization` header unchanged

`go test ./pkg/tcp/...` covers MD5 and SHA-256 vectors, algorithm ranking, dual-header selection in both orders, and the legacy header shape.

#2232 independently noted two Authenticate headers on the wire; that report itself was misconfigured credentials, not this defect.