### PR TITLE
security: redact credential query parameters in logs and API responses

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
 	pkgyaml "github.com/AlexxIT/go2rtc/pkg/yaml"
 	"gopkg.in/yaml.v3"
 )
@@ -27,7 +28,10 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// https://www.ietf.org/archive/id/draft-ietf-httpapi-yaml-mediatypes-00.html
-		Response(w, data, "application/yaml")
+		// The raw file may hold literal credentials (issue #2298). Registered
+		// secrets are masked here exactly as /api/streams already masks them;
+		// a ${VAR} config carries placeholders and is unaffected.
+		Response(creds.SecretResponse(w), data, "application/yaml")
 
 	case "POST", "PATCH":
 		if IsReadOnly() {

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/creds"
 )
 
 type state byte
@@ -43,6 +44,10 @@ func NewProducer(source string) *Producer {
 		return &Producer{template: source}
 	}
 
+	// Register credential query params the moment a URL exists. This must
+	// happen at construction, not at Dial: /api/streams serialises the
+	// producer (MarshalJSON) before it ever dials.
+	creds.AddURLSecrets(source)
 	return &Producer{url: source}
 }
 
@@ -52,6 +57,7 @@ func (p *Producer) SetSource(s string) {
 	} else {
 		p.url = strings.Replace(p.template, SourceTemplate, s, 1)
 	}
