### PR TITLE
Add unifi-protect support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ A summary table of all modules and features can be found [here](internal/README.
 - [`tapo`](internal/tapo/README.md) - [TP-Link Tapo](https://www.tapo.com/) cameras with two-way audio support.
 - [`vigi`](internal/tapo/README.md#tp-link-vigi) - TP-Link Vigi cameras.
 - [`tuya`](internal/tuya/README.md) - [Tuya](https://www.tuya.com/) ecosystem cameras with two-way audio support.
+- [`unifi-protect`](internal/unifiprotect/README.md) - UniFi Protect cameras without a Protect console or NVR.
 - [`webtorrent`](internal/webtorrent/README.md) - Stream from another go2rtc via [WebTorrent](https://en.wikipedia.org/wiki/WebTorrent) protocol.
 - [`wyze`](internal/wyze/README.md) - [Wyze](https://wyze.com/) cameras using native P2P protocol
 - [`xiaomi`](internal/xiaomi/README.md) - [Xiaomi Mi Home](https://home.mi.com/) ecosystem cameras with two-way audio support.

--- a/internal/README.md
+++ b/internal/README.md
@@ -59,6 +59,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 | [`rtsp`]       | `rtsp`          | `rtsp`           | yes   | yes    | yes    | yes     |
 | [`tapo`]       | `mpegts`        | `http`           | yes   |        |        | yes     |
 | [`tuya`]       | `srtp`          | `webrtc`         | yes   |        |        | yes     |
+| [`unifi-protect`] | `extendedFlv` | `wss`, `tcp`     | yes   |        | yes    |         |
 | [`v4l2`]       | `rawvideo`      | `ioctl`          | yes   |        |        |         |
 | [`webrtc`]     | `srtp`          | `webrtc`         | yes   | yes    | yes    | yes     |
 | [`webtorrent`] | `srtp`          | `webrtc`         | yes   | yes    |        |         |
@@ -104,6 +105,7 @@ Some formats and protocols go2rtc supports exclusively. They have no equivalent 
 [`streams`]: streams/README.md
 [`tapo`]: tapo/README.md
 [`tuya`]: tuya/README.md
+[`unifi-protect`]: unifiprotect/README.md
 [`v4l2`]: v4l2/README.md
 [`webrtc`]: webrtc/README.md
 [`webtorrent`]: webtorrent/README.md

--- a/internal/unifiprotect/README.md
+++ b/internal/unifiprotect/README.md
@@ -5,6 +5,26 @@ without a UniFi Protect console or NVR. It implements only the controller
 handshake and pushed-media path required for streaming. It has been tested with
 a G5 Flex running firmware `4.70.37`.
 
+## Architecture
+
+The internal module owns controller state and network listeners; the package
+under `pkg/unifiprotect` handles the media format independently of configuration
+and session management.
+
+| Component | Responsibility |
+| --- | --- |
+| [`unifiprotect.go`](unifiprotect.go) | Module setup, TLS identity, and listeners |
+| [`source.go`](source.go) | Source URL and camera/channel validation |
+| [`controller.go`](controller.go) | Camera WebSocket handshake and stream commands |
+| [`manager.go`](manager.go) | Camera sessions and stream-request lifecycle |
+| [`media.go`](media.go) | Incoming TCP routing by request token |
+| [`pkg/unifiprotect/flv.go`](../../pkg/unifiprotect/flv.go) | Extended-FLV framing and metadata |
+| [`pkg/unifiprotect/producer.go`](../../pkg/unifiprotect/producer.go) | Codec probing and native go2rtc tracks |
+
+The camera keeps the control WebSocket open. When a source gains a consumer,
+the manager requests its channel, routes the resulting TCP push by token, and
+hands the stream to the producer as H.264 with Opus or AAC.
+
 ## Configuration
 
 ```yaml

--- a/internal/unifiprotect/README.md
+++ b/internal/unifiprotect/README.md
@@ -1,0 +1,87 @@
+# UniFi Protect cameras
+
+This module receives H.264 and Opus or AAC directly from UniFi Protect cameras,
+without a UniFi Protect console or NVR. It implements only the controller
+handshake and pushed-media path required for streaming. It has been tested with
+a G5 Flex running firmware `4.70.37`.
+
+## Configuration
+
+```yaml
+unifi_protect:
+  listen: ":7442"
+  media_listen: ":7550"
+
+streams:
+  entrance_main: unifi-protect://02AABBCCDDEE?channel=video1
+  entrance_medium: unifi-protect://02AABBCCDDEE?channel=video2
+  entrance_detect: unifi-protect://02AABBCCDDEE?channel=video3&audio=0
+```
+
+The source identifier is the camera's 12 hexadecimal MAC digits without
+separators; it is case-insensitive. `02AABBCCDDEE` is a locally administered
+example address; replace it with the camera's MAC. `channel` defaults to
+`video1`; supported values are `video1`, `video2`, and `video3`. Audio is enabled
+by default and can be disabled per source with `audio=0`.
+
+All cameras and channels share the two listeners. The WebSocket handshake uses
+the TLS listener on `7442`; pushed media uses plain TCP on `7550`. Both ports
+must be reachable from the camera. If the host from the camera's WebSocket
+request is not a reachable media address, set it explicitly:
+
+```yaml
+unifi_protect:
+  listen: ":7442"
+  media_listen: ":7550"
+  media_host: "192.168.1.10"
+```
+
+## Camera setup
+
+Set the camera's Protect server URL in its web interface, or run `set-inform`
+over SSH after a factory reset:
+
+```text
+set-inform 192.168.1.10:7442
+```
+
+Use the address of the go2rtc host. Manual `set-inform` is the only adoption
+step; this module does not implement UniFi discovery or configure the camera
+over SSH.
+
+The controller endpoint is intended for a trusted LAN and has no user
+authentication. Do not expose either listener to the Internet.
+
+## TLS identity
+
+The camera pins the exact server certificate when `set-inform` is performed.
+When `tls_cert` and `tls_key` are omitted, go2rtc creates
+`go2rtc-unifi-protect.crt` and `go2rtc-unifi-protect.key` beside the go2rtc
+configuration and reuses them. Back up both files. Deleting or replacing them
+disconnects adopted cameras until `set-inform` is run again.
+
+A certificate and key can instead be supplied as paths or inline PEM:
+
+```yaml
+unifi_protect:
+  listen: ":7442"
+  media_listen: ":7550"
+  tls_cert: "/config/unifi-protect.crt"
+  tls_key: "/config/unifi-protect.key"
+```
+
+Normal certificate renewal changes the certificate and therefore also requires
+running `set-inform` again. Keeping the same subject or private key is not
+sufficient.
+
+## Scope and limitations
+
+- The camera pushes media only while a go2rtc consumer is active.
+- Concurrent quality channels use one shared media port and are routed by a
+  random per-request token.
+- Opus is preferred when advertised by the camera; AAC is used otherwise.
+- One producer may be active for each camera/channel pair.
+- Camera settings, recording, events, detections, snapshots, talkback, firmware
+  management, and UDP discovery are not implemented.
+- The control messages do not change microphone enablement, volume, or other
+  persistent camera settings.

--- a/internal/unifiprotect/README.md
+++ b/internal/unifiprotect/README.md
@@ -18,6 +18,7 @@ and session management.
 | [`controller.go`](controller.go) | Camera WebSocket handshake and stream commands |
 | [`manager.go`](manager.go) | Camera sessions and stream-request lifecycle |
 | [`media.go`](media.go) | Incoming TCP routing by request token |
+| [`shared_listener.go`](shared_listener.go) | Optional control/media connection routing on one port |
 | [`pkg/unifiprotect/flv.go`](../../pkg/unifiprotect/flv.go) | Extended-FLV framing and metadata |
 | [`pkg/unifiprotect/producer.go`](../../pkg/unifiprotect/producer.go) | Codec probing and native go2rtc tracks |
 
@@ -44,8 +45,8 @@ example address; replace it with the camera's MAC. `channel` defaults to
 `video1`; supported values are `video1`, `video2`, and `video3`. Audio is enabled
 by default and can be disabled per source with `audio=0`.
 
-All cameras and channels share the two listeners. The WebSocket handshake uses
-the TLS listener on `7442`; pushed media uses plain TCP on `7550`. Both ports
+All cameras and channels share the configured listeners. The WebSocket
+handshake uses TLS on `7442`; pushed media uses plain TCP on `7550`. Both ports
 must be reachable from the camera. If the host from the camera's WebSocket
 request is not a reachable media address, set it explicitly:
 
@@ -55,6 +56,19 @@ unifi_protect:
   media_listen: ":7550"
   media_host: "192.168.1.10"
 ```
+
+Control and media can instead share one port by setting both listen addresses
+to the same value:
+
+```yaml
+unifi_protect:
+  listen: ":7442"
+  media_listen: ":7442"
+```
+
+The shared listener routes TLS handshakes to the controller and all other
+connections to media ingest. This is useful when a container or firewall can
+expose only one incoming TCP port.
 
 ## Camera setup
 

--- a/internal/unifiprotect/controller.go
+++ b/internal/unifiprotect/controller.go
@@ -1,0 +1,331 @@
+package unifiprotect
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	websocketPath     = "/camera/1.0/ws"
+	websocketProtocol = "secure_transfer"
+	maxControlMessage = 8 * 1024 * 1024
+)
+
+type controlMessage struct {
+	From             string          `json:"from"`
+	FunctionName     string          `json:"functionName"`
+	InResponseTo     int64           `json:"inResponseTo"`
+	MessageID        int64           `json:"messageId"`
+	Payload          json.RawMessage `json:"payload"`
+	ResponseExpected bool            `json:"responseExpected"`
+	To               string          `json:"to"`
+}
+
+type outgoingMessage struct {
+	From             string `json:"from"`
+	FunctionName     string `json:"functionName"`
+	InResponseTo     int64  `json:"inResponseTo"`
+	MessageID        int64  `json:"messageId"`
+	Payload          any    `json:"payload"`
+	ResponseExpected bool   `json:"responseExpected"`
+	TimeStamp        string `json:"timeStamp"`
+	To               string `json:"to"`
+}
+
+type cameraFeatures struct {
+	AudioCodecs    []string `json:"audioCodecs"`
+	OpusSampleRate []int    `json:"opusSampleRates"`
+}
+
+type helloPayload struct {
+	Features        cameraFeatures `json:"features"`
+	ProtocolVersion int            `json:"protocolVersion"`
+}
+
+type controller struct {
+	manager  *Manager
+	upgrader websocket.Upgrader
+}
+
+func newController(manager *Manager) *controller {
+	return &controller{
+		manager: manager,
+		upgrader: websocket.Upgrader{
+			Subprotocols: []string{websocketProtocol},
+			CheckOrigin:  func(*http.Request) bool { return true },
+		},
+	}
+}
+
+func (c *controller) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet || r.URL.Path != websocketPath ||
+		!websocket.IsWebSocketUpgrade(r) ||
+		!slices.Contains(websocket.Subprotocols(r), websocketProtocol) {
+		http.Error(w, "bad camera websocket request", http.StatusBadRequest)
+		return
+	}
+
+	mac, err := normalizeMAC(r.Header.Get("camera-mac"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	conn, err := c.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	conn.SetReadLimit(maxControlMessage)
+
+	s := &session{
+		manager:        c.manager,
+		conn:           conn,
+		mac:            mac,
+		cameraIP:       remoteHost(r.RemoteAddr),
+		controllerHost: requestHost(r.Host),
+		done:           make(chan struct{}),
+		nextMessageID:  time.Now().UnixMilli(),
+	}
+	if s.controllerHost == "" {
+		s.controllerHost = requestHost(conn.LocalAddr().String())
+	}
+
+	go s.run()
+}
+
+type session struct {
+	manager *Manager
+	conn    *websocket.Conn
+
+	mac            string
+	cameraIP       string
+	controllerHost string
+	opusRate       int
+
+	writeMu       sync.Mutex
+	nextMessageID int64
+	paramID       int64
+	closeOnce     sync.Once
+	done          chan struct{}
+}
+
+func (s *session) run() {
+	defer func() {
+		s.close()
+		s.manager.removeSession(s)
+	}()
+
+	for {
+		var msg controlMessage
+		if err := s.conn.ReadJSON(&msg); err != nil {
+			return
+		}
+		if err := s.handle(msg); err != nil {
+			log.Debug().Err(err).Str("camera", s.mac).Msg("[unifi-protect] control message")
+			return
+		}
+	}
+}
+
+func (s *session) handle(msg controlMessage) error {
+	switch msg.FunctionName {
+	case "ubnt_avclient_timeSync":
+		now := time.Now().UnixMilli()
+		return s.respond(msg, map[string]any{"t1": now, "t2": now})
+
+	case "ubnt_avclient_hello":
+		var hello helloPayload
+		if err := json.Unmarshal(msg.Payload, &hello); err != nil {
+			return err
+		}
+		s.opusRate = preferredOpusRate(hello.Features)
+
+		if err := s.respond(msg, map[string]any{
+			"protocolVersion":   hello.ProtocolVersion,
+			"controllerName":    "go2rtc",
+			"controllerUuid":    s.manager.controllerUUID,
+			"controllerVersion": s.manager.controllerVersion,
+			"overrideUuid":      true,
+		}); err != nil {
+			return err
+		}
+
+		timer := time.NewTimer(500 * time.Millisecond)
+		select {
+		case <-timer.C:
+		case <-s.done:
+			timer.Stop()
+			return net.ErrClosed
+		}
+
+		id, err := s.send("ubnt_avclient_paramAgreement", map[string]any{
+			"enableStatusCodes":   true,
+			"useHeartbeats":       false,
+			"heartbeatsTimeoutMs": 60000,
+		}, true, 0, "ubnt_avclient")
+		s.paramID = id
+		return err
+
+	case "ubnt_avclient_paramAgreement":
+		if msg.InResponseTo == s.paramID && s.paramID != 0 {
+			s.manager.addSession(s)
+			return nil
+		}
+
+	case "ChangeVideoSettings":
+		if msg.InResponseTo != 0 {
+			log.Debug().Str("camera", s.mac).Msg("[unifi-protect] video settings applied")
+		}
+	}
+
+	if msg.ResponseExpected && msg.InResponseTo == 0 {
+		var payload any = map[string]any{}
+		if len(msg.Payload) != 0 {
+			_ = json.Unmarshal(msg.Payload, &payload)
+		}
+		return s.respond(msg, payload)
+	}
+	return nil
+}
+
+func (s *session) respond(msg controlMessage, payload any) error {
+	to := msg.From
+	if to == "" {
+		to = "ubnt_avclient"
+	}
+	_, err := s.send(msg.FunctionName, payload, false, msg.MessageID, to)
+	return err
+}
+
+func (s *session) send(function string, payload any, responseExpected bool, inResponseTo int64, to string) (int64, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	select {
+	case <-s.done:
+		return 0, net.ErrClosed
+	default:
+	}
+
+	s.nextMessageID++
+	msg := outgoingMessage{
+		From:             "UniFiVideo",
+		FunctionName:     function,
+		InResponseTo:     inResponseTo,
+		MessageID:        s.nextMessageID,
+		Payload:          payload,
+		ResponseExpected: responseExpected,
+		TimeStamp:        time.Now().UTC().Format("2006-01-02T15:04:05.000-07:00"),
+		To:               to,
+	}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return 0, err
+	}
+	log.Debug().Str("camera", s.mac).Str("function", function).Int64("message_id", msg.MessageID).Msg("[unifi-protect] control send")
+	return msg.MessageID, s.conn.WriteMessage(websocket.BinaryMessage, b)
+}
+
+func (s *session) startStream(channel, destination, token string, audio bool) error {
+	parameters := map[string]any{
+		"streamName":    token,
+		"suppressAudio": !audio,
+		"suppressVideo": false,
+		"withOpus":      audio && s.opusRate != 0,
+	}
+	if audio && s.opusRate != 0 {
+		parameters["opusSampleRate"] = s.opusRate
+	}
+
+	_, err := s.send("ChangeVideoSettings", map[string]any{
+		"video": map[string]any{
+			channel: map[string]any{
+				"avSerializer": map[string]any{
+					"type":         "extendedFlv",
+					"parameters":   parameters,
+					"destinations": []string{destination},
+				},
+				"type": "h264",
+			},
+		},
+	}, true, 0, "ubnt_avclient")
+	return err
+}
+
+func (s *session) stopStreams(channels []string) error {
+	video := make(map[string]any, len(channels))
+	for _, channel := range channels {
+		parameters := map[string]any{"withOpus": s.opusRate != 0}
+		if s.opusRate != 0 {
+			parameters["opusSampleRate"] = s.opusRate
+		}
+		video[channel] = map[string]any{
+			"avSerializer": map[string]any{
+				"type":         "extendedFlv",
+				"parameters":   parameters,
+				"destinations": []string{"file:///dev/null"},
+			},
+		}
+	}
+	if len(video) == 0 {
+		return nil
+	}
+	_, err := s.send("ChangeVideoSettings", map[string]any{"video": video}, true, 0, "ubnt_avclient")
+	return err
+}
+
+func (s *session) close() {
+	s.closeOnce.Do(func() {
+		close(s.done)
+		_ = s.conn.Close()
+	})
+}
+
+func preferredOpusRate(features cameraFeatures) int {
+	if !slices.Contains(features.AudioCodecs, "opus") {
+		return 0
+	}
+	rate := 0
+	for _, v := range features.OpusSampleRate {
+		if v > rate {
+			rate = v
+		}
+	}
+	return rate
+}
+
+func remoteHost(address string) string {
+	host, _, err := net.SplitHostPort(address)
+	if err == nil {
+		return normalizeIP(host)
+	}
+	return normalizeIP(address)
+}
+
+func requestHost(address string) string {
+	host, _, err := net.SplitHostPort(address)
+	if err == nil {
+		return host
+	}
+	return address
+}
+
+func normalizeIP(ip string) string {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ip
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return v4.String()
+	}
+	return parsed.String()
+}
+
+var errSessionUnavailable = errors.New("unifi-protect: camera session unavailable")

--- a/internal/unifiprotect/controller.go
+++ b/internal/unifiprotect/controller.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	websocketPath     = "/camera/1.0/ws"
-	websocketProtocol = "secure_transfer"
-	maxControlMessage = 8 * 1024 * 1024
+	websocketPath       = "/camera/1.0/ws"
+	websocketProtocol   = "secure_transfer"
+	maxControlMessage   = 8 * 1024 * 1024
+	handshakeTimeout    = 30 * time.Second
+	controlWriteTimeout = 5 * time.Second
 )
 
 type controlMessage struct {
@@ -50,13 +52,15 @@ type helloPayload struct {
 }
 
 type controller struct {
-	manager  *Manager
-	upgrader websocket.Upgrader
+	manager          *Manager
+	handshakeTimeout time.Duration
+	upgrader         websocket.Upgrader
 }
 
 func newController(manager *Manager) *controller {
 	return &controller{
-		manager: manager,
+		manager:          manager,
+		handshakeTimeout: handshakeTimeout,
 		upgrader: websocket.Upgrader{
 			Subprotocols: []string{websocketProtocol},
 			CheckOrigin:  func(*http.Request) bool { return true },
@@ -83,6 +87,10 @@ func (c *controller) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	conn.SetReadLimit(maxControlMessage)
+	if err := conn.SetReadDeadline(time.Now().Add(c.handshakeTimeout)); err != nil {
+		_ = conn.Close()
+		return
+	}
 
 	s := &session{
 		manager:        c.manager,
@@ -176,6 +184,9 @@ func (s *session) handle(msg controlMessage) error {
 
 	case "ubnt_avclient_paramAgreement":
 		if msg.InResponseTo == s.paramID && s.paramID != 0 {
+			if err := s.conn.SetReadDeadline(time.Time{}); err != nil {
+				return err
+			}
 			s.manager.addSession(s)
 			return nil
 		}
@@ -231,7 +242,13 @@ func (s *session) send(function string, payload any, responseExpected bool, inRe
 		return 0, err
 	}
 	log.Debug().Str("camera", s.mac).Str("function", function).Int64("message_id", msg.MessageID).Msg("[unifi-protect] control send")
-	return msg.MessageID, s.conn.WriteMessage(websocket.BinaryMessage, b)
+	if err = s.conn.SetWriteDeadline(time.Now().Add(controlWriteTimeout)); err == nil {
+		err = s.conn.WriteMessage(websocket.BinaryMessage, b)
+	}
+	if err != nil {
+		s.close()
+	}
+	return msg.MessageID, err
 }
 
 func (s *session) startStream(channel, destination, token string, audio bool) error {

--- a/internal/unifiprotect/controller.go
+++ b/internal/unifiprotect/controller.go
@@ -154,7 +154,11 @@ func (s *session) handle(msg controlMessage) error {
 		if err := json.Unmarshal(msg.Payload, &hello); err != nil {
 			return err
 		}
-		s.opusRate = preferredOpusRate(hello.Features)
+		s.manager.mu.Lock()
+		if !s.ready {
+			s.opusRate = preferredOpusRate(hello.Features)
+		}
+		s.manager.mu.Unlock()
 
 		if err := s.respond(msg, map[string]any{
 			"protocolVersion":   hello.ProtocolVersion,
@@ -256,9 +260,9 @@ func (s *session) startStream(channel, destination, token string, audio bool) er
 		"streamName":    token,
 		"suppressAudio": !audio,
 		"suppressVideo": false,
-		"withOpus":      audio && s.opusRate != 0,
+		"withOpus":      s.opusRate != 0,
 	}
-	if audio && s.opusRate != 0 {
+	if s.opusRate != 0 {
 		parameters["opusSampleRate"] = s.opusRate
 	}
 

--- a/internal/unifiprotect/controller.go
+++ b/internal/unifiprotect/controller.go
@@ -108,6 +108,7 @@ type session struct {
 	cameraIP       string
 	controllerHost string
 	opusRate       int
+	ready          bool // guarded by manager.mu
 
 	writeMu       sync.Mutex
 	nextMessageID int64

--- a/internal/unifiprotect/controller.go
+++ b/internal/unifiprotect/controller.go
@@ -154,6 +154,8 @@ func (s *session) handle(msg controlMessage) error {
 		if err := json.Unmarshal(msg.Payload, &hello); err != nil {
 			return err
 		}
+		// Some cameras repeat hello on an established connection. Capabilities are
+		// immutable once ready so active streams keep the profile they negotiated.
 		s.manager.mu.Lock()
 		if !s.ready {
 			s.opusRate = preferredOpusRate(hello.Features)
@@ -256,6 +258,8 @@ func (s *session) send(function string, payload any, responseExpected bool, inRe
 }
 
 func (s *session) startStream(channel, destination, token string, audio bool) error {
+	// withOpus is the negotiated serializer profile, not a per-destination mute.
+	// suppressAudio controls whether this particular stream includes audio.
 	parameters := map[string]any{
 		"streamName":    token,
 		"suppressAudio": !audio,

--- a/internal/unifiprotect/controller_test.go
+++ b/internal/unifiprotect/controller_test.go
@@ -39,6 +39,27 @@ func TestControllerRejectsMalformedCameraMAC(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, recorder.Code)
 }
 
+func TestControllerClosesIncompleteHandshake(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	controller := newController(m)
+	controller.handshakeTimeout = 20 * time.Millisecond
+	server := httptest.NewServer(controller)
+	defer server.Close()
+
+	dialer := websocket.Dialer{Subprotocols: []string{websocketProtocol}}
+	header := http.Header{"camera-mac": []string{"02AABBCCDDEE"}}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + websocketPath
+	ws, _, err := dialer.Dial(wsURL, header)
+	require.NoError(t, err)
+	defer ws.Close()
+
+	require.NoError(t, ws.SetReadDeadline(time.Now().Add(time.Second)))
+	started := time.Now()
+	_, _, err = ws.ReadMessage()
+	require.Error(t, err)
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+}
+
 func connectCamera(t *testing.T, m *Manager) (*websocket.Conn, *httptest.Server) {
 	t.Helper()
 	server := httptest.NewServer(newController(m))

--- a/internal/unifiprotect/controller_test.go
+++ b/internal/unifiprotect/controller_test.go
@@ -1,0 +1,117 @@
+package unifiprotect
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerHandshake(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	ws, server := connectCamera(t, m)
+	defer server.Close()
+	defer ws.Close()
+
+	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.Equal(t, 16000, s.opusRate)
+	require.Equal(t, "127.0.0.1", s.cameraIP)
+}
+
+func TestControllerRejectsMalformedCameraMAC(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	request := httptest.NewRequest(http.MethodGet, websocketPath, nil)
+	request.Header.Set("Connection", "Upgrade")
+	request.Header.Set("Upgrade", "websocket")
+	request.Header.Set("Sec-WebSocket-Version", "13")
+	request.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	request.Header.Set("Sec-WebSocket-Protocol", websocketProtocol)
+	request.Header.Set("camera-mac", "not-a-mac")
+	recorder := httptest.NewRecorder()
+
+	newController(m).ServeHTTP(recorder, request)
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func connectCamera(t *testing.T, m *Manager) (*websocket.Conn, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(newController(m))
+
+	dialer := websocket.Dialer{Subprotocols: []string{websocketProtocol}}
+	header := http.Header{"camera-mac": []string{"02AABBCCDDEE"}}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + websocketPath
+	ws, response, err := dialer.Dial(wsURL, header)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+	require.Equal(t, websocketProtocol, ws.Subprotocol())
+
+	sendCamera(t, ws, controlMessage{
+		From:         "ubnt_avclient",
+		FunctionName: "ubnt_avclient_timeSync",
+		MessageID:    1,
+		Payload:      json.RawMessage(`{"timeDelta":0}`),
+		To:           "UniFiVideo",
+	})
+	timeSync := readController(t, ws)
+	require.Equal(t, "ubnt_avclient_timeSync", timeSync.FunctionName)
+	require.Equal(t, int64(1), timeSync.InResponseTo)
+
+	hello, err := json.Marshal(map[string]any{
+		"protocolVersion": 67,
+		"features": map[string]any{
+			"audioCodecs":     []string{"aac", "opus"},
+			"opusSampleRates": []int{16000},
+		},
+	})
+	require.NoError(t, err)
+	sendCamera(t, ws, controlMessage{
+		From:         "ubnt_avclient",
+		FunctionName: "ubnt_avclient_hello",
+		MessageID:    2,
+		Payload:      hello,
+		To:           "UniFiVideo",
+	})
+	helloResponse := readController(t, ws)
+	require.Equal(t, "ubnt_avclient_hello", helloResponse.FunctionName)
+	require.Equal(t, int64(2), helloResponse.InResponseTo)
+
+	agreement := readController(t, ws)
+	require.Equal(t, "ubnt_avclient_paramAgreement", agreement.FunctionName)
+	require.True(t, agreement.ResponseExpected)
+	sendCamera(t, ws, controlMessage{
+		From:         "ubnt_avclient",
+		FunctionName: "ubnt_avclient_paramAgreement",
+		InResponseTo: agreement.MessageID,
+		MessageID:    3,
+		Payload:      json.RawMessage(`{"authToken":"test"}`),
+		To:           "UniFiVideo",
+	})
+
+	quiesce := readController(t, ws)
+	require.Equal(t, "ChangeVideoSettings", quiesce.FunctionName)
+	return ws, server
+}
+
+func sendCamera(t *testing.T, ws *websocket.Conn, msg controlMessage) {
+	t.Helper()
+	b, err := json.Marshal(msg)
+	require.NoError(t, err)
+	require.NoError(t, ws.WriteMessage(websocket.BinaryMessage, b))
+}
+
+func readController(t *testing.T, ws *websocket.Conn) controlMessage {
+	t.Helper()
+	require.NoError(t, ws.SetReadDeadline(time.Now().Add(3*time.Second)))
+	messageType, b, err := ws.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, websocket.BinaryMessage, messageType)
+	var msg controlMessage
+	require.NoError(t, json.Unmarshal(b, &msg))
+	return msg
+}

--- a/internal/unifiprotect/controller_test.go
+++ b/internal/unifiprotect/controller_test.go
@@ -24,6 +24,79 @@ func TestControllerHandshake(t *testing.T) {
 	require.Equal(t, "127.0.0.1", s.cameraIP)
 }
 
+func TestStartStreamPreservesNegotiatedAudioProfile(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	ws, server := connectCamera(t, m)
+	defer server.Close()
+	defer ws.Close()
+
+	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
+	require.NoError(t, err)
+
+	require.NoError(t, s.startStream("video1", "tcp://127.0.0.1:7550", "muted", false))
+	muted := decodeVideoCommand(t, readController(t, ws), "video1")
+	require.True(t, muted.Parameters.SuppressAudio)
+	require.True(t, muted.Parameters.WithOpus)
+	require.NotNil(t, muted.Parameters.OpusSampleRate)
+	require.Equal(t, 16000, *muted.Parameters.OpusSampleRate)
+
+	require.NoError(t, s.startStream("video1", "tcp://127.0.0.1:7550", "audio", true))
+	withAudio := decodeVideoCommand(t, readController(t, ws), "video1")
+	require.False(t, withAudio.Parameters.SuppressAudio)
+	require.True(t, withAudio.Parameters.WithOpus)
+	require.NotNil(t, withAudio.Parameters.OpusSampleRate)
+	require.Equal(t, 16000, *withAudio.Parameters.OpusSampleRate)
+}
+
+func TestStartStreamAACFallback(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	ws, server := connectCameraFeatures(t, m, cameraFeatures{AudioCodecs: []string{"aac"}})
+	defer server.Close()
+	defer ws.Close()
+
+	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.NoError(t, s.startStream("video1", "tcp://127.0.0.1:7550", "audio", true))
+
+	command := decodeVideoCommand(t, readController(t, ws), "video1")
+	require.False(t, command.Parameters.SuppressAudio)
+	require.False(t, command.Parameters.WithOpus)
+	require.Nil(t, command.Parameters.OpusSampleRate)
+}
+
+func TestControllerIgnoresHelloCapabilitiesAfterReady(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	ws, server := connectCamera(t, m)
+	defer server.Close()
+	defer ws.Close()
+
+	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
+	require.NoError(t, err)
+
+	hello, err := json.Marshal(helloPayload{
+		ProtocolVersion: 67,
+		Features: cameraFeatures{
+			AudioCodecs:    []string{"aac", "opus"},
+			OpusSampleRate: []int{48000},
+		},
+	})
+	require.NoError(t, err)
+	sendCamera(t, ws, controlMessage{
+		From:         "ubnt_avclient",
+		FunctionName: "ubnt_avclient_hello",
+		MessageID:    4,
+		Payload:      hello,
+		To:           "UniFiVideo",
+	})
+
+	response := readController(t, ws)
+	require.Equal(t, "ubnt_avclient_hello", response.FunctionName)
+	require.Equal(t, int64(4), response.InResponseTo)
+	agreement := readController(t, ws)
+	require.Equal(t, "ubnt_avclient_paramAgreement", agreement.FunctionName)
+	require.Equal(t, 16000, s.opusRate)
+}
+
 func TestControllerRejectsMalformedCameraMAC(t *testing.T) {
 	m := newManager("", 7550, "test", "controller-id")
 	request := httptest.NewRequest(http.MethodGet, websocketPath, nil)
@@ -61,6 +134,13 @@ func TestControllerClosesIncompleteHandshake(t *testing.T) {
 }
 
 func connectCamera(t *testing.T, m *Manager) (*websocket.Conn, *httptest.Server) {
+	return connectCameraFeatures(t, m, cameraFeatures{
+		AudioCodecs:    []string{"aac", "opus"},
+		OpusSampleRate: []int{16000},
+	})
+}
+
+func connectCameraFeatures(t *testing.T, m *Manager, features cameraFeatures) (*websocket.Conn, *httptest.Server) {
 	t.Helper()
 	server := httptest.NewServer(newController(m))
 
@@ -83,12 +163,9 @@ func connectCamera(t *testing.T, m *Manager) (*websocket.Conn, *httptest.Server)
 	require.Equal(t, "ubnt_avclient_timeSync", timeSync.FunctionName)
 	require.Equal(t, int64(1), timeSync.InResponseTo)
 
-	hello, err := json.Marshal(map[string]any{
-		"protocolVersion": 67,
-		"features": map[string]any{
-			"audioCodecs":     []string{"aac", "opus"},
-			"opusSampleRates": []int{16000},
-		},
+	hello, err := json.Marshal(helloPayload{
+		ProtocolVersion: 67,
+		Features:        features,
 	})
 	require.NoError(t, err)
 	sendCamera(t, ws, controlMessage{

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -77,18 +77,29 @@ func newManager(mediaHost string, mediaPort int, controllerVersion, controllerUU
 func (m *Manager) addSession(s *session) {
 	m.mu.Lock()
 	old := m.sessions[s.mac]
-	delete(m.sessions, s.mac)
+	if old == s && s.ready {
+		m.mu.Unlock()
+		return
+	}
+	s.ready = false
+	m.sessions[s.mac] = s
 	active := make(map[string]bool)
 	for key := range m.active {
 		if key.mac == s.mac {
 			active[key.channel] = true
 		}
 	}
-	m.signalLocked()
 	m.mu.Unlock()
 
 	if old != nil && old != s {
 		old.close()
+	}
+
+	m.mu.Lock()
+	current := m.sessions[s.mac] == s
+	m.mu.Unlock()
+	if !current {
+		return
 	}
 
 	var inactive []string
@@ -102,7 +113,11 @@ func (m *Manager) addSession(s *session) {
 	}
 
 	m.mu.Lock()
-	m.sessions[s.mac] = s
+	if m.sessions[s.mac] != s {
+		m.mu.Unlock()
+		return
+	}
+	s.ready = true
 	m.signalLocked()
 	m.mu.Unlock()
 
@@ -126,7 +141,7 @@ func (m *Manager) signalLocked() {
 func (m *Manager) waitSession(mac string, deadline time.Time) (*session, error) {
 	for {
 		m.mu.Lock()
-		if s := m.sessions[mac]; s != nil {
+		if s := m.sessions[mac]; s != nil && s.ready {
 			m.mu.Unlock()
 			return s, nil
 		}

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -1,0 +1,421 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/unifiprotect"
+)
+
+const (
+	sourceTimeout = 25 * time.Second
+	probeTimeout  = 5 * time.Second
+	settleTime    = 800 * time.Millisecond
+)
+
+var cameraChannels = [...]string{"video1", "video2", "video3"}
+
+type streamKey struct {
+	mac     string
+	channel string
+}
+
+type streamRequest struct {
+	key       streamKey
+	token     string
+	cameraIP  string
+	audioMode unifiprotect.AudioMode
+
+	candidates chan candidate
+	done       chan struct{}
+	mu         sync.Mutex
+	closed     bool
+}
+
+type candidate struct {
+	conn net.Conn
+	rd   io.ReadCloser
+}
+
+type Manager struct {
+	mu sync.Mutex
+
+	sessions map[string]*session
+	pending  map[string]*streamRequest
+	active   map[streamKey]*streamRequest
+	changed  chan struct{}
+
+	mediaHost         string
+	mediaPort         int
+	controllerUUID    string
+	controllerVersion string
+}
+
+func newManager(mediaHost string, mediaPort int, controllerVersion, controllerUUID string) *Manager {
+	return &Manager{
+		sessions:          make(map[string]*session),
+		pending:           make(map[string]*streamRequest),
+		active:            make(map[streamKey]*streamRequest),
+		changed:           make(chan struct{}),
+		mediaHost:         mediaHost,
+		mediaPort:         mediaPort,
+		controllerUUID:    controllerUUID,
+		controllerVersion: controllerVersion,
+	}
+}
+
+func (m *Manager) addSession(s *session) {
+	m.mu.Lock()
+	old := m.sessions[s.mac]
+	delete(m.sessions, s.mac)
+	active := make(map[string]bool)
+	for key := range m.active {
+		if key.mac == s.mac {
+			active[key.channel] = true
+		}
+	}
+	m.signalLocked()
+	m.mu.Unlock()
+
+	if old != nil && old != s {
+		old.close()
+	}
+
+	var inactive []string
+	for _, channel := range cameraChannels {
+		if !active[channel] {
+			inactive = append(inactive, channel)
+		}
+	}
+	if err := s.stopStreams(inactive); err != nil {
+		log.Debug().Err(err).Str("camera", s.mac).Msg("[unifi-protect] quiesce streams")
+	}
+
+	m.mu.Lock()
+	m.sessions[s.mac] = s
+	m.signalLocked()
+	m.mu.Unlock()
+
+	log.Info().Str("camera", s.mac).Str("remote", s.cameraIP).Msg("[unifi-protect] camera online")
+}
+
+func (m *Manager) removeSession(s *session) {
+	m.mu.Lock()
+	if m.sessions[s.mac] == s {
+		delete(m.sessions, s.mac)
+		m.signalLocked()
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) signalLocked() {
+	close(m.changed)
+	m.changed = make(chan struct{})
+}
+
+func (m *Manager) waitSession(mac string, deadline time.Time) (*session, error) {
+	for {
+		m.mu.Lock()
+		if s := m.sessions[mac]; s != nil {
+			m.mu.Unlock()
+			return s, nil
+		}
+		changed := m.changed
+		m.mu.Unlock()
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, fmt.Errorf("%w: %s", errSessionUnavailable, mac)
+		}
+		timer := time.NewTimer(remaining)
+		select {
+		case <-changed:
+			if !timer.Stop() {
+				<-timer.C
+			}
+		case <-timer.C:
+			return nil, fmt.Errorf("%w: %s", errSessionUnavailable, mac)
+		}
+	}
+}
+
+func (m *Manager) open(source string) (core.Producer, error) {
+	parsed, err := parseSource(source)
+	if err != nil {
+		return nil, err
+	}
+
+	deadline := time.Now().Add(sourceTimeout)
+	s, err := m.waitSession(parsed.mac, deadline)
+	if err != nil {
+		return nil, err
+	}
+
+	host := m.mediaHost
+	if host == "" {
+		host = s.controllerHost
+	}
+	if host == "" {
+		return nil, errors.New("unifi-protect: can't determine media destination host")
+	}
+
+	token, err := randomToken()
+	if err != nil {
+		return nil, err
+	}
+
+	audioMode := unifiprotect.AudioNone
+	if parsed.audio {
+		if s.opusRate != 0 {
+			audioMode = unifiprotect.AudioOpus
+		} else {
+			audioMode = unifiprotect.AudioAAC
+		}
+	}
+	req := &streamRequest{
+		key:        streamKey{mac: parsed.mac, channel: parsed.channel},
+		token:      token,
+		cameraIP:   s.cameraIP,
+		audioMode:  audioMode,
+		candidates: make(chan candidate, 1),
+		done:       make(chan struct{}),
+	}
+
+	m.mu.Lock()
+	if current := m.active[req.key]; current != nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("unifi-protect: stream already active for %s/%s", parsed.mac, parsed.channel)
+	}
+	m.active[req.key] = req
+	m.pending[token] = req
+	m.mu.Unlock()
+
+	destination := "tcp://" + net.JoinHostPort(host, strconv.Itoa(m.mediaPort))
+	log.Debug().Str("camera", parsed.mac).Str("channel", parsed.channel).Str("destination", destination).Msg("[unifi-protect] start stream")
+	if err = s.startStream(parsed.channel, destination, token, parsed.audio); err != nil {
+		m.release(req, false)
+		return nil, err
+	}
+
+	prod, err := m.waitProducer(req, deadline)
+	if err != nil {
+		m.release(req, true)
+		return nil, err
+	}
+	prod.SetOnStop(func() { m.release(req, true) })
+	prod.Source = source
+	prod.RemoteAddr = s.cameraIP
+	return prod, nil
+}
+
+func (m *Manager) waitProducer(req *streamRequest, deadline time.Time) (*unifiprotect.Producer, error) {
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		selected, err := req.settledCandidate(deadline)
+		if err != nil {
+			if lastErr != nil {
+				return nil, fmt.Errorf("unifi-protect: media probe: %w", lastErr)
+			}
+			return nil, err
+		}
+
+		_ = selected.conn.SetReadDeadline(time.Now().Add(probeTimeout))
+		prod, err := unifiprotect.Open(selected.rd, req.audioMode)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		_ = selected.conn.SetReadDeadline(time.Time{})
+
+		m.mu.Lock()
+		if m.pending[req.token] == req {
+			delete(m.pending, req.token)
+		}
+		m.mu.Unlock()
+		return prod, nil
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("unifi-protect: media probe: %w", lastErr)
+	}
+	return nil, errors.New("unifi-protect: timed out waiting for camera media")
+}
+
+func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) {
+	var selected candidate
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return selected, errors.New("unifi-protect: timed out waiting for camera media")
+	}
+	timer := time.NewTimer(remaining)
+	select {
+	case selected = <-r.candidates:
+		if !timer.Stop() {
+			<-timer.C
+		}
+	case <-r.done:
+		timer.Stop()
+		return selected, net.ErrClosed
+	case <-timer.C:
+		return selected, errors.New("unifi-protect: timed out waiting for camera media")
+	}
+
+	settle := time.NewTimer(settleTime)
+	defer settle.Stop()
+	for {
+		select {
+		case next := <-r.candidates:
+			_ = selected.rd.Close()
+			selected = next
+			if !settle.Stop() {
+				<-settle.C
+			}
+			settle.Reset(settleTime)
+		case <-settle.C:
+			return selected, nil
+		case <-r.done:
+			_ = selected.rd.Close()
+			return candidate{}, net.ErrClosed
+		}
+	}
+}
+
+func (r *streamRequest) offer(c candidate) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	select {
+	case old := <-r.candidates:
+		_ = old.rd.Close()
+	default:
+	}
+	r.candidates <- c
+	return true
+}
+
+func (r *streamRequest) close() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
+	r.closed = true
+	close(r.done)
+	select {
+	case c := <-r.candidates:
+		_ = c.rd.Close()
+	default:
+	}
+}
+
+func (m *Manager) release(req *streamRequest, stop bool) {
+	req.close()
+
+	m.mu.Lock()
+	if m.active[req.key] != req {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.active, req.key)
+	if m.pending[req.token] == req {
+		delete(m.pending, req.token)
+	}
+	s := m.sessions[req.key.mac]
+	m.mu.Unlock()
+
+	if stop && s != nil {
+		if err := s.stopStreams([]string{req.key.channel}); err != nil {
+			log.Debug().Err(err).Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] stop stream")
+		}
+	}
+}
+
+func (m *Manager) serveMedia(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go m.handleMedia(conn)
+	}
+}
+
+func (m *Manager) handleMedia(conn net.Conn) {
+	log.Debug().Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media connection")
+	owned := true
+	defer func() {
+		if owned {
+			_ = conn.Close()
+		}
+	}()
+
+	_ = conn.SetReadDeadline(time.Now().Add(probeTimeout))
+	var prefix bytes.Buffer
+	rd := unifiprotect.NewReader(io.TeeReader(conn, &prefix))
+
+	var token string
+	for i := 0; i < 8; i++ {
+		tag, err := rd.ReadTag()
+		if err != nil {
+			log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media header")
+			return
+		}
+		metadata, ok, err := unifiprotect.ParseMetadata(tag)
+		if err != nil {
+			log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media metadata")
+			return
+		}
+		if ok {
+			token = metadata.StreamName
+			break
+		}
+	}
+	if token == "" {
+		log.Debug().Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media stream name missing")
+		return
+	}
+
+	m.mu.Lock()
+	req := m.pending[token]
+	m.mu.Unlock()
+	if req == nil || req.cameraIP != remoteHost(conn.RemoteAddr().String()) {
+		log.Debug().Str("remote", conn.RemoteAddr().String()).Str("stream_name", token).Msg("[unifi-protect] unrouted media")
+		return
+	}
+
+	replay := &replayReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(append([]byte(nil), prefix.Bytes()...)), conn),
+		Closer: conn,
+	}
+	if !req.offer(candidate{conn: conn, rd: replay}) {
+		return
+	}
+	log.Debug().Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] routed media")
+	owned = false
+}
+
+type replayReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func randomToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -35,10 +35,11 @@ type streamRequest struct {
 	cameraIP  string
 	audioMode unifiprotect.AudioMode
 
-	candidates chan candidate
-	done       chan struct{}
-	mu         sync.Mutex
-	closed     bool
+	candidates  chan candidate
+	done        chan struct{}
+	mu          sync.Mutex
+	closed      bool
+	releaseOnce sync.Once
 }
 
 type candidate struct {
@@ -322,25 +323,32 @@ func (r *streamRequest) close() {
 }
 
 func (m *Manager) release(req *streamRequest, stop bool) {
-	req.close()
+	req.releaseOnce.Do(func() {
+		req.close()
 
-	m.mu.Lock()
-	if m.active[req.key] != req {
-		m.mu.Unlock()
-		return
-	}
-	delete(m.active, req.key)
-	if m.pending[req.token] == req {
-		delete(m.pending, req.token)
-	}
-	s := m.sessions[req.key.mac]
-	m.mu.Unlock()
-
-	if stop && s != nil {
-		if err := s.stopStreams([]string{req.key.channel}); err != nil {
-			log.Debug().Err(err).Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] stop stream")
+		m.mu.Lock()
+		if m.active[req.key] != req {
+			m.mu.Unlock()
+			return
 		}
-	}
+		if m.pending[req.token] == req {
+			delete(m.pending, req.token)
+		}
+		s := m.sessions[req.key.mac]
+		m.mu.Unlock()
+
+		if stop && s != nil {
+			if err := s.stopStreams([]string{req.key.channel}); err != nil {
+				log.Debug().Err(err).Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] stop stream")
+			}
+		}
+
+		m.mu.Lock()
+		if m.active[req.key] == req {
+			delete(m.active, req.key)
+		}
+		m.mu.Unlock()
+	})
 }
 
 func (m *Manager) serveMedia(ln net.Listener) {

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -248,7 +248,11 @@ func (m *Manager) waitProducer(req *streamRequest, deadline time.Time) (*unifipr
 			return nil, err
 		}
 
-		_ = selected.conn.SetReadDeadline(time.Now().Add(probeTimeout))
+		probeDeadline := time.Now().Add(probeTimeout)
+		if deadline.Before(probeDeadline) {
+			probeDeadline = deadline
+		}
+		_ = selected.conn.SetReadDeadline(probeDeadline)
 		prod, err := unifiprotect.Open(selected.rd, req.audioMode)
 		if err != nil {
 			lastErr = err

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -259,6 +259,7 @@ func (m *Manager) waitProducer(req *streamRequest, deadline time.Time) (*unifipr
 			continue
 		}
 		_ = selected.conn.SetReadDeadline(time.Time{})
+		req.close()
 
 		m.mu.Lock()
 		if m.pending[req.token] == req {

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -86,6 +86,9 @@ func (m *Manager) addSession(s *session) {
 		m.mu.Unlock()
 		return
 	}
+	// Install the replacement before closing the old session. removeSession
+	// checks identity, so a late close can't remove the new session. Keep it
+	// unready until channels left behind by the previous connection are stopped.
 	s.ready = false
 	m.sessions[s.mac] = s
 	active := make(map[string]bool)
@@ -261,6 +264,8 @@ func (m *Manager) waitProducer(req *streamRequest, deadline time.Time) (*unifipr
 			continue
 		}
 		_ = selected.conn.SetReadDeadline(time.Time{})
+		// Open owns the selected connection now. Retiring candidate intake closes
+		// late duplicate pushes without touching the producer transport.
 		req.retireCandidates()
 
 		m.mu.Lock()
@@ -294,6 +299,8 @@ func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) 
 		return selected, errors.New("unifi-protect: timed out waiting for camera media")
 	}
 
+	// A camera may open several connections for one request. Let the burst
+	// settle and keep the newest attempt, closing the ones it supersedes.
 	settle := time.NewTimer(settleTime)
 	defer settle.Stop()
 	for {
@@ -362,6 +369,8 @@ func (m *Manager) release(req *streamRequest, stop bool) {
 		s := m.sessions[req.key.mac]
 		m.mu.Unlock()
 
+		// Keep the request active until the stop command completes. Otherwise a
+		// replacement could start the same channel while its old push still runs.
 		if stop && s != nil {
 			if err := s.stopStreams([]string{req.key.channel}); err != nil {
 				log.Debug().Err(err).Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] stop stream")

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -274,16 +274,13 @@ func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) 
 	if remaining <= 0 {
 		return selected, errors.New("unifi-protect: timed out waiting for camera media")
 	}
-	timer := time.NewTimer(remaining)
+	deadlineTimer := time.NewTimer(remaining)
+	defer deadlineTimer.Stop()
 	select {
 	case selected = <-r.candidates:
-		if !timer.Stop() {
-			<-timer.C
-		}
 	case <-r.done:
-		timer.Stop()
 		return selected, net.ErrClosed
-	case <-timer.C:
+	case <-deadlineTimer.C:
 		return selected, errors.New("unifi-protect: timed out waiting for camera media")
 	}
 
@@ -303,6 +300,9 @@ func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) 
 		case <-r.done:
 			_ = selected.rd.Close()
 			return candidate{}, net.ErrClosed
+		case <-deadlineTimer.C:
+			_ = selected.rd.Close()
+			return candidate{}, errors.New("unifi-protect: timed out waiting for camera media")
 		}
 	}
 }

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -1,7 +1,6 @@
 package unifiprotect
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -36,11 +35,14 @@ type streamRequest struct {
 	cameraIP  string
 	audioMode unifiprotect.AudioMode
 
-	candidates  chan candidate
-	done        chan struct{}
-	mu          sync.Mutex
-	closed      bool
-	releaseOnce sync.Once
+	// Lifecycle: pending -> probing -> committed -> released. Pending and
+	// probing requests accept media candidates. Committing retires candidates,
+	// while the request remains active until the producer is released.
+	candidates        chan candidate
+	candidatesDone    chan struct{}
+	mu                sync.Mutex
+	candidatesRetired bool
+	releaseOnce       sync.Once
 }
 
 type candidate struct {
@@ -201,12 +203,12 @@ func (m *Manager) open(source string) (core.Producer, error) {
 		}
 	}
 	req := &streamRequest{
-		key:        streamKey{mac: parsed.mac, channel: parsed.channel},
-		token:      token,
-		cameraIP:   s.cameraIP,
-		audioMode:  audioMode,
-		candidates: make(chan candidate, 1),
-		done:       make(chan struct{}),
+		key:            streamKey{mac: parsed.mac, channel: parsed.channel},
+		token:          token,
+		cameraIP:       s.cameraIP,
+		audioMode:      audioMode,
+		candidates:     make(chan candidate, 1),
+		candidatesDone: make(chan struct{}),
 	}
 
 	m.mu.Lock()
@@ -259,7 +261,7 @@ func (m *Manager) waitProducer(req *streamRequest, deadline time.Time) (*unifipr
 			continue
 		}
 		_ = selected.conn.SetReadDeadline(time.Time{})
-		req.close()
+		req.retireCandidates()
 
 		m.mu.Lock()
 		if m.pending[req.token] == req {
@@ -286,7 +288,7 @@ func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) 
 	defer deadlineTimer.Stop()
 	select {
 	case selected = <-r.candidates:
-	case <-r.done:
+	case <-r.candidatesDone:
 		return selected, net.ErrClosed
 	case <-deadlineTimer.C:
 		return selected, errors.New("unifi-protect: timed out waiting for camera media")
@@ -305,7 +307,7 @@ func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) 
 			settle.Reset(settleTime)
 		case <-settle.C:
 			return selected, nil
-		case <-r.done:
+		case <-r.candidatesDone:
 			_ = selected.rd.Close()
 			return candidate{}, net.ErrClosed
 		case <-deadlineTimer.C:
@@ -315,10 +317,10 @@ func (r *streamRequest) settledCandidate(deadline time.Time) (candidate, error) 
 	}
 }
 
-func (r *streamRequest) offer(c candidate) bool {
+func (r *streamRequest) offerCandidate(c candidate) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.closed {
+	if r.candidatesRetired {
 		return false
 	}
 	select {
@@ -330,14 +332,14 @@ func (r *streamRequest) offer(c candidate) bool {
 	return true
 }
 
-func (r *streamRequest) close() {
+func (r *streamRequest) retireCandidates() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if r.closed {
+	if r.candidatesRetired {
 		return
 	}
-	r.closed = true
-	close(r.done)
+	r.candidatesRetired = true
+	close(r.candidatesDone)
 	select {
 	case c := <-r.candidates:
 		_ = c.rd.Close()
@@ -347,7 +349,7 @@ func (r *streamRequest) close() {
 
 func (m *Manager) release(req *streamRequest, stop bool) {
 	req.releaseOnce.Do(func() {
-		req.close()
+		req.retireCandidates()
 
 		m.mu.Lock()
 		if m.active[req.key] != req {
@@ -372,76 +374,6 @@ func (m *Manager) release(req *streamRequest, stop bool) {
 		}
 		m.mu.Unlock()
 	})
-}
-
-func (m *Manager) serveMedia(ln net.Listener) {
-	for {
-		conn, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		go m.handleMedia(conn)
-	}
-}
-
-func (m *Manager) handleMedia(conn net.Conn) {
-	log.Debug().Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media connection")
-	owned := true
-	defer func() {
-		if owned {
-			_ = conn.Close()
-		}
-	}()
-
-	_ = conn.SetReadDeadline(time.Now().Add(probeTimeout))
-	var prefix bytes.Buffer
-	limited := &io.LimitedReader{R: conn, N: m.mediaProbeLimit}
-	rd := unifiprotect.NewReader(io.TeeReader(limited, &prefix))
-
-	var token string
-	for i := 0; i < 8; i++ {
-		tag, err := rd.ReadTag()
-		if err != nil {
-			log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media header")
-			return
-		}
-		metadata, ok, err := unifiprotect.ParseMetadata(tag)
-		if err != nil {
-			log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media metadata")
-			return
-		}
-		if ok {
-			token = metadata.StreamName
-			break
-		}
-	}
-	if token == "" {
-		log.Debug().Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media stream name missing")
-		return
-	}
-
-	m.mu.Lock()
-	req := m.pending[token]
-	m.mu.Unlock()
-	if req == nil || req.cameraIP != remoteHost(conn.RemoteAddr().String()) {
-		log.Debug().Str("remote", conn.RemoteAddr().String()).Str("stream_name", token).Msg("[unifi-protect] unrouted media")
-		return
-	}
-
-	replay := &replayReadCloser{
-		Reader: io.MultiReader(bytes.NewReader(append([]byte(nil), prefix.Bytes()...)), conn),
-		Closer: conn,
-	}
-	if !req.offer(candidate{conn: conn, rd: replay}) {
-		return
-	}
-	log.Debug().Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] routed media")
-	owned = false
-}
-
-type replayReadCloser struct {
-	io.Reader
-	io.Closer
 }
 
 func randomToken() (string, error) {

--- a/internal/unifiprotect/manager.go
+++ b/internal/unifiprotect/manager.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	sourceTimeout = 25 * time.Second
-	probeTimeout  = 5 * time.Second
-	settleTime    = 800 * time.Millisecond
+	sourceTimeout   = 25 * time.Second
+	probeTimeout    = 5 * time.Second
+	settleTime      = 800 * time.Millisecond
+	mediaProbeLimit = 8 * 1024 * 1024
 )
 
 var cameraChannels = [...]string{"video1", "video2", "video3"}
@@ -59,6 +60,7 @@ type Manager struct {
 	mediaPort         int
 	controllerUUID    string
 	controllerVersion string
+	mediaProbeLimit   int64
 }
 
 func newManager(mediaHost string, mediaPort int, controllerVersion, controllerUUID string) *Manager {
@@ -71,6 +73,7 @@ func newManager(mediaHost string, mediaPort int, controllerVersion, controllerUU
 		mediaPort:         mediaPort,
 		controllerUUID:    controllerUUID,
 		controllerVersion: controllerVersion,
+		mediaProbeLimit:   mediaProbeLimit,
 	}
 }
 
@@ -387,7 +390,8 @@ func (m *Manager) handleMedia(conn net.Conn) {
 
 	_ = conn.SetReadDeadline(time.Now().Add(probeTimeout))
 	var prefix bytes.Buffer
-	rd := unifiprotect.NewReader(io.TeeReader(conn, &prefix))
+	limited := &io.LimitedReader{R: conn, N: m.mediaProbeLimit}
+	rd := unifiprotect.NewReader(io.TeeReader(limited, &prefix))
 
 	var token string
 	for i := 0; i < 8; i++ {

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -108,10 +108,10 @@ func TestManagerReleaseKeepsChannelActiveUntilStopSent(t *testing.T) {
 	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
 	require.NoError(t, err)
 	req := &streamRequest{
-		key:        streamKey{mac: "02AABBCCDDEE", channel: "video2"},
-		token:      "test-token",
-		candidates: make(chan candidate, 1),
-		done:       make(chan struct{}),
+		key:            streamKey{mac: "02AABBCCDDEE", channel: "video2"},
+		token:          "test-token",
+		candidates:     make(chan candidate, 1),
+		candidatesDone: make(chan struct{}),
 	}
 	m.mu.Lock()
 	m.active[req.key] = req
@@ -248,8 +248,8 @@ func TestManagerConcurrentSessionReplacement(t *testing.T) {
 
 func TestSettledCandidateHonorsDeadline(t *testing.T) {
 	req := &streamRequest{
-		candidates: make(chan candidate, 1),
-		done:       make(chan struct{}),
+		candidates:     make(chan candidate, 1),
+		candidatesDone: make(chan struct{}),
 	}
 	req.candidates <- candidate{rd: io.NopCloser(bytes.NewReader(nil))}
 
@@ -259,8 +259,8 @@ func TestSettledCandidateHonorsDeadline(t *testing.T) {
 
 func TestWaitProducerCapsProbeDeadline(t *testing.T) {
 	req := &streamRequest{
-		candidates: make(chan candidate, 1),
-		done:       make(chan struct{}),
+		candidates:     make(chan candidate, 1),
+		candidatesDone: make(chan struct{}),
 	}
 	server, client := net.Pipe()
 	defer server.Close()
@@ -283,7 +283,7 @@ func TestWaitProducerCapsProbeDeadline(t *testing.T) {
 	select {
 	case got := <-conn.deadlines:
 		require.Equal(t, deadline, got)
-		req.close()
+		req.retireCandidates()
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for probe deadline")
 	}
@@ -296,9 +296,9 @@ func TestWaitProducerCapsProbeDeadline(t *testing.T) {
 
 func TestWaitProducerRetiresLateCandidate(t *testing.T) {
 	req := &streamRequest{
-		token:      "test-token",
-		candidates: make(chan candidate, 1),
-		done:       make(chan struct{}),
+		token:          "test-token",
+		candidates:     make(chan candidate, 1),
+		candidatesDone: make(chan struct{}),
 	}
 	winnerServer, winnerClient := net.Pipe()
 	defer winnerServer.Close()
@@ -330,7 +330,7 @@ func TestWaitProducerRetiresLateCandidate(t *testing.T) {
 	defer duplicateServer.Close()
 	defer duplicateClient.Close()
 	require.NoError(t, duplicateClient.SetReadDeadline(time.Now().Add(time.Second)))
-	require.True(t, req.offer(candidate{conn: duplicateServer, rd: duplicateServer}))
+	require.True(t, req.offerCandidate(candidate{conn: duplicateServer, rd: duplicateServer}))
 	_, err := winnerClient.Write(syntheticMedia(req.token))
 	require.NoError(t, err)
 

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -1,0 +1,260 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/flv"
+	"github.com/AlexxIT/go2rtc/pkg/flv/amf"
+	"github.com/AlexxIT/go2rtc/pkg/h264"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerSyntheticCamera(t *testing.T) {
+	mediaListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer mediaListener.Close()
+
+	m := newManager("", mediaListener.Addr().(*net.TCPAddr).Port, "test", "controller-id")
+	go m.serveMedia(mediaListener)
+	ws, server := connectCamera(t, m)
+	defer server.Close()
+	defer ws.Close()
+
+	type openResult struct {
+		producer core.Producer
+		err      error
+	}
+	result := make(chan openResult, 1)
+	go func() {
+		producer, err := m.open("unifi-protect://02AABBCCDDEE?channel=video2&audio=0")
+		result <- openResult{producer: producer, err: err}
+	}()
+
+	start := readController(t, ws)
+	require.Equal(t, "ChangeVideoSettings", start.FunctionName)
+	command := decodeVideoCommand(t, start, "video2")
+	require.True(t, command.Parameters.SuppressAudio)
+	require.False(t, command.Parameters.WithOpus)
+	require.Len(t, command.Destinations, 1)
+	require.NotEmpty(t, command.Parameters.StreamName)
+
+	media, err := net.Dial("tcp", mediaListener.Addr().String())
+	require.NoError(t, err)
+	defer media.Close()
+	_, err = media.Write(syntheticMedia(command.Parameters.StreamName))
+	require.NoError(t, err)
+
+	var first core.Producer
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		require.Len(t, got.producer.GetMedias(), 1)
+		require.Equal(t, core.CodecH264, got.producer.GetMedias()[0].Codecs[0].Name)
+		first = got.producer
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for producer")
+	}
+
+	result2 := make(chan openResult, 1)
+	go func() {
+		producer, err := m.open("unifi-protect://02AABBCCDDEE?channel=video3&audio=0")
+		result2 <- openResult{producer: producer, err: err}
+	}()
+	start2 := readController(t, ws)
+	command2 := decodeVideoCommand(t, start2, "video3")
+	media2, err := net.Dial("tcp", mediaListener.Addr().String())
+	require.NoError(t, err)
+	defer media2.Close()
+	_, err = media2.Write(syntheticMedia(command2.Parameters.StreamName))
+	require.NoError(t, err)
+
+	var second core.Producer
+	select {
+	case got := <-result2:
+		require.NoError(t, got.err)
+		second = got.producer
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for second producer")
+	}
+
+	require.NoError(t, first.Stop())
+	stop := readController(t, ws)
+	stopped := decodeVideoCommand(t, stop, "video2")
+	require.Equal(t, []string{"file:///dev/null"}, stopped.Destinations)
+
+	require.NoError(t, second.Stop())
+	stop2 := readController(t, ws)
+	stopped2 := decodeVideoCommand(t, stop2, "video3")
+	require.Equal(t, []string{"file:///dev/null"}, stopped2.Destinations)
+}
+
+func TestLoadOrCreateCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, defaultTLSCert)
+	keyPath := filepath.Join(dir, defaultTLSKey)
+
+	cert, err := loadOrCreateCertificate(certPath, keyPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, cert.Certificate)
+
+	keyInfo, err := os.Stat(keyPath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0600), keyInfo.Mode().Perm())
+
+	reloaded, err := loadOrCreateCertificate(certPath, keyPath)
+	require.NoError(t, err)
+	require.Equal(t, cert.Certificate[0], reloaded.Certificate[0])
+	require.Equal(t, certificateUUID(cert), certificateUUID(reloaded))
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+	require.True(t, leaf.IsCA)
+	require.Greater(t, time.Until(leaf.NotAfter), 9*365*24*time.Hour)
+}
+
+func TestLoadOrCreateCertificateRejectsIncompleteIdentity(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, defaultTLSCert)
+	keyPath := filepath.Join(dir, defaultTLSKey)
+	require.NoError(t, os.WriteFile(certPath, []byte("incomplete"), 0600))
+
+	_, err := loadOrCreateCertificate(certPath, keyPath)
+	require.ErrorContains(t, err, "incomplete TLS identity")
+}
+
+func TestManagerSyntheticCameraAACFallback(t *testing.T) {
+	mediaListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer mediaListener.Close()
+
+	m := newManager("", mediaListener.Addr().(*net.TCPAddr).Port, "test", "controller-id")
+	go m.serveMedia(mediaListener)
+	ws, server := connectCamera(t, m)
+	defer server.Close()
+	defer ws.Close()
+
+	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
+	require.NoError(t, err)
+	s.opusRate = 0
+
+	type openResult struct {
+		producer core.Producer
+		err      error
+	}
+	result := make(chan openResult, 1)
+	go func() {
+		producer, err := m.open("unifi-protect://02AABBCCDDEE?channel=video1")
+		result <- openResult{producer: producer, err: err}
+	}()
+
+	start := readController(t, ws)
+	command := decodeVideoCommand(t, start, "video1")
+	require.False(t, command.Parameters.SuppressAudio)
+	require.False(t, command.Parameters.WithOpus)
+
+	media, err := net.Dial("tcp", mediaListener.Addr().String())
+	require.NoError(t, err)
+	defer media.Close()
+	_, err = media.Write(syntheticMediaAAC(command.Parameters.StreamName))
+	require.NoError(t, err)
+
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		require.Len(t, got.producer.GetMedias(), 2)
+		require.Equal(t, core.CodecAAC, got.producer.GetMedias()[1].Codecs[0].Name)
+		require.NoError(t, got.producer.Stop())
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for producer")
+	}
+
+	stop := readController(t, ws)
+	require.Equal(t, "ChangeVideoSettings", stop.FunctionName)
+}
+
+type videoCommand struct {
+	Destinations []string `json:"destinations"`
+	Parameters   struct {
+		StreamName    string `json:"streamName"`
+		SuppressAudio bool   `json:"suppressAudio"`
+		WithOpus      bool   `json:"withOpus"`
+	} `json:"parameters"`
+}
+
+func decodeVideoCommand(t *testing.T, msg controlMessage, channel string) videoCommand {
+	t.Helper()
+	var payload struct {
+		Video map[string]struct {
+			AVSerializer videoCommand `json:"avSerializer"`
+		} `json:"video"`
+	}
+	require.NoError(t, json.Unmarshal(msg.Payload, &payload))
+	require.Len(t, payload.Video, 1)
+	command, ok := payload.Video[channel]
+	require.True(t, ok)
+	return command.AVSerializer
+}
+
+func syntheticMedia(token string) []byte {
+	metadata := amf.EncodeItems("onMetaData", map[string]any{
+		"streamName":  token,
+		"videoWidth":  1920,
+		"videoHeight": 1080,
+	})
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	config := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	frame := []byte{0x17, 1, 0, 0, 0, 0, 0, 0, 2, 0x65, 0x88}
+
+	wire := []byte{'F', 'L', 'V', 1, 5, 0, 0, 0, 9, 0, 0, 0, 0}
+	for i, tag := range []struct {
+		typeID byte
+		data   []byte
+	}{
+		{18, metadata},
+		{9, config},
+		{9, frame},
+	} {
+		wire = append(wire, flv.EncodeTag(tag.typeID, uint32(i*20), tag.data)...)
+		if i != 2 {
+			wire = append(wire, bytes.Repeat([]byte{0x55}, 16)...)
+		}
+	}
+	return wire
+}
+
+func syntheticMediaAAC(token string) []byte {
+	metadata := amf.EncodeItems("onMetaData", map[string]any{"streamName": token})
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	videoConfig := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	audioConfig := []byte{0xaf, 0, 0x14, 0x08}
+	videoFrame := []byte{0x17, 1, 0, 0, 0, 0, 0, 0, 2, 0x65, 0x88}
+	audioFrame := []byte{0xaf, 1, 1, 2, 3, 4}
+
+	wire := []byte{'F', 'L', 'V', 1, 5, 0, 0, 0, 9, 0, 0, 0, 0}
+	for i, tag := range []struct {
+		typeID byte
+		data   []byte
+	}{
+		{18, metadata},
+		{9, videoConfig},
+		{8, audioConfig},
+		{9, videoFrame},
+		{8, audioFrame},
+	} {
+		wire = append(wire, flv.EncodeTag(tag.typeID, uint32(i*20), tag.data)...)
+		if i != 4 {
+			wire = append(wire, bytes.Repeat([]byte{0x55}, 16)...)
+		}
+	}
+	return wire
+}

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/json"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -241,6 +242,17 @@ func TestManagerConcurrentSessionReplacement(t *testing.T) {
 	require.Same(t, second, m.sessions[second.mac])
 	require.True(t, second.ready)
 	m.mu.Unlock()
+}
+
+func TestSettledCandidateHonorsDeadline(t *testing.T) {
+	req := &streamRequest{
+		candidates: make(chan candidate, 1),
+		done:       make(chan struct{}),
+	}
+	req.candidates <- candidate{rd: io.NopCloser(bytes.NewReader(nil))}
+
+	_, err := req.settledCandidate(time.Now().Add(20 * time.Millisecond))
+	require.ErrorContains(t, err, "timed out waiting for camera media")
 }
 
 func TestLoadOrCreateCertificate(t *testing.T) {

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -96,6 +96,65 @@ func TestManagerSyntheticCamera(t *testing.T) {
 	require.Equal(t, []string{"file:///dev/null"}, stopped2.Destinations)
 }
 
+func TestManagerReleaseKeepsChannelActiveUntilStopSent(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	ws, server := connectCamera(t, m)
+	defer server.Close()
+	defer ws.Close()
+
+	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
+	require.NoError(t, err)
+	req := &streamRequest{
+		key:        streamKey{mac: "02AABBCCDDEE", channel: "video2"},
+		token:      "test-token",
+		candidates: make(chan candidate, 1),
+		done:       make(chan struct{}),
+	}
+	m.mu.Lock()
+	m.active[req.key] = req
+	m.pending[req.token] = req
+	m.mu.Unlock()
+
+	s.writeMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			s.writeMu.Unlock()
+		}
+	}()
+
+	released := make(chan struct{})
+	go func() {
+		m.release(req, true)
+		close(released)
+	}()
+
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return m.pending[req.token] == nil
+	}, time.Second, time.Millisecond)
+
+	m.mu.Lock()
+	require.Same(t, req, m.active[req.key])
+	m.mu.Unlock()
+
+	s.writeMu.Unlock()
+	locked = false
+	stop := readController(t, ws)
+	stopped := decodeVideoCommand(t, stop, "video2")
+	require.Equal(t, []string{"file:///dev/null"}, stopped.Destinations)
+
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for release")
+	}
+	m.mu.Lock()
+	require.Nil(t, m.active[req.key])
+	m.mu.Unlock()
+}
+
 func TestLoadOrCreateCertificate(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, defaultTLSCert)

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -257,6 +257,53 @@ func TestSettledCandidateHonorsDeadline(t *testing.T) {
 	require.ErrorContains(t, err, "timed out waiting for camera media")
 }
 
+func TestWaitProducerCapsProbeDeadline(t *testing.T) {
+	req := &streamRequest{
+		candidates: make(chan candidate, 1),
+		done:       make(chan struct{}),
+	}
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+	conn := &deadlineConn{
+		Conn:      server,
+		deadlines: make(chan time.Time, 1),
+	}
+	req.candidates <- candidate{
+		conn: conn,
+		rd:   io.NopCloser(bytes.NewReader(nil)),
+	}
+	deadline := time.Now().Add(4 * time.Second)
+	done := make(chan struct{})
+	go func() {
+		_, _ = newManager("", 7550, "test", "controller-id").waitProducer(req, deadline)
+		close(done)
+	}()
+
+	select {
+	case got := <-conn.deadlines:
+		require.Equal(t, deadline, got)
+		req.close()
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for probe deadline")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for producer")
+	}
+}
+
+type deadlineConn struct {
+	net.Conn
+	deadlines chan time.Time
+}
+
+func (c *deadlineConn) SetReadDeadline(deadline time.Time) error {
+	c.deadlines <- deadline
+	return c.Conn.SetReadDeadline(deadline)
+}
+
 func TestMediaRouteProbeLimit(t *testing.T) {
 	m := newManager("", 7550, "test", "controller-id")
 	m.mediaProbeLimit = 64

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -255,6 +255,37 @@ func TestSettledCandidateHonorsDeadline(t *testing.T) {
 	require.ErrorContains(t, err, "timed out waiting for camera media")
 }
 
+func TestMediaRouteProbeLimit(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	m.mediaProbeLimit = 64
+	server, client := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		m.handleMedia(server)
+		close(done)
+	}()
+
+	type writeResult struct {
+		n   int
+		err error
+	}
+	written := make(chan writeResult, 1)
+	go func() {
+		n, err := client.Write(bytes.Repeat([]byte{0}, 128))
+		written <- writeResult{n: n, err: err}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for media probe")
+	}
+	result := <-written
+	require.LessOrEqual(t, result.n, int(m.mediaProbeLimit))
+	require.Error(t, result.err)
+	require.NoError(t, client.Close())
+}
+
 func TestLoadOrCreateCertificate(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, defaultTLSCert)

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -155,6 +155,94 @@ func TestManagerReleaseKeepsChannelActiveUntilStopSent(t *testing.T) {
 	m.mu.Unlock()
 }
 
+func TestManagerConcurrentSessionReplacement(t *testing.T) {
+	m := newManager("", 7550, "test", "controller-id")
+	newBlockedSession := func() *session {
+		s := &session{
+			manager:  m,
+			mac:      "02AABBCCDDEE",
+			cameraIP: "127.0.0.1",
+			done:     make(chan struct{}),
+		}
+		// The test closes done before releasing writeMu, so stopStreams exits
+		// before it needs a WebSocket connection.
+		s.closeOnce.Do(func() {})
+		s.writeMu.Lock()
+		return s
+	}
+
+	first := newBlockedSession()
+	second := newBlockedSession()
+	firstLocked, secondLocked := true, true
+	firstClosed, secondClosed := false, false
+	defer func() {
+		if !firstClosed {
+			close(first.done)
+		}
+		if !secondClosed {
+			close(second.done)
+		}
+		if firstLocked {
+			first.writeMu.Unlock()
+		}
+		if secondLocked {
+			second.writeMu.Unlock()
+		}
+	}()
+
+	firstDone := make(chan struct{})
+	go func() {
+		m.addSession(first)
+		close(firstDone)
+	}()
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return m.sessions[first.mac] == first && !first.ready
+	}, time.Second, time.Millisecond)
+
+	secondDone := make(chan struct{})
+	go func() {
+		m.addSession(second)
+		close(secondDone)
+	}()
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return m.sessions[second.mac] == second && !second.ready
+	}, time.Second, time.Millisecond)
+
+	close(first.done)
+	firstClosed = true
+	first.writeMu.Unlock()
+	firstLocked = false
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for displaced session")
+	}
+
+	m.mu.Lock()
+	require.Same(t, second, m.sessions[second.mac])
+	require.False(t, second.ready)
+	m.mu.Unlock()
+
+	close(second.done)
+	secondClosed = true
+	second.writeMu.Unlock()
+	secondLocked = false
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for current session")
+	}
+
+	m.mu.Lock()
+	require.Same(t, second, m.sessions[second.mac])
+	require.True(t, second.ready)
+	m.mu.Unlock()
+}
+
 func TestLoadOrCreateCertificate(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, defaultTLSCert)

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -43,7 +43,9 @@ func TestManagerSyntheticCamera(t *testing.T) {
 	require.Equal(t, "ChangeVideoSettings", start.FunctionName)
 	command := decodeVideoCommand(t, start, "video2")
 	require.True(t, command.Parameters.SuppressAudio)
-	require.False(t, command.Parameters.WithOpus)
+	require.True(t, command.Parameters.WithOpus)
+	require.NotNil(t, command.Parameters.OpusSampleRate)
+	require.Equal(t, 16000, *command.Parameters.OpusSampleRate)
 	require.Len(t, command.Destinations, 1)
 	require.NotEmpty(t, command.Parameters.StreamName)
 
@@ -327,13 +329,9 @@ func TestManagerSyntheticCameraAACFallback(t *testing.T) {
 
 	m := newManager("", mediaListener.Addr().(*net.TCPAddr).Port, "test", "controller-id")
 	go m.serveMedia(mediaListener)
-	ws, server := connectCamera(t, m)
+	ws, server := connectCameraFeatures(t, m, cameraFeatures{AudioCodecs: []string{"aac"}})
 	defer server.Close()
 	defer ws.Close()
-
-	s, err := m.waitSession("02AABBCCDDEE", time.Now().Add(time.Second))
-	require.NoError(t, err)
-	s.opusRate = 0
 
 	type openResult struct {
 		producer core.Producer
@@ -349,6 +347,7 @@ func TestManagerSyntheticCameraAACFallback(t *testing.T) {
 	command := decodeVideoCommand(t, start, "video1")
 	require.False(t, command.Parameters.SuppressAudio)
 	require.False(t, command.Parameters.WithOpus)
+	require.Nil(t, command.Parameters.OpusSampleRate)
 
 	media, err := net.Dial("tcp", mediaListener.Addr().String())
 	require.NoError(t, err)
@@ -373,9 +372,10 @@ func TestManagerSyntheticCameraAACFallback(t *testing.T) {
 type videoCommand struct {
 	Destinations []string `json:"destinations"`
 	Parameters   struct {
-		StreamName    string `json:"streamName"`
-		SuppressAudio bool   `json:"suppressAudio"`
-		WithOpus      bool   `json:"withOpus"`
+		StreamName     string `json:"streamName"`
+		SuppressAudio  bool   `json:"suppressAudio"`
+		WithOpus       bool   `json:"withOpus"`
+		OpusSampleRate *int   `json:"opusSampleRate"`
 	} `json:"parameters"`
 }
 

--- a/internal/unifiprotect/manager_test.go
+++ b/internal/unifiprotect/manager_test.go
@@ -294,6 +294,69 @@ func TestWaitProducerCapsProbeDeadline(t *testing.T) {
 	}
 }
 
+func TestWaitProducerRetiresLateCandidate(t *testing.T) {
+	req := &streamRequest{
+		token:      "test-token",
+		candidates: make(chan candidate, 1),
+		done:       make(chan struct{}),
+	}
+	winnerServer, winnerClient := net.Pipe()
+	defer winnerServer.Close()
+	defer winnerClient.Close()
+	winner := &deadlineConn{
+		Conn:      winnerServer,
+		deadlines: make(chan time.Time, 1),
+	}
+	req.candidates <- candidate{conn: winner, rd: winner}
+
+	m := newManager("", 7550, "test", "controller-id")
+	m.pending[req.token] = req
+	type result struct {
+		producer core.Producer
+		err      error
+	}
+	done := make(chan result, 1)
+	go func() {
+		producer, err := m.waitProducer(req, time.Now().Add(5*time.Second))
+		done <- result{producer: producer, err: err}
+	}()
+
+	select {
+	case <-winner.deadlines:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for media probe")
+	}
+	duplicateServer, duplicateClient := net.Pipe()
+	defer duplicateServer.Close()
+	defer duplicateClient.Close()
+	require.NoError(t, duplicateClient.SetReadDeadline(time.Now().Add(time.Second)))
+	require.True(t, req.offer(candidate{conn: duplicateServer, rd: duplicateServer}))
+	_, err := winnerClient.Write(syntheticMedia(req.token))
+	require.NoError(t, err)
+
+	var producer core.Producer
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		producer = got.producer
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for producer")
+	}
+
+	_, err = duplicateClient.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF)
+
+	require.NoError(t, winnerClient.SetReadDeadline(time.Now().Add(20*time.Millisecond)))
+	_, err = winnerClient.Read(make([]byte, 1))
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	require.True(t, netErr.Timeout())
+	require.NoError(t, winnerClient.SetReadDeadline(time.Time{}))
+	require.NoError(t, producer.Stop())
+	_, err = winnerClient.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF)
+}
+
 type deadlineConn struct {
 	net.Conn
 	deadlines chan time.Time

--- a/internal/unifiprotect/media.go
+++ b/internal/unifiprotect/media.go
@@ -1,0 +1,80 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/unifiprotect"
+)
+
+func (m *Manager) serveMedia(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go m.handleMedia(conn)
+	}
+}
+
+func (m *Manager) handleMedia(conn net.Conn) {
+	log.Debug().Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media connection")
+	owned := true
+	defer func() {
+		if owned {
+			_ = conn.Close()
+		}
+	}()
+
+	_ = conn.SetReadDeadline(time.Now().Add(probeTimeout))
+	var prefix bytes.Buffer
+	limited := &io.LimitedReader{R: conn, N: m.mediaProbeLimit}
+	rd := unifiprotect.NewReader(io.TeeReader(limited, &prefix))
+
+	var token string
+	for i := 0; i < 8; i++ {
+		tag, err := rd.ReadTag()
+		if err != nil {
+			log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media header")
+			return
+		}
+		metadata, ok, err := unifiprotect.ParseMetadata(tag)
+		if err != nil {
+			log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media metadata")
+			return
+		}
+		if ok {
+			token = metadata.StreamName
+			break
+		}
+	}
+	if token == "" {
+		log.Debug().Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] media stream name missing")
+		return
+	}
+
+	m.mu.Lock()
+	req := m.pending[token]
+	m.mu.Unlock()
+	if req == nil || req.cameraIP != remoteHost(conn.RemoteAddr().String()) {
+		log.Debug().Str("remote", conn.RemoteAddr().String()).Str("stream_name", token).Msg("[unifi-protect] unrouted media")
+		return
+	}
+
+	replay := &replayReadCloser{
+		Reader: io.MultiReader(bytes.NewReader(append([]byte(nil), prefix.Bytes()...)), conn),
+		Closer: conn,
+	}
+	if !req.offerCandidate(candidate{conn: conn, rd: replay}) {
+		return
+	}
+	log.Debug().Str("camera", req.key.mac).Str("channel", req.key.channel).Msg("[unifi-protect] routed media")
+	owned = false
+}
+
+type replayReadCloser struct {
+	io.Reader
+	io.Closer
+}

--- a/internal/unifiprotect/media.go
+++ b/internal/unifiprotect/media.go
@@ -63,6 +63,8 @@ func (m *Manager) handleMedia(conn net.Conn) {
 		return
 	}
 
+	// The routing metadata is part of the media stream. Replay everything read
+	// while finding its token so the producer receives the complete FLV input.
 	replay := &replayReadCloser{
 		Reader: io.MultiReader(bytes.NewReader(append([]byte(nil), prefix.Bytes()...)), conn),
 		Closer: conn,

--- a/internal/unifiprotect/shared_listener.go
+++ b/internal/unifiprotect/shared_listener.go
@@ -1,0 +1,105 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+const tlsHandshakeRecord byte = 22
+
+// sharedListener accepts control connections through net.Listener while
+// sending non-TLS connections directly to the media handler. TLS handshake
+// records and FLV tags have distinct first bytes, so no protocol bytes need to
+// be consumed while selecting the destination.
+type sharedListener struct {
+	net.Listener
+
+	control   chan net.Conn
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+func newSharedListener(ln net.Listener) *sharedListener {
+	return &sharedListener{
+		Listener: ln,
+		control:  make(chan net.Conn),
+		done:     make(chan struct{}),
+	}
+}
+
+func (l *sharedListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.control:
+		return conn, nil
+	case <-l.done:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *sharedListener) Close() (err error) {
+	l.closeOnce.Do(func() {
+		close(l.done)
+		err = l.Listener.Close()
+	})
+	return
+}
+
+func (l *sharedListener) serve(m *Manager) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			_ = l.Close()
+			return
+		}
+		go l.route(conn, m)
+	}
+}
+
+func (l *sharedListener) route(conn net.Conn, m *Manager) {
+	owned := true
+	defer func() {
+		if owned {
+			_ = conn.Close()
+		}
+	}()
+
+	if err := conn.SetReadDeadline(time.Now().Add(probeTimeout)); err != nil {
+		return
+	}
+	var first [1]byte
+	if _, err := io.ReadFull(conn, first[:]); err != nil {
+		log.Debug().Err(err).Str("remote", conn.RemoteAddr().String()).Msg("[unifi-protect] shared connection")
+		return
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		return
+	}
+
+	conn = &replayConn{
+		Conn:   conn,
+		Reader: io.MultiReader(bytes.NewReader(first[:]), conn),
+	}
+	if first[0] != tlsHandshakeRecord {
+		owned = false
+		m.handleMedia(conn)
+		return
+	}
+
+	select {
+	case l.control <- conn:
+		owned = false
+	case <-l.done:
+	}
+}
+
+type replayConn struct {
+	net.Conn
+	io.Reader
+}
+
+func (c *replayConn) Read(p []byte) (int, error) {
+	return c.Reader.Read(p)
+}

--- a/internal/unifiprotect/shared_listener_test.go
+++ b/internal/unifiprotect/shared_listener_test.go
@@ -1,0 +1,108 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	protectmedia "github.com/AlexxIT/go2rtc/pkg/unifiprotect"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSharedListenerRoutesControl(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	shared := newSharedListener(listener)
+	defer shared.Close()
+	go shared.serve(newManager("", listener.Addr().(*net.TCPAddr).Port, "test", "controller-id"))
+
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		conn, err := shared.Accept()
+		accepted <- acceptResult{conn: conn, err: err}
+	}()
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+	payload := []byte{tlsHandshakeRecord, 3, 3, 0, 1, 0}
+	_, err = client.Write(payload)
+	require.NoError(t, err)
+
+	select {
+	case result := <-accepted:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.conn)
+		defer result.conn.Close()
+		got := make([]byte, len(payload))
+		_, err = io.ReadFull(result.conn, got)
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control connection")
+	}
+}
+
+func TestSharedListenerRoutesMedia(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	shared := newSharedListener(listener)
+	defer shared.Close()
+
+	m := newManager("", listener.Addr().(*net.TCPAddr).Port, "test", "controller-id")
+	const token = "shared-listener-test"
+	req := &streamRequest{
+		token:          token,
+		cameraIP:       "127.0.0.1",
+		candidates:     make(chan candidate, 1),
+		candidatesDone: make(chan struct{}),
+	}
+	m.pending[token] = req
+	go shared.serve(m)
+
+	client, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer client.Close()
+	media := syntheticMedia(token)
+	_, err = io.Copy(client, bytes.NewReader(media))
+	require.NoError(t, err)
+
+	select {
+	case selected := <-req.candidates:
+		defer selected.rd.Close()
+		tag, err := protectmedia.NewReader(selected.rd).ReadTag()
+		require.NoError(t, err)
+		metadata, ok, err := protectmedia.ParseMetadata(tag)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, token, metadata.StreamName)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for media connection")
+	}
+}
+
+func TestSharedListenerCloseUnblocksAccept(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	shared := newSharedListener(listener)
+
+	accepted := make(chan error, 1)
+	go func() {
+		_, err := shared.Accept()
+		accepted <- err
+	}()
+	require.NoError(t, shared.Close())
+
+	select {
+	case err := <-accepted:
+		require.ErrorIs(t, err, net.ErrClosed)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for listener close")
+	}
+}

--- a/internal/unifiprotect/source.go
+++ b/internal/unifiprotect/source.go
@@ -1,0 +1,80 @@
+package unifiprotect
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type sourceConfig struct {
+	mac     string
+	channel string
+	audio   bool
+}
+
+func parseSource(source string) (sourceConfig, error) {
+	u, err := url.Parse(source)
+	if err != nil {
+		return sourceConfig{}, err
+	}
+	if u.Scheme != "unifi-protect" {
+		return sourceConfig{}, errors.New("unifi-protect: invalid source scheme")
+	}
+	if u.User != nil || u.Port() != "" || u.Path != "" && u.Path != "/" || u.Fragment != "" {
+		return sourceConfig{}, errors.New("unifi-protect: source must contain only a camera MAC and query options")
+	}
+
+	mac, err := normalizeMAC(u.Hostname())
+	if err != nil {
+		return sourceConfig{}, err
+	}
+
+	query := u.Query()
+	for key := range query {
+		if key != "channel" && key != "audio" {
+			return sourceConfig{}, fmt.Errorf("unifi-protect: unsupported source option %q", key)
+		}
+		if len(query[key]) != 1 {
+			return sourceConfig{}, fmt.Errorf("unifi-protect: source option %q must be specified once", key)
+		}
+	}
+
+	channel := query.Get("channel")
+	if channel == "" {
+		channel = "video1"
+	}
+	if channel != "video1" && channel != "video2" && channel != "video3" {
+		return sourceConfig{}, fmt.Errorf("unifi-protect: unsupported channel %q", channel)
+	}
+
+	audio := true
+	switch query.Get("audio") {
+	case "", "1", "true":
+	case "0", "false":
+		audio = false
+	default:
+		return sourceConfig{}, errors.New("unifi-protect: audio must be 0 or 1")
+	}
+
+	return sourceConfig{mac: mac, channel: channel, audio: audio}, nil
+}
+
+func normalizeMAC(value string) (string, error) {
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case ':', '-', '.':
+			return -1
+		}
+		return r
+	}, value)
+	if len(value) != 12 {
+		return "", errors.New("unifi-protect: camera MAC must contain 12 hexadecimal digits")
+	}
+	for _, c := range value {
+		if c < '0' || c > '9' && c < 'A' || c > 'F' && c < 'a' || c > 'f' {
+			return "", errors.New("unifi-protect: camera MAC must contain 12 hexadecimal digits")
+		}
+	}
+	return strings.ToUpper(value), nil
+}

--- a/internal/unifiprotect/source_test.go
+++ b/internal/unifiprotect/source_test.go
@@ -1,0 +1,49 @@
+package unifiprotect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSource(t *testing.T) {
+	tests := []struct {
+		source string
+		want   sourceConfig
+	}{
+		{
+			source: "unifi-protect://02aabbccddee",
+			want:   sourceConfig{mac: "02AABBCCDDEE", channel: "video1", audio: true},
+		},
+		{
+			source: "unifi-protect://02AABBCCDDEE?channel=video3&audio=0",
+			want:   sourceConfig{mac: "02AABBCCDDEE", channel: "video3", audio: false},
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := parseSource(tt.source)
+		require.NoError(t, err)
+		require.Equal(t, tt.want, got)
+	}
+}
+
+func TestParseSourceRejectsInvalidValues(t *testing.T) {
+	for _, source := range []string{
+		"unifi-protect://not-a-mac",
+		"unifi-protect://02AABBCCDDEE:7550",
+		"unifi-protect://02AABBCCDDEE/video1",
+		"unifi-protect://02AABBCCDDEE?channel=video4",
+		"unifi-protect://02AABBCCDDEE?audio=yes",
+		"unifi-protect://02AABBCCDDEE?unknown=1",
+	} {
+		_, err := parseSource(source)
+		require.Error(t, err, source)
+	}
+}
+
+func TestNormalizeMAC(t *testing.T) {
+	got, err := normalizeMAC("02:aa:bb:cc:dd:ee")
+	require.NoError(t, err)
+	require.Equal(t, "02AABBCCDDEE", got)
+}

--- a/internal/unifiprotect/unifiprotect.go
+++ b/internal/unifiprotect/unifiprotect.go
@@ -1,0 +1,231 @@
+package unifiprotect
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/internal/streams"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+const (
+	defaultTLSCert = "go2rtc-unifi-protect.crt"
+	defaultTLSKey  = "go2rtc-unifi-protect.key"
+)
+
+type config struct {
+	Listen      string `yaml:"listen"`
+	MediaListen string `yaml:"media_listen"`
+	MediaHost   string `yaml:"media_host"`
+	TLSCert     string `yaml:"tls_cert"`
+	TLSKey      string `yaml:"tls_key"`
+}
+
+var (
+	log     zerolog.Logger
+	manager *Manager
+)
+
+func Init() {
+	log = app.GetLogger("unifi_protect")
+	streams.HandleFunc("unifi-protect", func(source string) (core.Producer, error) {
+		if manager == nil {
+			return nil, errors.New("unifi-protect: unifi_protect is not configured")
+		}
+		return manager.open(source)
+	})
+
+	var cfg struct {
+		Mod *config `yaml:"unifi_protect"`
+	}
+	app.LoadConfig(&cfg)
+	if cfg.Mod == nil {
+		return
+	}
+	if cfg.Mod.Listen == "" {
+		cfg.Mod.Listen = ":7442"
+	}
+	if cfg.Mod.MediaListen == "" {
+		cfg.Mod.MediaListen = ":7550"
+	}
+
+	cert, err := loadCertificate(cfg.Mod.TLSCert, cfg.Mod.TLSKey)
+	if err != nil {
+		log.Error().Err(err).Msg("[unifi-protect] TLS certificate")
+		return
+	}
+
+	mediaListener, err := net.Listen("tcp", cfg.Mod.MediaListen)
+	if err != nil {
+		log.Error().Err(err).Msg("[unifi-protect] media listen")
+		return
+	}
+	controlListener, err := net.Listen("tcp", cfg.Mod.Listen)
+	if err != nil {
+		_ = mediaListener.Close()
+		log.Error().Err(err).Msg("[unifi-protect] control listen")
+		return
+	}
+
+	mediaPort := mediaListener.Addr().(*net.TCPAddr).Port
+	manager = newManager(cfg.Mod.MediaHost, mediaPort, app.Version, certificateUUID(cert))
+
+	log.Info().Str("addr", controlListener.Addr().String()).Msg("[unifi-protect] control listen")
+	log.Info().Str("addr", mediaListener.Addr().String()).Msg("[unifi-protect] media listen")
+
+	go manager.serveMedia(mediaListener)
+	go func() {
+		server := &http.Server{
+			Handler:           newController(manager),
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		tlsConfig := &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{cert},
+		}
+		if err := server.Serve(tls.NewListener(controlListener, tlsConfig)); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Error().Err(err).Msg("[unifi-protect] control serve")
+		}
+	}()
+}
+
+func loadCertificate(certValue, keyValue string) (tls.Certificate, error) {
+	if certValue == "" && keyValue == "" {
+		dir := "."
+		if app.ConfigPath != "" {
+			dir = filepath.Dir(app.ConfigPath)
+		}
+		certPath := filepath.Join(dir, defaultTLSCert)
+		keyPath := filepath.Join(dir, defaultTLSKey)
+		_, statErr := os.Stat(certPath)
+		cert, err := loadOrCreateCertificate(certPath, keyPath)
+		if err == nil && errors.Is(statErr, os.ErrNotExist) {
+			log.Info().Str("cert", certPath).Str("key", keyPath).Msg("[unifi-protect] created TLS identity")
+		}
+		return cert, err
+	}
+	if certValue == "" || keyValue == "" {
+		return tls.Certificate{}, errors.New("tls_cert and tls_key must be configured together")
+	}
+	if strings.Contains(certValue, "\n") || strings.Contains(keyValue, "\n") {
+		return tls.X509KeyPair([]byte(certValue), []byte(keyValue))
+	}
+	return tls.LoadX509KeyPair(certValue, keyValue)
+}
+
+func loadOrCreateCertificate(certPath, keyPath string) (tls.Certificate, error) {
+	certInfo, certErr := os.Stat(certPath)
+	keyInfo, keyErr := os.Stat(keyPath)
+
+	switch {
+	case certErr == nil && keyErr == nil:
+		if certInfo.IsDir() || keyInfo.IsDir() {
+			return tls.Certificate{}, errors.New("TLS certificate path is a directory")
+		}
+		return tls.LoadX509KeyPair(certPath, keyPath)
+	case errors.Is(certErr, os.ErrNotExist) && errors.Is(keyErr, os.ErrNotExist):
+		// Generate the identity only when neither half exists. A camera pins the
+		// exact certificate during set-inform, so silently replacing a damaged or
+		// partially missing identity would leave adopted cameras disconnected.
+	case certErr != nil && !errors.Is(certErr, os.ErrNotExist):
+		return tls.Certificate{}, certErr
+	case keyErr != nil && !errors.Is(keyErr, os.ErrNotExist):
+		return tls.Certificate{}, keyErr
+	default:
+		return tls.Certificate{}, fmt.Errorf("unifi-protect: incomplete TLS identity: both %s and %s are required", certPath, keyPath)
+	}
+
+	certPEM, keyPEM, err := createCertificate()
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	if err = writeFileAtomic(keyPath, keyPEM, 0600); err != nil {
+		return tls.Certificate{}, err
+	}
+	if err = writeFileAtomic(certPath, certPEM, 0644); err != nil {
+		return tls.Certificate{}, err
+	}
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+func createCertificate() (certPEM, keyPEM []byte, err error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	if serial.Sign() == 0 {
+		serial.SetInt64(1)
+	}
+
+	now := time.Now()
+	template := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "go2rtc"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
+	return certPEM, keyPEM, nil
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) (err error) {
+	f, err := os.CreateTemp(filepath.Dir(path), ".unifi-protect-tls-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+	}()
+	if err = f.Chmod(mode); err == nil {
+		_, err = f.Write(data)
+	}
+	if err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func certificateUUID(cert tls.Certificate) string {
+	if len(cert.Certificate) == 0 {
+		return uuid.Nil.String()
+	}
+	return uuid.NewSHA1(uuid.NameSpaceOID, cert.Certificate[0]).String()
+}

--- a/internal/unifiprotect/unifiprotect.go
+++ b/internal/unifiprotect/unifiprotect.go
@@ -71,25 +71,39 @@ func Init() {
 		return
 	}
 
-	mediaListener, err := net.Listen("tcp", cfg.Mod.MediaListen)
-	if err != nil {
-		log.Error().Err(err).Msg("[unifi-protect] media listen")
-		return
+	var controlListener net.Listener
+	if cfg.Mod.Listen == cfg.Mod.MediaListen {
+		listener, err := net.Listen("tcp", cfg.Mod.Listen)
+		if err != nil {
+			log.Error().Err(err).Msg("[unifi-protect] shared listen")
+			return
+		}
+		mediaPort := listener.Addr().(*net.TCPAddr).Port
+		manager = newManager(cfg.Mod.MediaHost, mediaPort, app.Version, certificateUUID(cert))
+		shared := newSharedListener(listener)
+		controlListener = shared
+		log.Info().Str("addr", listener.Addr().String()).Msg("[unifi-protect] shared listen")
+		go shared.serve(manager)
+	} else {
+		mediaListener, err := net.Listen("tcp", cfg.Mod.MediaListen)
+		if err != nil {
+			log.Error().Err(err).Msg("[unifi-protect] media listen")
+			return
+		}
+		listener, err := net.Listen("tcp", cfg.Mod.Listen)
+		if err != nil {
+			_ = mediaListener.Close()
+			log.Error().Err(err).Msg("[unifi-protect] control listen")
+			return
+		}
+		controlListener = listener
+		mediaPort := mediaListener.Addr().(*net.TCPAddr).Port
+		manager = newManager(cfg.Mod.MediaHost, mediaPort, app.Version, certificateUUID(cert))
+		log.Info().Str("addr", controlListener.Addr().String()).Msg("[unifi-protect] control listen")
+		log.Info().Str("addr", mediaListener.Addr().String()).Msg("[unifi-protect] media listen")
+		go manager.serveMedia(mediaListener)
 	}
-	controlListener, err := net.Listen("tcp", cfg.Mod.Listen)
-	if err != nil {
-		_ = mediaListener.Close()
-		log.Error().Err(err).Msg("[unifi-protect] control listen")
-		return
-	}
 
-	mediaPort := mediaListener.Addr().(*net.TCPAddr).Port
-	manager = newManager(cfg.Mod.MediaHost, mediaPort, app.Version, certificateUUID(cert))
-
-	log.Info().Str("addr", controlListener.Addr().String()).Msg("[unifi-protect] control listen")
-	log.Info().Str("addr", mediaListener.Addr().String()).Msg("[unifi-protect] media listen")
-
-	go manager.serveMedia(mediaListener)
 	go func() {
 		server := &http.Server{
 			Handler:           newController(manager),

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/internal/tapo"
 	"github.com/AlexxIT/go2rtc/internal/tuya"
+	"github.com/AlexxIT/go2rtc/internal/unifiprotect"
 	"github.com/AlexxIT/go2rtc/internal/v4l2"
 	"github.com/AlexxIT/go2rtc/internal/webrtc"
 	"github.com/AlexxIT/go2rtc/internal/webtorrent"
@@ -105,6 +106,7 @@ func main() {
 		{"roborock", roborock.Init},
 		{"tapo", tapo.Init},
 		{"tuya", tuya.Init},
+		{"unifi_protect", unifiprotect.Init},
 		{"wyze", wyze.Init},
 		{"xiaomi", xiaomi.Init},
 		{"yandex", yandex.Init},

--- a/pkg/unifiprotect/flv.go
+++ b/pkg/unifiprotect/flv.go
@@ -1,0 +1,269 @@
+package unifiprotect
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/AlexxIT/go2rtc/pkg/flv/amf"
+)
+
+const (
+	TagAudio = 8
+	TagVideo = 9
+	TagOpus  = 10
+	TagData  = 18
+
+	maxTagSize     = 4 * 1024 * 1024
+	maxTrailerScan = 1 << 16
+)
+
+var ErrFraming = errors.New("unifi-protect: invalid extended FLV framing")
+
+type Tag struct {
+	Type      byte
+	Timestamp uint32
+	Data      []byte
+}
+
+type Metadata struct {
+	StreamName     string
+	AudioFrequency uint32
+	AudioChannels  uint8
+	VideoWidth     uint16
+	VideoHeight    uint16
+}
+
+// Reader removes the private trailer UniFi appends to each extended-FLV tag.
+// The next tag is located structurally because the trailer size varies with
+// the payload. One complete tag is held while its successor is validated.
+type Reader struct {
+	r   io.Reader
+	buf []byte
+	eof bool
+
+	headerDone bool
+}
+
+func NewReader(r io.Reader) *Reader {
+	return &Reader{r: r}
+}
+
+func (r *Reader) ReadTag() (*Tag, error) {
+	if err := r.readHeader(); err != nil {
+		return nil, err
+	}
+
+	for skipped := 0; ; skipped++ {
+		if err := r.fill(15); err != nil {
+			return nil, err
+		}
+
+		if !validTagType(r.buf[0]) {
+			if skipped >= maxTrailerScan {
+				return nil, ErrFraming
+			}
+			r.buf = r.buf[1:]
+			continue
+		}
+
+		dataSize := int(uint24(r.buf[1:4]))
+		if dataSize > maxTagSize {
+			if skipped >= maxTrailerScan {
+				return nil, ErrFraming
+			}
+			r.buf = r.buf[1:]
+			continue
+		}
+
+		tagSize := 11 + dataSize
+		if err := r.fill(tagSize + 4); err != nil {
+			return nil, err
+		}
+		if binary.BigEndian.Uint32(r.buf[tagSize:tagSize+4]) != uint32(tagSize) {
+			if skipped >= maxTrailerScan {
+				return nil, ErrFraming
+			}
+			r.buf = r.buf[1:]
+			continue
+		}
+
+		tag := &Tag{
+			Type:      r.buf[0],
+			Timestamp: uint24(r.buf[4:7]) | uint32(r.buf[7])<<24,
+			Data:      append([]byte(nil), r.buf[11:tagSize]...),
+		}
+
+		next, err := r.nextTag(tagSize + 4)
+		if err != nil {
+			return nil, err
+		}
+		r.buf = r.buf[next:]
+		return tag, nil
+	}
+}
+
+func (r *Reader) readHeader() error {
+	if r.headerDone {
+		return nil
+	}
+
+	if err := r.fill(3); err != nil {
+		return err
+	}
+	if string(r.buf[:3]) != "FLV" {
+		r.headerDone = true
+		return nil
+	}
+
+	if err := r.fill(9); err != nil {
+		return err
+	}
+	offset := int(binary.BigEndian.Uint32(r.buf[5:9]))
+	if offset < 9 || offset > maxTagSize {
+		return fmt.Errorf("%w: invalid FLV header size %d", ErrFraming, offset)
+	}
+	if err := r.fill(offset + 4); err != nil {
+		return err
+	}
+	if binary.BigEndian.Uint32(r.buf[offset:offset+4]) != 0 {
+		return fmt.Errorf("%w: invalid first previous-tag size", ErrFraming)
+	}
+	r.buf = r.buf[offset+4:]
+	r.headerDone = true
+	return nil
+}
+
+func (r *Reader) nextTag(tagEnd int) (int, error) {
+	for {
+		pending := false
+		scanMax := len(r.buf) - tagEnd
+		if scanMax > maxTrailerScan {
+			scanMax = maxTrailerScan
+		}
+
+		for gap := 0; gap <= scanMax; gap++ {
+			pos := tagEnd + gap
+			if pos+11 > len(r.buf) {
+				pending = true
+				break
+			}
+			if !validTagType(r.buf[pos]) || r.buf[pos+8] != 0 || r.buf[pos+9] != 0 || r.buf[pos+10] != 0 {
+				continue
+			}
+
+			dataSize := int(uint24(r.buf[pos+1 : pos+4]))
+			if dataSize > maxTagSize {
+				continue
+			}
+			nextEnd := pos + 11 + dataSize
+			if nextEnd+4 > len(r.buf) {
+				pending = true
+				continue
+			}
+			if binary.BigEndian.Uint32(r.buf[nextEnd:nextEnd+4]) == uint32(11+dataSize) {
+				return pos, nil
+			}
+		}
+
+		if r.eof {
+			// The final tag has no successor to validate. Its own framing was
+			// already checked, so emit it and discard any final private trailer.
+			return len(r.buf), nil
+		}
+		if len(r.buf) > tagEnd+maxTrailerScan+11+maxTagSize+4 {
+			return 0, fmt.Errorf("%w: next tag not found", ErrFraming)
+		}
+
+		before := len(r.buf)
+		if err := r.readMore(); err != nil {
+			if errors.Is(err, io.EOF) {
+				continue
+			}
+			return 0, err
+		}
+		if !pending && len(r.buf) == before {
+			return 0, io.ErrNoProgress
+		}
+	}
+}
+
+func (r *Reader) fill(size int) error {
+	for len(r.buf) < size {
+		if r.eof {
+			return io.EOF
+		}
+		if err := r.readMore(); err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reader) readMore() error {
+	b := make([]byte, 32*1024)
+	n, err := r.r.Read(b)
+	if n > 0 {
+		r.buf = append(r.buf, b[:n]...)
+	}
+	if errors.Is(err, io.EOF) {
+		r.eof = true
+	}
+	if n > 0 {
+		return nil
+	}
+	if err == nil {
+		return io.ErrNoProgress
+	}
+	return err
+}
+
+func ParseMetadata(tag *Tag) (Metadata, bool, error) {
+	if tag.Type != TagData {
+		return Metadata{}, false, nil
+	}
+
+	items, err := amf.NewReader(tag.Data).ReadItems()
+	if err != nil {
+		return Metadata{}, false, err
+	}
+
+	for i, item := range items {
+		name, ok := item.(string)
+		if !ok || name != "onMetaData" || i+1 >= len(items) {
+			continue
+		}
+		obj, ok := items[i+1].(map[string]any)
+		if !ok {
+			return Metadata{}, false, errors.New("unifi-protect: invalid onMetaData object")
+		}
+		return Metadata{
+			StreamName:     stringValue(obj["streamName"]),
+			AudioFrequency: uint32(numberValue(obj["audioFrequency"])),
+			AudioChannels:  uint8(numberValue(obj["audioChannels"])),
+			VideoWidth:     uint16(numberValue(obj["videoWidth"])),
+			VideoHeight:    uint16(numberValue(obj["videoHeight"])),
+		}, true, nil
+	}
+
+	return Metadata{}, false, nil
+}
+
+func validTagType(v byte) bool {
+	return v == TagAudio || v == TagVideo || v == TagOpus || v == TagData
+}
+
+func uint24(b []byte) uint32 {
+	return uint32(b[0])<<16 | uint32(b[1])<<8 | uint32(b[2])
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func numberValue(v any) float64 {
+	n, _ := v.(float64)
+	return n
+}

--- a/pkg/unifiprotect/flv_test.go
+++ b/pkg/unifiprotect/flv_test.go
@@ -1,0 +1,121 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/flv"
+	"github.com/AlexxIT/go2rtc/pkg/flv/amf"
+	"github.com/stretchr/testify/require"
+)
+
+var flvHeader = []byte{
+	'F', 'L', 'V', 1, 5,
+	0, 0, 0, 9,
+	0, 0, 0, 0,
+}
+
+func TestReaderExtendedFLV(t *testing.T) {
+	metadata := amf.EncodeItems("onMetaData", map[string]any{
+		"streamName":     "f4c2d8a19e7340b6",
+		"audioFrequency": 16000,
+		"audioChannels":  1,
+		"videoWidth":     2688,
+		"videoHeight":    1512,
+	})
+
+	want := []*Tag{
+		{Type: TagData, Timestamp: 0, Data: metadata},
+		{Type: TagVideo, Timestamp: 33, Data: []byte{0x17, 0, 0, 0, 0, 1, 2, 3}},
+		{Type: TagOpus, Timestamp: 40, Data: []byte{0xcf, 0, 3, 2}},
+		{Type: TagOpus, Timestamp: 60, Data: append([]byte{0xb8}, bytes.Repeat([]byte{0x55}, 160)...)},
+	}
+
+	var wire []byte
+	wire = append(wire, flvHeader...)
+	for i, tag := range want {
+		wire = append(wire, flv.EncodeTag(tag.Type, tag.Timestamp, tag.Data)...)
+		if i != len(want)-1 {
+			wire = append(wire, bytes.Repeat([]byte{byte(0x40 + i)}, []int{16, 432, 784}[i])...)
+		}
+	}
+
+	rd := NewReader(&chunkReader{data: wire, size: 7})
+	for _, expected := range want {
+		actual, err := rd.ReadTag()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+	_, err := rd.ReadTag()
+	require.ErrorIs(t, err, io.EOF)
+
+	got, ok, err := ParseMetadata(want[0])
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, Metadata{
+		StreamName:     "f4c2d8a19e7340b6",
+		AudioFrequency: 16000,
+		AudioChannels:  1,
+		VideoWidth:     2688,
+		VideoHeight:    1512,
+	}, got)
+}
+
+func TestReaderHeaderless(t *testing.T) {
+	want := []*Tag{
+		{Type: TagVideo, Timestamp: 0xffffffff, Data: []byte{0x17, 0, 0, 0, 0}},
+		{Type: TagAudio, Timestamp: 20, Data: []byte{0xaf, 0, 0x14, 8}},
+	}
+
+	wire := appendTag(nil, want[0])
+	wire = append(wire, bytes.Repeat([]byte{0xa5}, 20)...)
+	wire = appendTag(wire, want[1])
+
+	rd := NewReader(bytes.NewReader(wire))
+	for _, expected := range want {
+		actual, err := rd.ReadTag()
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+}
+
+func TestReaderRejectsInvalidHeader(t *testing.T) {
+	header := append([]byte(nil), flvHeader...)
+	binary.BigEndian.PutUint32(header[9:], 1)
+	_, err := NewReader(bytes.NewReader(header)).ReadTag()
+	require.ErrorIs(t, err, ErrFraming)
+}
+
+func TestParseMetadataIgnoresOtherData(t *testing.T) {
+	tag := &Tag{Type: TagData, Data: amf.EncodeItems("onClockSync", map[string]any{})}
+	_, ok, err := ParseMetadata(tag)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func appendTag(dst []byte, tag *Tag) []byte {
+	return append(dst, flv.EncodeTag(tag.Type, tag.Timestamp, tag.Data)...)
+}
+
+type chunkReader struct {
+	data []byte
+	size int
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	n := r.size
+	if n > len(r.data) {
+		n = len(r.data)
+	}
+	if n > len(p) {
+		n = len(p)
+	}
+	copy(p, r.data[:n])
+	r.data = r.data[n:]
+	return n, nil
+}

--- a/pkg/unifiprotect/producer.go
+++ b/pkg/unifiprotect/producer.go
@@ -205,7 +205,7 @@ func (p *Producer) writeTag(tag *Tag) {
 
 	switch tag.Type {
 	case TagVideo:
-		if p.video == nil || len(tag.Data) < 5 || tag.Data[0]&0x0f != 7 || tag.Data[1] != 1 {
+		if p.video == nil || len(tag.Data) < 5 || tag.Data[0]&0x0f != 7 || tag.Data[1] != 1 || !validAVCCPayload(tag.Data[5:]) {
 			return
 		}
 		p.video.WriteRTP(&rtp.Packet{
@@ -258,7 +258,7 @@ func isAVCConfig(data []byte) bool {
 }
 
 func validAVCDecoderConfig(config []byte) bool {
-	if len(config) < 7 || config[0] != 1 {
+	if len(config) < 7 || config[0] != 1 || config[4]&3 != 3 {
 		return false
 	}
 
@@ -292,6 +292,22 @@ func validAVCDecoderConfig(config []byte) bool {
 	}
 
 	return true
+}
+
+func validAVCCPayload(data []byte) bool {
+	valid := false
+	for len(data) != 0 {
+		if len(data) < 4 {
+			return false
+		}
+		size := binary.BigEndian.Uint32(data)
+		if size == 0 || uint64(size) > uint64(len(data)-4) {
+			return false
+		}
+		data = data[4+int(size):]
+		valid = true
+	}
+	return valid
 }
 
 func isAACConfig(data []byte) bool {

--- a/pkg/unifiprotect/producer.go
+++ b/pkg/unifiprotect/producer.go
@@ -2,6 +2,7 @@ package unifiprotect
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"sync"
@@ -122,9 +123,13 @@ func (p *Producer) probe() error {
 		switch tag.Type {
 		case TagVideo:
 			if video == nil && isAVCConfig(tag.Data) {
-				_, sps, pps := h264.DecodeConfig(tag.Data[5:])
+				config := tag.Data[5:]
+				if !validAVCDecoderConfig(config) {
+					continue
+				}
+				_, sps, pps := h264.DecodeConfig(config)
 				if len(sps) != 0 && len(pps) != 0 {
-					video = h264.ConfigToCodec(tag.Data[5:])
+					video = h264.ConfigToCodec(config)
 				}
 			}
 
@@ -235,6 +240,43 @@ func (p *Producer) timestamp(ms, clockRate uint32) uint32 {
 
 func isAVCConfig(data []byte) bool {
 	return len(data) >= 6 && data[0]&0x0f == 7 && data[1] == 0
+}
+
+func validAVCDecoderConfig(config []byte) bool {
+	if len(config) < 7 || config[0] != 1 {
+		return false
+	}
+
+	count := int(config[5] & 0x1f)
+	config = config[6:]
+	for i := 0; i < count; i++ {
+		if len(config) < 2 {
+			return false
+		}
+		size := 2 + int(binary.BigEndian.Uint16(config))
+		if len(config) < size {
+			return false
+		}
+		config = config[size:]
+	}
+
+	if len(config) < 1 {
+		return false
+	}
+	count = int(config[0])
+	config = config[1:]
+	for i := 0; i < count; i++ {
+		if len(config) < 2 {
+			return false
+		}
+		size := 2 + int(binary.BigEndian.Uint16(config))
+		if len(config) < size {
+			return false
+		}
+		config = config[size:]
+	}
+
+	return true
 }
 
 func isAACConfig(data []byte) bool {

--- a/pkg/unifiprotect/producer.go
+++ b/pkg/unifiprotect/producer.go
@@ -1,0 +1,244 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/aac"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/h264"
+	"github.com/pion/rtp"
+)
+
+var opusConfig = []byte{0xcf, 0x00, 0x03, 0x02}
+
+type AudioMode byte
+
+const (
+	AudioNone AudioMode = iota
+	AudioAAC
+	AudioOpus
+)
+
+type Producer struct {
+	core.Connection
+
+	rd        *Reader
+	pending   []*Tag
+	audioMode AudioMode
+	audioType byte
+
+	video *core.Receiver
+	audio *core.Receiver
+
+	audioSeq uint16
+	started  time.Time
+	onStop   func()
+	stopOnce sync.Once
+}
+
+func Open(rd io.ReadCloser, audioMode AudioMode) (*Producer, error) {
+	p := &Producer{
+		Connection: core.Connection{
+			ID:         core.NewID(),
+			FormatName: "unifi-protect",
+			Protocol:   "tcp",
+			Transport:  rd,
+		},
+		rd:        NewReader(rd),
+		audioMode: audioMode,
+		started:   time.Now(),
+	}
+	if err := p.probe(); err != nil {
+		_ = rd.Close()
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *Producer) SetOnStop(fn func()) {
+	p.onStop = fn
+}
+
+func (p *Producer) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver, error) {
+	receiver, err := p.Connection.GetTrack(media, codec)
+	if err != nil {
+		return nil, err
+	}
+	if media.Kind == core.KindVideo {
+		p.video = receiver
+	} else {
+		p.audio = receiver
+	}
+	return receiver, nil
+}
+
+func (p *Producer) Start() error {
+	defer p.release()
+
+	for _, tag := range p.pending {
+		p.writeTag(tag)
+	}
+	p.pending = nil
+
+	for {
+		tag, err := p.rd.ReadTag()
+		if err != nil {
+			return err
+		}
+		p.writeTag(tag)
+	}
+}
+
+func (p *Producer) Stop() error {
+	p.release()
+	return p.Connection.Stop()
+}
+
+func (p *Producer) release() {
+	p.stopOnce.Do(func() {
+		if p.onStop != nil {
+			p.onStop()
+		}
+	})
+}
+
+func (p *Producer) probe() error {
+	var video, opus, audio *core.Codec
+
+	for {
+		tag, err := p.rd.ReadTag()
+		if err != nil {
+			if video == nil {
+				return fmt.Errorf("unifi-protect: probe video: %w", err)
+			}
+			break
+		}
+		p.pending = append(p.pending, tag)
+
+		switch tag.Type {
+		case TagVideo:
+			if video == nil && isAVCConfig(tag.Data) {
+				_, sps, pps := h264.DecodeConfig(tag.Data[5:])
+				if len(sps) != 0 && len(pps) != 0 {
+					video = h264.ConfigToCodec(tag.Data[5:])
+				}
+			}
+
+		case TagOpus:
+			if bytes.Equal(tag.Data, opusConfig) {
+				opus = &core.Codec{
+					Name:        core.CodecOpus,
+					ClockRate:   48000,
+					Channels:    2,
+					FmtpLine:    "stereo=0;sprop-stereo=0",
+					PayloadType: 111,
+				}
+			}
+
+		case TagAudio:
+			if audio == nil && isAACConfig(tag.Data) {
+				codec := aac.ConfigToCodec(tag.Data[2:])
+				if codec.Name == core.CodecAAC && codec.ClockRate != 0 {
+					audio = codec
+				}
+			}
+		}
+
+		if video != nil && (p.audioMode == AudioNone || p.audioMode == AudioOpus && opus != nil || p.audioMode == AudioAAC && audio != nil) {
+			break
+		}
+	}
+
+	p.Medias = append(p.Medias, &core.Media{
+		Kind:      core.KindVideo,
+		Direction: core.DirectionRecvonly,
+		Codecs:    []*core.Codec{video},
+	})
+
+	if p.audioMode == AudioNone {
+		audio = nil
+	} else if p.audioMode == AudioOpus && opus != nil || audio == nil && opus != nil {
+		p.audioType = TagOpus
+		audio = opus
+	} else if audio != nil {
+		p.audioType = TagAudio
+	} else {
+		audio = nil
+	}
+	if audio != nil {
+		p.Medias = append(p.Medias, &core.Media{
+			Kind:      core.KindAudio,
+			Direction: core.DirectionRecvonly,
+			Codecs:    []*core.Codec{audio},
+		})
+	}
+
+	return nil
+}
+
+func (p *Producer) writeTag(tag *Tag) {
+	p.Recv += len(tag.Data)
+
+	switch tag.Type {
+	case TagVideo:
+		if p.video == nil || len(tag.Data) < 5 || tag.Data[0]&0x0f != 7 || tag.Data[1] != 1 {
+			return
+		}
+		p.video.WriteRTP(&rtp.Packet{
+			Header: rtp.Header{
+				Marker:    true,
+				Timestamp: p.timestamp(tag.Timestamp, p.video.Codec.ClockRate),
+			},
+			Payload: tag.Data[5:],
+		})
+
+	case TagOpus:
+		if p.audio == nil || p.audioType != TagOpus || len(tag.Data) == 0 || bytes.Equal(tag.Data, opusConfig) {
+			return
+		}
+		p.audioSeq++
+		p.audio.WriteRTP(&rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				Marker:         true,
+				PayloadType:    p.audio.Codec.PayloadType,
+				SequenceNumber: p.audioSeq,
+				Timestamp:      p.timestamp(tag.Timestamp, p.audio.Codec.ClockRate),
+			},
+			Payload: tag.Data,
+		})
+
+	case TagAudio:
+		if p.audio == nil || p.audioType != TagAudio || len(tag.Data) < 2 || tag.Data[0]>>4 != 10 || tag.Data[1] != 1 {
+			return
+		}
+		p.audio.WriteRTP(&rtp.Packet{
+			Header: rtp.Header{
+				Marker:    true,
+				Timestamp: p.timestamp(tag.Timestamp, p.audio.Codec.ClockRate),
+			},
+			Payload: tag.Data[2:],
+		})
+	}
+}
+
+func (p *Producer) timestamp(ms, clockRate uint32) uint32 {
+	if ms == ^uint32(0) {
+		ms = uint32(time.Since(p.started) / time.Millisecond)
+	}
+	return uint32(uint64(ms) * uint64(clockRate) / 1000)
+}
+
+func isAVCConfig(data []byte) bool {
+	return len(data) >= 6 && data[0]&0x0f == 7 && data[1] == 0
+}
+
+func isAACConfig(data []byte) bool {
+	return len(data) >= 4 && data[0]>>4 == 10 && data[1] == 0
+}
+
+var _ core.Producer = (*Producer)(nil)

--- a/pkg/unifiprotect/producer.go
+++ b/pkg/unifiprotect/producer.go
@@ -16,7 +16,10 @@ import (
 
 var opusConfig = []byte{0xcf, 0x00, 0x03, 0x02}
 
-const maxProbeBuffer = 16 * 1024 * 1024
+const (
+	maxProbeBuffer   = 16 * 1024 * 1024
+	probeTagOverhead = 64
+)
 
 type AudioMode byte
 
@@ -192,10 +195,14 @@ func (p *Producer) probe() error {
 }
 
 func (p *Producer) bufferProbeTag(tag *Tag) error {
-	if len(tag.Data) > maxProbeBuffer-p.probeBytes {
+	if len(tag.Data) > maxProbeBuffer-probeTagOverhead {
 		return fmt.Errorf("unifi-protect: probe exceeds %d bytes", maxProbeBuffer)
 	}
-	p.probeBytes += len(tag.Data)
+	cost := probeTagOverhead + len(tag.Data)
+	if p.probeBytes > maxProbeBuffer-cost {
+		return fmt.Errorf("unifi-protect: probe exceeds %d bytes", maxProbeBuffer)
+	}
+	p.probeBytes += cost
 	p.pending = append(p.pending, tag)
 	return nil
 }

--- a/pkg/unifiprotect/producer.go
+++ b/pkg/unifiprotect/producer.go
@@ -16,6 +16,8 @@ import (
 
 var opusConfig = []byte{0xcf, 0x00, 0x03, 0x02}
 
+const maxProbeBuffer = 16 * 1024 * 1024
+
 type AudioMode byte
 
 const (
@@ -27,10 +29,11 @@ const (
 type Producer struct {
 	core.Connection
 
-	rd        *Reader
-	pending   []*Tag
-	audioMode AudioMode
-	audioType byte
+	rd         *Reader
+	pending    []*Tag
+	probeBytes int
+	audioMode  AudioMode
+	audioType  byte
 
 	video *core.Receiver
 	audio *core.Receiver
@@ -84,6 +87,7 @@ func (p *Producer) Start() error {
 		p.writeTag(tag)
 	}
 	p.pending = nil
+	p.probeBytes = 0
 
 	for {
 		tag, err := p.rd.ReadTag()
@@ -118,7 +122,9 @@ func (p *Producer) probe() error {
 			}
 			break
 		}
-		p.pending = append(p.pending, tag)
+		if err := p.bufferProbeTag(tag); err != nil {
+			return err
+		}
 
 		switch tag.Type {
 		case TagVideo:
@@ -182,6 +188,15 @@ func (p *Producer) probe() error {
 		})
 	}
 
+	return nil
+}
+
+func (p *Producer) bufferProbeTag(tag *Tag) error {
+	if len(tag.Data) > maxProbeBuffer-p.probeBytes {
+		return fmt.Errorf("unifi-protect: probe exceeds %d bytes", maxProbeBuffer)
+	}
+	p.probeBytes += len(tag.Data)
+	p.pending = append(p.pending, tag)
 	return nil
 }
 

--- a/pkg/unifiprotect/producer_test.go
+++ b/pkg/unifiprotect/producer_test.go
@@ -103,7 +103,53 @@ func TestProducerRejectsTruncatedAVCConfig(t *testing.T) {
 func TestValidAVCDecoderConfig(t *testing.T) {
 	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
 	pps := []byte{0x68, 0xce, 0x38, 0x80}
-	require.True(t, validAVCDecoderConfig(h264.EncodeConfig(sps, pps)))
+	config := h264.EncodeConfig(sps, pps)
+	require.True(t, validAVCDecoderConfig(config))
+
+	for lengthSizeMinusOne := byte(0); lengthSizeMinusOne < 3; lengthSizeMinusOne++ {
+		unsupported := append([]byte(nil), config...)
+		unsupported[4] = unsupported[4]&^3 | lengthSizeMinusOne
+		require.False(t, validAVCDecoderConfig(unsupported))
+	}
+}
+
+func TestValidAVCCPayload(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{name: "empty"},
+		{name: "missing length", data: []byte{0, 0, 1}},
+		{name: "truncated NAL", data: []byte{0, 0, 0, 2, 0x65}},
+		{name: "oversized length", data: []byte{0xff, 0xff, 0xff, 0xff, 0x65}},
+		{name: "zero length NAL", data: []byte{0, 0, 0, 0}},
+		{name: "trailing partial bytes", data: []byte{0, 0, 0, 1, 0x65, 0, 0}},
+		{name: "single NAL", data: []byte{0, 0, 0, 2, 0x65, 0x88}, want: true},
+		{name: "multiple NALs", data: []byte{0, 0, 0, 1, 0x65, 0, 0, 0, 2, 0x41, 0x88}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, validAVCCPayload(tt.data))
+		})
+	}
+}
+
+func TestProducerDropsMalformedAVCCFrame(t *testing.T) {
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	config := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	malformed := []byte{0x17, 1, 0, 0, 0, 0, 0, 0, 2, 0x65}
+	p, err := Open(io.NopCloser(bytes.NewReader(extendedWire(
+		&Tag{Type: TagVideo, Data: config},
+		&Tag{Type: TagVideo, Data: malformed},
+	))), AudioNone)
+	require.NoError(t, err)
+
+	packets := attach(t, p, p.Medias[0])
+	require.ErrorIs(t, p.Start(), io.EOF)
+	require.Empty(t, *packets)
 }
 
 func TestProducerProbeBufferLimit(t *testing.T) {

--- a/pkg/unifiprotect/producer_test.go
+++ b/pkg/unifiprotect/producer_test.go
@@ -84,6 +84,28 @@ func TestProducerVideoOnly(t *testing.T) {
 	require.Len(t, p.Medias, 1)
 }
 
+func TestProducerRejectsTruncatedAVCConfig(t *testing.T) {
+	// This is a valid FLV AVC sequence header whose AVCDecoderConfigurationRecord
+	// ends after the first SPS, before the PPS count byte.
+	config := []byte{1, 0x42, 0, 0x1f, 0xff, 0xe1, 0, 1, 0x67}
+	wire := extendedWire(&Tag{
+		Type: TagVideo,
+		Data: append([]byte{0x17, 0, 0, 0, 0}, config...),
+	})
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = Open(io.NopCloser(bytes.NewReader(wire)), AudioNone)
+	})
+	require.Error(t, err)
+}
+
+func TestValidAVCDecoderConfig(t *testing.T) {
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	require.True(t, validAVCDecoderConfig(h264.EncodeConfig(sps, pps)))
+}
+
 func TestProducerStopCallbackOnce(t *testing.T) {
 	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
 	pps := []byte{0x68, 0xce, 0x38, 0x80}

--- a/pkg/unifiprotect/producer_test.go
+++ b/pkg/unifiprotect/producer_test.go
@@ -1,0 +1,122 @@
+package unifiprotect
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/aac"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/flv"
+	"github.com/AlexxIT/go2rtc/pkg/h264"
+	"github.com/pion/rtp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProducerPrefersOpus(t *testing.T) {
+	sps := []byte{0x67, 0x4d, 0x40, 0x32, 0xa6, 0x80, 0x2a}
+	pps := []byte{0x68, 0xea, 0x8f, 0x20}
+	videoConfig := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	videoFrame := []byte{0x17, 1, 0, 0, 0, 0, 0, 0, 2, 0x65, 0x88}
+	opusPacket := append([]byte{0xb8}, bytes.Repeat([]byte{0x42}, 80)...)
+	aacConfig := aac.EncodeConfig(aac.TypeAACLC, 16000, 1, false)
+
+	wire := extendedWire(
+		&Tag{Type: TagVideo, Data: videoConfig},
+		&Tag{Type: TagOpus, Data: opusConfig},
+		&Tag{Type: TagVideo, Timestamp: 20, Data: videoFrame},
+		&Tag{Type: TagOpus, Timestamp: 20, Data: opusPacket},
+		&Tag{Type: TagAudio, Data: append([]byte{0xaf, 0}, aacConfig...)},
+		&Tag{Type: TagAudio, Timestamp: 20, Data: []byte{0xaf, 1, 1, 2, 3}},
+	)
+
+	p, err := Open(io.NopCloser(bytes.NewReader(wire)), AudioOpus)
+	require.NoError(t, err)
+	require.Len(t, p.Medias, 2)
+	require.Equal(t, core.CodecH264, p.Medias[0].Codecs[0].Name)
+	require.Equal(t, core.CodecOpus, p.Medias[1].Codecs[0].Name)
+	require.Equal(t, uint32(48000), p.Medias[1].Codecs[0].ClockRate)
+	require.Equal(t, uint8(2), p.Medias[1].Codecs[0].Channels)
+
+	videoPackets := attach(t, p, p.Medias[0])
+	audioPackets := attach(t, p, p.Medias[1])
+	require.ErrorIs(t, p.Start(), io.EOF)
+	require.Len(t, *videoPackets, 1)
+	require.Equal(t, videoFrame[5:], (*videoPackets)[0].Payload)
+	require.Len(t, *audioPackets, 1)
+	require.Equal(t, opusPacket, (*audioPackets)[0].Payload)
+	require.Equal(t, uint32(960), (*audioPackets)[0].Timestamp)
+}
+
+func TestProducerAACFallback(t *testing.T) {
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	videoConfig := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	aacConfig := aac.EncodeConfig(aac.TypeAACLC, 16000, 1, false)
+	aacPacket := []byte{1, 2, 3, 4}
+
+	wire := extendedWire(
+		&Tag{Type: TagVideo, Data: videoConfig},
+		&Tag{Type: TagAudio, Data: append([]byte{0xaf, 0}, aacConfig...)},
+		&Tag{Type: TagAudio, Timestamp: 20, Data: append([]byte{0xaf, 1}, aacPacket...)},
+	)
+
+	p, err := Open(io.NopCloser(bytes.NewReader(wire)), AudioAAC)
+	require.NoError(t, err)
+	require.Len(t, p.Medias, 2)
+	require.Equal(t, core.CodecAAC, p.Medias[1].Codecs[0].Name)
+
+	packets := attach(t, p, p.Medias[1])
+	require.ErrorIs(t, p.Start(), io.EOF)
+	require.Len(t, *packets, 1)
+	require.Equal(t, aacPacket, (*packets)[0].Payload)
+	require.Equal(t, uint32(320), (*packets)[0].Timestamp)
+}
+
+func TestProducerVideoOnly(t *testing.T) {
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	videoConfig := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	wire := extendedWire(&Tag{Type: TagVideo, Data: videoConfig})
+
+	p, err := Open(io.NopCloser(bytes.NewReader(wire)), AudioNone)
+	require.NoError(t, err)
+	require.Len(t, p.Medias, 1)
+}
+
+func TestProducerStopCallbackOnce(t *testing.T) {
+	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
+	pps := []byte{0x68, 0xce, 0x38, 0x80}
+	config := append([]byte{0x17, 0, 0, 0, 0}, h264.EncodeConfig(sps, pps)...)
+	p, err := Open(io.NopCloser(bytes.NewReader(extendedWire(&Tag{Type: TagVideo, Data: config}))), AudioNone)
+	require.NoError(t, err)
+
+	called := 0
+	p.SetOnStop(func() { called++ })
+	require.NoError(t, p.Stop())
+	require.NoError(t, p.Stop())
+	require.Equal(t, 1, called)
+}
+
+func attach(t *testing.T, p *Producer, media *core.Media) *[]*rtp.Packet {
+	t.Helper()
+	receiver, err := p.GetTrack(media, media.Codecs[0])
+	require.NoError(t, err)
+	packets := []*rtp.Packet{}
+	receiver.AppendChild(&core.Node{Input: func(packet *rtp.Packet) {
+		clone := packet.Clone()
+		packets = append(packets, clone)
+	}})
+	return &packets
+}
+
+func extendedWire(tags ...*Tag) []byte {
+	wire := append([]byte(nil), flvHeader...)
+	for i, tag := range tags {
+		wire = append(wire, flv.EncodeTag(tag.Type, tag.Timestamp, tag.Data)...)
+		if i != len(tags)-1 {
+			wire = append(wire, bytes.Repeat([]byte{0x55}, 16+i*8)...)
+		}
+	}
+	return wire
+}

--- a/pkg/unifiprotect/producer_test.go
+++ b/pkg/unifiprotect/producer_test.go
@@ -106,6 +106,13 @@ func TestValidAVCDecoderConfig(t *testing.T) {
 	require.True(t, validAVCDecoderConfig(h264.EncodeConfig(sps, pps)))
 }
 
+func TestProducerProbeBufferLimit(t *testing.T) {
+	p := &Producer{probeBytes: maxProbeBuffer - 1}
+	require.NoError(t, p.bufferProbeTag(&Tag{Data: []byte{1}}))
+	require.ErrorContains(t, p.bufferProbeTag(&Tag{Data: []byte{1}}), "probe exceeds")
+	require.Len(t, p.pending, 1)
+}
+
 func TestProducerStopCallbackOnce(t *testing.T) {
 	sps := []byte{0x67, 0x42, 0, 0x1f, 0xe5, 0x88}
 	pps := []byte{0x68, 0xce, 0x38, 0x80}

--- a/pkg/unifiprotect/producer_test.go
+++ b/pkg/unifiprotect/producer_test.go
@@ -153,10 +153,18 @@ func TestProducerDropsMalformedAVCCFrame(t *testing.T) {
 }
 
 func TestProducerProbeBufferLimit(t *testing.T) {
-	p := &Producer{probeBytes: maxProbeBuffer - 1}
+	p := &Producer{probeBytes: maxProbeBuffer - probeTagOverhead - 1}
 	require.NoError(t, p.bufferProbeTag(&Tag{Data: []byte{1}}))
-	require.ErrorContains(t, p.bufferProbeTag(&Tag{Data: []byte{1}}), "probe exceeds")
+	require.ErrorContains(t, p.bufferProbeTag(&Tag{}), "probe exceeds")
 	require.Len(t, p.pending, 1)
+}
+
+func TestProducerProbeBufferCountsTagOverhead(t *testing.T) {
+	p := &Producer{probeBytes: maxProbeBuffer - 2*probeTagOverhead - 1}
+	require.NoError(t, p.bufferProbeTag(&Tag{}))
+	require.NoError(t, p.bufferProbeTag(&Tag{Data: []byte{1}}))
+	require.ErrorContains(t, p.bufferProbeTag(&Tag{}), "probe exceeds")
+	require.Len(t, p.pending, 2)
 }
 
 func TestProducerStopCallbackOnce(t *testing.T) {

--- a/www/schema.json
+++ b/www/schema.json
@@ -43,7 +43,8 @@
         "ffmpeg:virtual?video=testsrc&size=4K#video=h264#hardware#bitrate=50M",
         "exec:ffmpeg -re -i media.mp4 -c copy -rtsp_transport tcp -f rtsp {output}",
         "onvif://username:password@192.168.1.123:80?subtype=0",
-        "tapo://password@192.168.1.123:8800?channel=0&subtype=0"
+        "tapo://password@192.168.1.123:8800?channel=0&subtype=0",
+        "unifi-protect://02AABBCCDDEE?channel=video1"
       ]
     }
   },
@@ -178,6 +179,7 @@
               "roborock",
               "tapo",
               "tuya",
+              "unifi_protect",
               "xiaomi",
               "yandex",
               "debug",
@@ -445,6 +447,9 @@
         "streams": {
           "$ref": "#/definitions/log_level"
         },
+        "unifi_protect": {
+          "$ref": "#/definitions/log_level"
+        },
         "webrtc": {
           "$ref": "#/definitions/log_level"
         },
@@ -575,6 +580,43 @@
             "type": "null"
           }
         ]
+      }
+    },
+    "unifi_protect": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "listen": {
+          "type": "string",
+          "default": ":7442"
+        },
+        "media_listen": {
+          "type": "string",
+          "default": ":7550"
+        },
+        "media_host": {
+          "description": "Address advertised to cameras for pushed media",
+          "type": "string",
+          "examples": [
+            "192.168.1.10"
+          ]
+        },
+        "tls_cert": {
+          "description": "Certificate path or inline PEM; omitted to create a persistent self-signed certificate",
+          "type": "string",
+          "examples": [
+            "-----BEGIN CERTIFICATE-----",
+            "/config/unifi-protect.crt"
+          ]
+        },
+        "tls_key": {
+          "description": "Private key path or inline PEM; must be configured with tls_cert",
+          "type": "string",
+          "examples": [
+            "-----BEGIN PRIVATE KEY-----",
+            "/config/unifi-protect.key"
+          ]
+        }
       }
     },
     "xiaomi": {


### PR DESCRIPTION
Adds a `unifi-protect://` source for using UniFi Protect cameras directly with go2rtc, without a Protect NVR.

Implements #2457

Newer UniFi cameras no longer provide a standalone RTSP server. Instead, they connect to a protect controller and push media after a WebSocket handshake.

**Disclaimer: This was completely vibecoded and I don't have experience writing go. But it works 😅**

This implements the minimal subset needed for streaming:

- TLS WebSocket controller on port `7442`
- Incoming media listener on port `7550`
- On-demand `video1`, `video2`, and `video3` streams
- H.264 video with Opus or AAC audio
- Native go2rtc tracks without transcoding
- Multiple cameras and concurrent quality channels
- Persistent self-signed certificate by default, with custom certificate support

Example:

```yaml
unifi_protect:
  listen: ":7442"
  media_listen: ":7550"

streams:
  entrance: unifi-protect://02AABBCCDDEE?channel=video1
  entrance_low: unifi-protect://02AABBCCDDEE?channel=video3&audio=0
```

The camera must be pointed at the go2rtc host using its Protect server setting or set-inform. Discovery and automatic camera configuration are intentionally not included.

Tested with a real G5 Flex running firmware 4.70.37, including RTSP playback, audio, reconnects, on-demand startup, and concurrent quality streams.

My current setup with this build:

- Homeassistant with Frigate Addon
- This PR build go2rtc copied to /addon_configs/ccab4aaf_frigate/go2rtc
- Frigate Addon configured to enable proxy on port 1935 via the ui (misusing the RTMP port)
- listen and media_listen port both set to 1935 
- Factory reset G5 Flex configured via webui to use "homeassistant:1935" as UniFi Protect Server

The protocol implementation is partially based on the work in scrypted-unifi-direct (https://github.com/xuio/scrypted-unifi-direct), adapted to go2rtc's producer and track model. 

It supports the standard UniFi Protect video1, video2, and video3 tracks.  
I dont know if other camera models use different tracks, if so we can of course adjust it.

The implementation has basic unit tests and passes:

go test ./internal/unifiprotect ./pkg/unifiprotect
go build ./...

Review of the Go structure and conventions would be especially appreciated!