### PR TITLE
Fix H.265 fMP4 sample entry codec

### DIFF
--- a/pkg/iso/codecs.go
+++ b/pkg/iso/codecs.go
@@ -11,7 +11,7 @@ func (m *Movie) WriteVideo(codec string, width, height uint16, conf []byte) {
 	case core.CodecH264:
 		m.StartAtom("avc1")
 	case core.CodecH265:
-		m.StartAtom("hev1")
+		m.StartAtom("hvc1")
 	default:
 		panic("unsupported iso video: " + codec)
 	}

--- a/pkg/iso/codecs_test.go
+++ b/pkg/iso/codecs_test.go
@@ -1,0 +1,37 @@
+package iso
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+func TestWriteVideoH265UsesHVC1(t *testing.T) {
+	config := []byte{1, 2, 3}
+	movie := NewMovie(128)
+	movie.WriteVideo(core.CodecH265, 1920, 1080, config)
+
+	data := movie.Bytes()
+	if got := string(data[4:8]); got != "hvc1" {
+		t.Fatalf("expected hvc1 sample entry, got %q", got)
+	}
+	if bytes.Contains(data, []byte("hev1")) {
+		t.Fatal("H.265 sample entry must not use hev1 when the MIME codec is hvc1")
+	}
+
+	atom, err := DecodeAtom(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	video, ok := atom.(*AtomVideo)
+	if !ok {
+		t.Fatalf("expected AtomVideo, got %T", atom)
+	}
+	if video.Name != "hvc1" {
+		t.Fatalf("expected decoded hvc1 sample entry, got %q", video.Name)
+	}
+	if !bytes.Equal(video.Config, config) {
+		t.Fatalf("expected config %v, got %v", config, video.Config)
+	}
+}

--- a/pkg/iso/reader.go
+++ b/pkg/iso/reader.go
@@ -86,7 +86,7 @@ func DecodeAtom(b []byte) (any, error) {
 			return DecodeAtom(data[1+3+4:])
 		}
 
-	case "avc1", "hev1":
+	case "avc1", "hev1", "hvc1":
 		b = data[6+2+2+2+4+4+4+2+2+4+4+4+2+32+2+2:]
 		atom, err := DecodeAtom(b)
 		if err != nil {


### PR DESCRIPTION
Fixes #2205

## TLDR
Use `hvc1` for H.265 fMP4 sample entries so init segments match the advertised MIME codec. Allow the ISO reader to decode both `hvc1` and legacy `hev1` entries.

## Why

I ran into this myself receive H265 from Dahua DSS. Still draft, as I'm just ensuring this change actually fixed my problem.