+	creds.AddURLSecrets(p.url)
 }
 
 func (p *Producer) Dial() error {

--- a/pkg/creds/secrets_test.go
+++ b/pkg/creds/secrets_test.go
@@ -11,5 +11,7 @@ func TestString(t *testing.T) {
 	AddSecret("pa$$word")
 
 	s := SecretString("rtsp://admin:pa$$word@192.168.1.123/stream1")
-	require.Equal(t, "rtsp://***:***@192.168.1.123/stream1", s)
+	// Since "Strip Userinfo from log entries and errors" (#2051) the whole
+	// user:pass@ block collapses to ***@ — one marker, no hint of the shape.
+	require.Equal(t, "rtsp://***@192.168.1.123/stream1", s)
 }

--- a/pkg/creds/urlsecrets.go
+++ b/pkg/creds/urlsecrets.go
@@ -1,0 +1,59 @@
+package creds
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Query parameters whose values are credentials. Cloud sources (nest, ring,
+// tuya, hass, xiaomi, roborock, ...) take tokens and passwords this way:
+//
+//	nest:?client_id=...&client_secret=...&refresh_token=...
+//
+// Values that arrive through ${VAR} are registered by GetValue; values written
+// literally into a source URL were not registered anywhere, so they reached
+// the log, /api/log and /api/streams in clear text. Userinfo (user:pass@) is
+// handled separately by the regexp in SecretString.
+var secretQueryKeys = map[string]struct{}{
+	"password":      {},
+	"pass":          {},
+	"secret":        {},
+	"client_secret": {},
+	"refresh_token": {},
+	"access_token":  {},
+	"token":         {},
+	"api_key":       {},
+	"key":           {},
+	"auth":          {},
+}
+
+// A registered secret is replaced everywhere it appears. A short value (a
+// port, a channel number, a word) would mask unrelated text in every log line,
+// so anything below this length is left alone. Real tokens are far longer.
+const minSecretLen = 8
+
+// AddURLSecrets registers the credential-bearing query parameters of a source
+// URL as secrets. Identifying parameters (client_id, project_id, device_id,
+// host) are untouched so diagnostics stay readable: the URL logs as
+// "client_secret=***&project_id=abc". Safe on any string: no query, or one that
+// does not parse, is a no-op.
+func AddURLSecrets(rawURL string) {
+	i := strings.IndexByte(rawURL, '?')
+	if i < 0 {
+		return
+	}
+	// ParseQuery keeps parsing past a bad pair and returns what it could
+	// read alongside the error. Use it: a malformed URL is exactly where a
+	// secret would otherwise slip through, so never bail on the error.
+	query, _ := url.ParseQuery(rawURL[i+1:])
+	for key, values := range query {
+		if _, ok := secretQueryKeys[strings.ToLower(key)]; !ok {
+			continue
+		}
+		for _, value := range values {
+			if len(value) >= minSecretLen {
+				AddSecret(value)
+			}
+		}
+	}
+}

--- a/pkg/creds/urlsecrets_test.go
+++ b/pkg/creds/urlsecrets_test.go
@@ -1,0 +1,42 @@
+package creds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddURLSecrets(t *testing.T) {
+	// cloud-style source: credentials as query parameters
+	src := "nest:?client_id=CLIENT-ID-ABC&client_secret=GOCSPX-verysecretvalue&refresh_token=1//0refreshTOKEN&project_id=proj-123"
+	AddURLSecrets(src)
+
+	logLine := "[streams] start producer url=" + src
+	got := SecretString(logLine)
+	require.NotContains(t, got, "GOCSPX-verysecretvalue")
+	require.NotContains(t, got, "1//0refreshTOKEN")
+	// identifying detail survives so diagnostics still make sense
+	require.Contains(t, got, "client_id=CLIENT-ID-ABC")
+	require.Contains(t, got, "project_id=proj-123")
+	require.Contains(t, got, "client_secret=***")
+	require.Contains(t, got, "refresh_token=***")
+
+	// JSON serialisation of the same URL (what /api/streams emits) is masked too
+	require.NotContains(t, SecretString(`{"url":"`+src+`"}`), "GOCSPX-verysecretvalue")
+}
+
+func TestAddURLSecretsShortValueIgnored(t *testing.T) {
+	// a short value must never become a secret: it would mask innocent text
+	// ("key=1234" turning every "1234" in the log into ***)
+	AddURLSecrets("roborock://?key=1234&password=ab")
+	require.Equal(t, "port 1234 password ab", SecretString("port 1234 password ab"))
+}
+
+func TestAddURLSecretsNoQueryOrGarbage(t *testing.T) {
+	// no-ops, and no panics
+	AddURLSecrets("rtsp://192.168.1.10/stream")
+	AddURLSecrets("")
+	AddURLSecrets("nest:?%zz=bad&client_secret=stillregisteredvalue")
+	// ParseQuery rejects the malformed pair; the rest is still registered
+	require.NotContains(t, SecretString("x=stillregisteredvalue"), "stillregisteredvalue")
+}


### PR DESCRIPTION
## Summary

Cloud sources (nest, ring, tuya, hass, xiaomi, roborock) take credentials as URL **query parameters**:

```
nest:?client_id=...&client_secret=...&refresh_token=...
```

Secrets that arrive through `${VAR}` are registered by `creds.GetValue` and masked everywhere by `SecretWriter`/`SecretResponse`. Secrets written **literally** into a source URL were never registered, so they reached the log, `GET /api/log` and `GET /api/streams` in clear text. And `GET /api/config` returns the on-disk YAML verbatim, bypassing the masking `/api/streams` applies. This is issue #2298.

## Changes (each independently revertible)

1. **`creds: register credential query parameters of source URLs as secrets`** — `AddURLSecrets()` registers the values of credential-bearing query keys at the one point a producer URL enters the system (`NewProducer`/`SetSource`, not `Dial`, because `/api/streams` serialises producers before they dial). One hook covers every current and future cloud source. Identifying params (`client_id`, `project_id`, `device_id`) are preserved so a masked URL still reads `client_secret=***&project_id=abc`; a minimum-length guard stops a short value from wildcard-masking unrelated log text.
2. **`api: mask registered secrets in GET /api/config`** — answer `/api/config` through the same `SecretResponse` as `/api/streams`. A `${VAR}` config serves placeholders and is unaffected.
3. **`creds: fix TestString after userinfo stripping (#2051)`** — `de157eb` changed `SecretString` (whole `user:pass@` collapses to `***@`) but left `secrets_test.go` asserting the old `***:***@`; the test has failed on dev/master since. This aligns the expectation, so the suite is green again.

## Testing

- `go test ./pkg/creds/` passes (including four new `AddURLSecrets` cases: live masking, JSON/`/api/streams` masking, short-value-ignored, malformed-query).
- `go build` clean.
- Verified against a live Nest deployment: `client_secret` + `refresh_token` exposures on `/api/log`, `/api/streams` and `/api/config` went to zero, while device/project identifiers stayed visible for diagnostics.

Fixes #2298.

*Opened as a draft for maintainer review of the approach before polishing.*