### PR TITLE
feat(arenti): add native support for Arenti & Meari cloud cameras

### DIFF
--- a/internal/arenti/arenti.go
+++ b/internal/arenti/arenti.go
@@ -380,7 +380,7 @@ func apiDeviceList(w http.ResponseWriter, r *http.Request) {
 		items = append(items, &api.Source{
 			Name: dev.DeviceName,
 			Info: strings.Join(infoParts, " | "),
-			URL:  fmt.Sprintf("arenti://%s", dev.DeviceName),
+			URL:  fmt.Sprintf("arenti://%s", url.PathEscape(dev.DeviceName)),
 		})
 	}
 
@@ -479,7 +479,7 @@ func apiAuth(w http.ResponseWriter, r *http.Request) {
 		items = append(items, &api.Source{
 			Name: dev.DeviceName,
 			Info: strings.Join(infoParts, " | "),
-			URL:  fmt.Sprintf("arenti://%s", dev.DeviceName),
+			URL:  fmt.Sprintf("arenti://%s", url.PathEscape(dev.DeviceName)),
 		})
 	}
 

--- a/internal/arenti/arenti.go
+++ b/internal/arenti/arenti.go
@@ -366,7 +366,10 @@ func apiDeviceList(w http.ResponseWriter, r *http.Request) {
 
 	var items []*api.Source
 	for _, dev := range devices {
-		infoParts := []string{dev.Model}
+		var infoParts []string
+		if dev.Model != "" {
+			infoParts = append(infoParts, dev.Model)
+		}
 		if dev.Battery > 0 {
 			infoParts = append(infoParts, fmt.Sprintf("battery: %d%%", dev.Battery))
 		}
@@ -462,7 +465,10 @@ func apiAuth(w http.ResponseWriter, r *http.Request) {
 
 	var items []*api.Source
 	for _, dev := range devices {
-		infoParts := []string{dev.Model}
+		var infoParts []string
+		if dev.Model != "" {
+			infoParts = append(infoParts, dev.Model)
+		}
 		if dev.Battery > 0 {
 			infoParts = append(infoParts, fmt.Sprintf("battery: %d%%", dev.Battery))
 		}

--- a/internal/arenti/arenti.go
+++ b/internal/arenti/arenti.go
@@ -1,0 +1,481 @@
+package arenti
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/internal/api"
+	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/internal/streams"
+	"github.com/AlexxIT/go2rtc/pkg/arenti"
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+type AccountConfig struct {
+	Username    string `yaml:"username"`
+	Password    string `yaml:"password"`
+	CountryCode string `yaml:"country_code"`
+	Region      string `yaml:"region"`
+	Server      string `yaml:"server"`
+	Battery     *bool  `yaml:"battery"`
+}
+
+func parseBattery(v any) *bool {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case bool:
+		return &val
+	case string:
+		switch strings.ToLower(strings.TrimSpace(val)) {
+		case "no", "false", "0":
+			b := false
+			return &b
+		case "yes", "true", "1":
+			b := true
+			return &b
+		}
+	case int:
+		b := val != 0
+		return &b
+	}
+	return nil
+}
+
+var (
+	accounts map[string]AccountConfig
+	clients  map[string]*arenti.Client
+	mu       sync.RWMutex
+)
+
+func Init() {
+	var v struct {
+		Streams map[string]any `yaml:"streams"`
+		Cfg     map[string]any `yaml:"arenti"`
+	}
+	app.LoadConfig(&v)
+
+	accounts = make(map[string]AccountConfig)
+	clients = make(map[string]*arenti.Client)
+
+	if v.Cfg != nil {
+		if u, ok := v.Cfg["username"].(string); ok && u != "" {
+			p, _ := v.Cfg["password"].(string)
+			c, _ := v.Cfg["country_code"].(string)
+			if c == "" {
+				c = "US"
+			}
+			reg, _ := v.Cfg["region"].(string)
+			srv, _ := v.Cfg["server"].(string)
+			bat := parseBattery(v.Cfg["battery"])
+			accounts[u] = AccountConfig{
+				Username:    u,
+				Password:    p,
+				CountryCode: c,
+				Region:      reg,
+				Server:      srv,
+				Battery:     bat,
+			}
+		} else {
+			for key, val := range v.Cfg {
+				if m, ok := val.(map[string]any); ok {
+					p, _ := m["password"].(string)
+					c, _ := m["country_code"].(string)
+					if c == "" {
+						c = "US"
+					}
+					reg, _ := m["region"].(string)
+					srv, _ := m["server"].(string)
+					bat := parseBattery(m["battery"])
+					accounts[key] = AccountConfig{
+						Username:    key,
+						Password:    p,
+						CountryCode: c,
+						Region:      reg,
+						Server:      srv,
+						Battery:     bat,
+					}
+				}
+			}
+		}
+	}
+
+	log := app.GetLogger("arenti")
+	arenti.Log = func(format string, a ...any) {
+		log.Debug().Msgf(format, a...)
+	}
+
+	streams.HandleFunc("arenti", func(rawURL string) (core.Producer, error) {
+		log.Debug().Msgf("arenti: dial %s", rawURL)
+		return dialProducer(rawURL)
+	})
+
+	api.HandleFunc("api/arenti", apiArenti)
+
+	if len(v.Streams) > 0 {
+		time.AfterFunc(1500*time.Millisecond, func() {
+			for name, item := range v.Streams {
+				checkAutoPreload(name, item)
+			}
+		})
+	}
+}
+
+func checkAutoPreload(name string, item any) {
+	var urls []string
+	switch val := item.(type) {
+	case string:
+		urls = []string{val}
+	case []string:
+		urls = val
+	case []any:
+		for _, s := range val {
+			if str, ok := s.(string); ok {
+				urls = append(urls, str)
+			}
+		}
+	}
+
+	for _, rawURL := range urls {
+		if !strings.HasPrefix(rawURL, "arenti://") && !strings.HasPrefix(rawURL, "arenti:") {
+			continue
+		}
+
+		accountEmail, _, _, _, _, battery, _, err := parseURL(rawURL)
+		if err != nil {
+			continue
+		}
+
+		isBattery := true
+		if battery != nil {
+			isBattery = *battery
+		} else {
+			mu.RLock()
+			var cfg AccountConfig
+			var ok bool
+			if accountEmail != "" {
+				cfg, ok = accounts[accountEmail]
+			} else {
+				for _, a := range accounts {
+					cfg = a
+					ok = true
+					break
+				}
+			}
+			mu.RUnlock()
+
+			if ok && cfg.Battery != nil {
+				isBattery = *cfg.Battery
+			}
+		}
+
+		// If explicitly marked as NOT battery-powered (wired / AC camera), keep connected via preload
+		if !isBattery {
+			log := app.GetLogger("arenti")
+			log.Info().Msgf("arenti: keeping wired camera always connected (preload): %s", name)
+			_ = streams.AddPreload(name, "")
+		}
+	}
+}
+
+func getClient(email string) (*arenti.Client, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if client, ok := clients[email]; ok {
+		return client, nil
+	}
+
+	cfg, ok := accounts[email]
+	if !ok {
+		return nil, fmt.Errorf("arenti: account not configured: %s", email)
+	}
+
+	client := arenti.NewClient(cfg.Username, cfg.Password, cfg.CountryCode)
+	if cfg.Server != "" {
+		client.SetBaseURL(cfg.Server)
+	} else if cfg.Region != "" {
+		client.SetRegion(cfg.Region)
+	}
+	if cfg.Battery != nil {
+		client.SetBattery(*cfg.Battery)
+	}
+
+	if err := client.Login(); err != nil {
+		return nil, err
+	}
+
+	clients[email] = client
+	return client, nil
+}
+
+func parseURL(rawURL string) (accountEmail, password, country, region, server string, battery *bool, target string, err error) {
+	s := strings.TrimPrefix(rawURL, "arenti://")
+	s = strings.TrimPrefix(s, "arenti:")
+
+	// Check query string
+	if idx := strings.IndexByte(s, '?'); idx != -1 {
+		q, _ := url.ParseQuery(s[idx+1:])
+		country = q.Get("country")
+		region = q.Get("region")
+		server = q.Get("server")
+		if bStr := q.Get("battery"); bStr != "" {
+			battery = parseBattery(bStr)
+		}
+		if acc := q.Get("account"); acc != "" {
+			accountEmail = acc
+		}
+		s = s[:idx]
+	}
+
+	// Check user:pass@
+	if idx := strings.IndexByte(s, '@'); idx != -1 {
+		userinfo := s[:idx]
+		s = s[idx+1:]
+		if uidx := strings.IndexByte(userinfo, ':'); uidx != -1 {
+			accountEmail = userinfo[:uidx]
+			password = userinfo[uidx+1:]
+		} else {
+			accountEmail = userinfo
+		}
+	}
+
+	// If contains slash (e.g. "/boat cam" or "host/boat cam" or "web-eu.arenti.net/boat cam")
+	if idx := strings.LastIndexByte(s, '/'); idx != -1 {
+		s = s[idx+1:]
+	}
+
+	if unescaped, err := url.QueryUnescape(s); err == nil && unescaped != "" {
+		s = unescaped
+	}
+	target = strings.TrimSpace(s)
+	if target == "" {
+		return "", "", "", "", "", nil, "", errors.New("arenti: missing camera name or serial in url")
+	}
+
+	return accountEmail, password, country, region, server, battery, target, nil
+}
+
+func dialProducer(rawURL string) (core.Producer, error) {
+	accountEmail, password, country, region, server, battery, target, err := parseURL(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var client *arenti.Client
+
+	if password != "" {
+		client = arenti.NewClient(accountEmail, password, country)
+		if server != "" {
+			client.SetBaseURL(server)
+		} else if region != "" {
+			client.SetRegion(region)
+		}
+		if battery != nil {
+			client.SetBattery(*battery)
+		}
+		if err := client.Login(); err != nil {
+			return nil, err
+		}
+	} else {
+		// Lookup configured account
+		if accountEmail == "" {
+			mu.RLock()
+			for email := range accounts {
+				accountEmail = email
+				break
+			}
+			mu.RUnlock()
+		}
+
+		if accountEmail == "" {
+			return nil, errors.New("arenti: no account configured in go2rtc.yaml")
+		}
+
+		client, err = getClient(accountEmail)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	dev, err := client.GetDevice(target)
+	if err != nil {
+		return nil, err
+	}
+
+	return arenti.NewProducer(client, dev, rawURL)
+}
+
+func apiArenti(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		apiDeviceList(w, r)
+	case http.MethodPost:
+		apiAuth(w, r)
+	default:
+		http.Error(w, "", http.StatusMethodNotAllowed)
+	}
+}
+
+func apiDeviceList(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	email := query.Get("id")
+
+	if email == "" {
+		mu.RLock()
+		count := len(accounts)
+		if count == 1 {
+			for id := range accounts {
+				email = id
+				break
+			}
+		} else if count > 1 {
+			accountList := make([]string, 0, count)
+			for id := range accounts {
+				accountList = append(accountList, id)
+			}
+			mu.RUnlock()
+			api.ResponseJSON(w, accountList)
+			return
+		}
+		mu.RUnlock()
+	}
+
+	if email == "" {
+		http.Error(w, "arenti: no account configured", http.StatusBadRequest)
+		return
+	}
+
+	client, err := getClient(email)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	devices, err := client.GetDevices()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var items []*api.Source
+	for _, dev := range devices {
+		infoParts := []string{dev.Model}
+		if dev.Battery > 0 {
+			infoParts = append(infoParts, fmt.Sprintf("battery: %d%%", dev.Battery))
+		}
+		if dev.WifiStrength > 0 {
+			infoParts = append(infoParts, fmt.Sprintf("wifi: %d%%", dev.WifiStrength))
+		}
+
+		items = append(items, &api.Source{
+			Name: dev.DeviceName,
+			Info: strings.Join(infoParts, " | "),
+			URL:  fmt.Sprintf("arenti://%s", dev.DeviceName),
+		})
+	}
+
+	api.ResponseSources(w, items)
+}
+
+func apiAuth(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	email := r.Form.Get("email")
+	if email == "" {
+		email = r.Form.Get("username")
+	}
+	password := r.Form.Get("password")
+	countryCode := r.Form.Get("country_code")
+	if countryCode == "" {
+		countryCode = "US"
+	}
+	region := r.Form.Get("region")
+	server := r.Form.Get("server")
+	batteryStr := r.Form.Get("battery")
+	battery := parseBattery(batteryStr)
+
+	if email == "" || password == "" {
+		http.Error(w, "username and password required", http.StatusBadRequest)
+		return
+	}
+
+	client := arenti.NewClient(email, password, countryCode)
+	if server != "" {
+		client.SetBaseURL(server)
+	} else if region != "" {
+		client.SetRegion(region)
+	}
+	if battery != nil {
+		client.SetBattery(*battery)
+	}
+	if err := client.Login(); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	cfg := map[string]string{
+		"password":     password,
+		"country_code": countryCode,
+	}
+	if region != "" {
+		cfg["region"] = region
+	}
+	if server != "" {
+		cfg["server"] = server
+	}
+	if batteryStr != "" {
+		cfg["battery"] = batteryStr
+	}
+
+	if err := app.PatchConfig([]string{"arenti", email}, cfg); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	mu.Lock()
+	accounts[email] = AccountConfig{
+		Username:    email,
+		Password:    password,
+		CountryCode: countryCode,
+		Region:      region,
+		Server:      server,
+		Battery:     battery,
+	}
+	clients[email] = client
+	mu.Unlock()
+
+	devices, err := client.GetDevices()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var items []*api.Source
+	for _, dev := range devices {
+		infoParts := []string{dev.Model}
+		if dev.Battery > 0 {
+			infoParts = append(infoParts, fmt.Sprintf("battery: %d%%", dev.Battery))
+		}
+		if dev.WifiStrength > 0 {
+			infoParts = append(infoParts, fmt.Sprintf("wifi: %d%%", dev.WifiStrength))
+		}
+
+		items = append(items, &api.Source{
+			Name: dev.DeviceName,
+			Info: strings.Join(infoParts, " | "),
+			URL:  fmt.Sprintf("arenti://%s", dev.DeviceName),
+		})
+	}
+
+	api.ResponseSources(w, items)
+}

--- a/internal/arenti/arenti_test.go
+++ b/internal/arenti/arenti_test.go
@@ -1,0 +1,68 @@
+package arenti
+
+import (
+	"testing"
+
+	"github.com/AlexxIT/go2rtc/pkg/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTarget(t *testing.T) {
+	tests := []struct {
+		rawURL    string
+		expected  string
+		region    string
+		server    string
+		isBattery *bool
+	}{
+		{"arenti://camera1", "camera1", "", "", nil},
+		{"arenti://front%20door", "front door", "", "", nil},
+		{"arenti://ppslaa00000000000000", "ppslaa00000000000000", "", "", nil},
+		{"arenti:///camera1", "camera1", "", "", nil},
+		{"arenti://user:pass@/camera1", "camera1", "", "", nil},
+		{"arenti://user:pass@host/camera1", "camera1", "", "", nil},
+		{"arenti://camera1?country=US", "camera1", "", "", nil},
+		{"arenti://camera1?region=eu", "camera1", "eu", "", nil},
+		{"arenti://camera1?server=https://custom.arenti.net", "camera1", "", "https://custom.arenti.net", nil},
+		{"arenti://camera1?battery=no", "camera1", "", "", boolPtr(false)},
+		{"arenti://camera1?battery=yes", "camera1", "", "", boolPtr(true)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.rawURL, func(t *testing.T) {
+			_, _, _, region, server, battery, target, err := parseURL(tc.rawURL)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, target)
+			require.Equal(t, tc.region, region)
+			require.Equal(t, tc.server, server)
+			require.Equal(t, tc.isBattery, battery)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestConfigLoad(t *testing.T) {
+	yamlStr := `
+arenti:
+  username: user@example.com
+  password: "SecretPassword123!"
+  country_code: US
+  region: us
+  server: "https://web-us.arenti.net"
+  battery: false
+`
+	var v struct {
+		Cfg map[string]any `yaml:"arenti"`
+	}
+	err := yaml.Unmarshal([]byte(yamlStr), &v)
+	require.NoError(t, err)
+	require.NotNil(t, v.Cfg)
+	require.Equal(t, "user@example.com", v.Cfg["username"])
+	require.Equal(t, "US", v.Cfg["country_code"])
+	require.Equal(t, "us", v.Cfg["region"])
+	require.Equal(t, "https://web-us.arenti.net", v.Cfg["server"])
+	require.Equal(t, false, v.Cfg["battery"])
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AlexxIT/go2rtc/internal/api"
 	"github.com/AlexxIT/go2rtc/internal/api/ws"
 	"github.com/AlexxIT/go2rtc/internal/app"
+	"github.com/AlexxIT/go2rtc/internal/arenti"
 	"github.com/AlexxIT/go2rtc/internal/bubble"
 	"github.com/AlexxIT/go2rtc/internal/debug"
 	"github.com/AlexxIT/go2rtc/internal/doorbird"
@@ -89,6 +90,7 @@ func main() {
 		{"alsa", alsa.Init},
 		{"v4l2", v4l2.Init},
 		// Other sources
+		{"arenti", arenti.Init},
 		{"bubble", bubble.Init},
 		{"doorbird", doorbird.Init},
 		{"dvrip", dvrip.Init},

--- a/pkg/arenti/arenti_test.go
+++ b/pkg/arenti/arenti_test.go
@@ -1,0 +1,121 @@
+package arenti
+
+import (
+	"encoding/base64"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestEncryptPassword(t *testing.T) {
+	enc, err := EncryptPassword("SecretPassword123!")
+	if err != nil {
+		t.Fatalf("EncryptPassword failed: %v", err)
+	}
+
+	// Encrypted double-base64 string should be non-empty and decodable
+	raw1, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("first base64 decode failed: %v", err)
+	}
+
+	raw2, err := base64.StdEncoding.DecodeString(string(raw1))
+	if err != nil {
+		t.Fatalf("second base64 decode failed: %v", err)
+	}
+
+	// 1024-bit RSA ciphertext is 128 bytes
+	if len(raw2) != 128 {
+		t.Fatalf("expected 128 bytes RSA ciphertext, got %d", len(raw2))
+	}
+}
+
+func TestCalcSign(t *testing.T) {
+	// Test HMAC calculation with known vectors
+	identity := "100001273858"
+	timestamp := "1788510000000"
+	nonce := "0123456789abcdef0123456789abcdef"
+	params := "deviceid=aa2d2bc5598e4e4c"
+	body := ""
+	key := "test-secret-key"
+
+	sign := CalcSign(identity, timestamp, nonce, params, body, key)
+	if len(sign) != 64 {
+		t.Fatalf("expected 64 hex chars signature, got %d (%s)", len(sign), sign)
+	}
+
+	// Must be uppercase hex
+	if sign != strings.ToUpper(sign) {
+		t.Fatalf("signature must be uppercase hex: %s", sign)
+	}
+}
+
+func TestNewUUID(t *testing.T) {
+	uuid := NewUUID()
+	matched, err := regexp.MatchString(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`, uuid)
+	if err != nil || !matched {
+		t.Fatalf("invalid UUID v4 generated: %s", uuid)
+	}
+}
+
+func TestFormatOfferSDP(t *testing.T) {
+	rawSDP := "v=0\r\n" +
+		"m=video 9 UDP/TLS/RTP/SAVPF 96\r\n" +
+		"a=rtpmap:96 H264/90000\r\n" +
+		"a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid\r\n" +
+		"a=fmtp:96 level-asymmetry-allowed=1\r\n" +
+		"m=audio 9 UDP/TLS/RTP/SAVPF 0\r\n" +
+		"a=rtpmap:0 PCMU/8000\r\n" +
+		"a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\n"
+
+	filtered := formatOfferSDP(rawSDP)
+
+	// Video section must not have extmap
+	if strings.Contains(filtered, "a=extmap:1") {
+		t.Fatalf("expected a=extmap:1 to be stripped from video: %s", filtered)
+	}
+
+	// Audio section keeps extmap or whatever outside video
+	if !strings.Contains(filtered, "a=extmap:2") {
+		t.Fatalf("expected audio extmap to be retained: %s", filtered)
+	}
+}
+
+func TestDefaultCountry(t *testing.T) {
+	client := NewClient("user@example.com", "SecretPassword123!", "")
+	if client.CountryCode != "US" {
+		t.Fatalf("expected default country code to be US, got %s", client.CountryCode)
+	}
+	if client.BaseURL != DefaultBaseURLUS {
+		t.Fatalf("expected default BaseURL to be US (%s), got %s", DefaultBaseURLUS, client.BaseURL)
+	}
+}
+
+func TestResolveBaseURL(t *testing.T) {
+	// Country-based
+	if url := ResolveBaseURL("US", "", ""); url != DefaultBaseURLUS {
+		t.Fatalf("expected US to resolve to %s, got %s", DefaultBaseURLUS, url)
+	}
+	if url := ResolveBaseURL("CA", "", ""); url != DefaultBaseURLUS {
+		t.Fatalf("expected CA to resolve to %s, got %s", DefaultBaseURLUS, url)
+	}
+	if url := ResolveBaseURL("DK", "", ""); url != DefaultBaseURLEU {
+		t.Fatalf("expected DK to resolve to %s, got %s", DefaultBaseURLEU, url)
+	}
+	if url := ResolveBaseURL("DE", "", ""); url != DefaultBaseURLEU {
+		t.Fatalf("expected DE to resolve to %s, got %s", DefaultBaseURLEU, url)
+	}
+
+	// Region override
+	if url := ResolveBaseURL("DK", "us", ""); url != DefaultBaseURLUS {
+		t.Fatalf("expected region 'us' to override to %s, got %s", DefaultBaseURLUS, url)
+	}
+	if url := ResolveBaseURL("US", "eu", ""); url != DefaultBaseURLEU {
+		t.Fatalf("expected region 'eu' to override to %s, got %s", DefaultBaseURLEU, url)
+	}
+
+	// Server override
+	if url := ResolveBaseURL("US", "eu", "https://custom.arenti.net/"); url != "https://custom.arenti.net" {
+		t.Fatalf("expected server override, got %s", url)
+	}
+}

--- a/pkg/arenti/client.go
+++ b/pkg/arenti/client.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -319,7 +321,88 @@ func (c *Client) GetDevices() ([]Device, error) {
 	allDevices = append(allDevices, devListResp.Data.Ipc...)
 	allDevices = append(allDevices, devListResp.Data.Nvr...)
 
+	var wg sync.WaitGroup
+	for i := range allDevices {
+		dev := &allDevices[i]
+		if dev.DeviceTypeName != "" {
+			filename := path.Base(dev.DeviceTypeName)
+			name := strings.TrimSuffix(filename, path.Ext(filename))
+			if strings.HasPrefix(name, "Arenti") {
+				name = "Arenti " + strings.TrimPrefix(name, "Arenti")
+			}
+			dev.Model = name
+		}
+
+		if dev.SnNum == "" {
+			continue
+		}
+
+		wg.Add(1)
+		go func(d *Device) {
+			defer wg.Done()
+			battery, wifi, model, ip, err := c.GetDeviceInfo(d.SnNum)
+			if err != nil {
+				return
+			}
+			if battery > 0 {
+				d.Battery = battery
+			}
+			if wifi > 0 {
+				d.WifiStrength = wifi
+			}
+			if d.Model == "" && model != "" {
+				d.Model = model
+			}
+			if ip != "" {
+				d.IP = ip
+			}
+		}(dev)
+	}
+	wg.Wait()
+
 	return allDevices, nil
+}
+
+// GetDeviceInfo fetches detailed device telemetry (battery %, wifi %, IP, model) via /ipc_web/device/info
+func (c *Client) GetDeviceInfo(snNum string) (battery, wifi int, model, ip string, err error) {
+	rawQuery := "snNum=" + url.QueryEscape(snNum)
+	respBytes, err := c.doAuthRequest(http.MethodGet, "/ipc_web/device/info", rawQuery, nil)
+	if err != nil {
+		return 0, 0, "", "", err
+	}
+
+	var resp struct {
+		Code string `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			Data map[string]any `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return 0, 0, "", "", err
+	}
+	if resp.Code != "1001" {
+		return 0, 0, "", "", fmt.Errorf("arenti: device info error code %s: %s", resp.Code, resp.Msg)
+	}
+
+	if val, ok := resp.Data.Data["204"].(string); ok {
+		var p struct {
+			Wifi int `json:"wifi"`
+			Bt   int `json:"bt"`
+		}
+		if json.Unmarshal([]byte(val), &p) == nil {
+			battery = p.Bt
+			wifi = p.Wifi
+		}
+	}
+	if val, ok := resp.Data.Data["63"].(string); ok && val != "" {
+		model = val
+	}
+	if val, ok := resp.Data.Data["126"].(string); ok {
+		ip = val
+	}
+
+	return battery, wifi, model, ip, nil
 }
 
 // GetDevice finds a device by name, serial number (with or without ppsl), or device ID.

--- a/pkg/arenti/client.go
+++ b/pkg/arenti/client.go
@@ -1,0 +1,397 @@
+package arenti
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	DefaultBaseURLEU  = "https://web-eu.arenti.net"
+	DefaultBaseURLUS  = "https://web-us.arenti.net"
+	DefaultBaseURL    = DefaultBaseURLEU
+	DefaultSourceApp  = "39"
+	MeariPasswordSalt = "https://www.mearitek.com/zh/home-cn/"
+	MeariRSAPublicKey = `-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCS3LSuG7ttWGvFV+Cn6FCKqqMxe9kF81McQO+tc4H5n1FImoeDDM28z1mnGGSqJHNAUbiRzcHYL8VAblH7Lbo7SwDnQtm+gjRIl9yUuyLBlA39ry14+dqCEXaO9N4hNOeRbZUXxTB126DkvKQOxzfoU1/mnDji0gUCy/zcB1KNOwIDAQAB
+-----END PUBLIC KEY-----`
+)
+
+var americasCountries = map[string]bool{
+	"US": true, "CA": true, "MX": true, "BR": true, "AR": true, "CL": true,
+	"CO": true, "PE": true, "VE": true, "EC": true, "GT": true, "CU": true,
+	"BO": true, "DO": true, "HN": true, "PY": true, "SV": true, "NI": true,
+	"CR": true, "PA": true, "UY": true, "JM": true, "TT": true, "PR": true,
+	"VI": true, "BS": true, "BZ": true, "GY": true, "SR": true,
+}
+
+// ResolveBaseURL determines the appropriate regional REST API endpoint.
+func ResolveBaseURL(countryCode, region, server string) string {
+	if server != "" {
+		return strings.TrimRight(server, "/")
+	}
+	switch strings.ToLower(strings.TrimSpace(region)) {
+	case "us", "usa", "america", "americas":
+		return DefaultBaseURLUS
+	case "eu", "europe":
+		return DefaultBaseURLEU
+	}
+	if americasCountries[strings.ToUpper(strings.TrimSpace(countryCode))] {
+		return DefaultBaseURLUS
+	}
+	return DefaultBaseURLEU
+}
+
+type Client struct {
+	Account     string
+	Password    string
+	CountryCode string
+	PhoneCode   string
+	SourceApp   string
+	BaseURL     string
+	UserID      int64
+	UserToken   string
+	WssDomain   string
+	Battery     *bool
+
+	httpClient *http.Client
+	mu         sync.RWMutex
+}
+
+func NewClient(account, password, countryCode string) *Client {
+	if countryCode == "" {
+		countryCode = "US"
+	}
+	cc := strings.ToUpper(countryCode)
+	return &Client{
+		Account:     account,
+		Password:    password,
+		CountryCode: cc,
+		SourceApp:   DefaultSourceApp,
+		BaseURL:     ResolveBaseURL(cc, "", ""),
+		httpClient:  &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *Client) SetBattery(battery bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Battery = &battery
+}
+
+func (c *Client) SetRegion(region string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.BaseURL = ResolveBaseURL(c.CountryCode, region, "")
+}
+
+func (c *Client) SetBaseURL(baseURL string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.BaseURL = strings.TrimRight(baseURL, "/")
+}
+
+// EncryptPassword performs RSA 1024-bit PKCS#1 v1.5 encryption on the salted password
+// and encodes it into base64 twice as required by the Meari/Arenti cloud.
+func EncryptPassword(password string) (string, error) {
+	block, _ := pem.Decode([]byte(MeariRSAPublicKey))
+	if block == nil {
+		return "", fmt.Errorf("failed to decode Meari RSA public key PEM")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse RSA public key: %w", err)
+	}
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return "", fmt.Errorf("public key is not an RSA public key")
+	}
+
+	salted := []byte(password + MeariPasswordSalt)
+	encrypted, err := rsa.EncryptPKCS1v15(rand.Reader, rsaPub, salted)
+	if err != nil {
+		return "", fmt.Errorf("RSA encryption failed: %w", err)
+	}
+
+	firstB64 := base64.StdEncoding.EncodeToString(encrypted)
+	secondB64 := base64.StdEncoding.EncodeToString([]byte(firstB64))
+	return secondB64, nil
+}
+
+// CalcSign calculates the HMAC-SHA256 signature for Arenti REST API requests.
+func CalcSign(identity, t, nonce, queryParams, body, key string) string {
+	bodyMD5 := ""
+	if body != "" {
+		h := md5.Sum([]byte(body))
+		bodyMD5 = hex.EncodeToString(h[:])
+	}
+	plain := identity + t + nonce + queryParams + bodyMD5
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(plain))
+	return strings.ToUpper(hex.EncodeToString(mac.Sum(nil)))
+}
+
+// NewNonce generates a 16-byte random hex string
+func NewNonce() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// NewUUID generates an RFC4122 v4 UUID string
+func NewUUID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+func (c *Client) Login() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	encPassword, err := EncryptPassword(c.Password)
+	if err != nil {
+		return fmt.Errorf("arenti: password encryption failed: %w", err)
+	}
+
+	reqBody := map[string]interface{}{
+		"app":         c.SourceApp,
+		"countryCode": c.CountryCode,
+		"lngType":     "en",
+		"password":    encPassword,
+		"phoneCode":   c.PhoneCode,
+		"userAccount": c.Account,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	t := fmt.Sprintf("%d", time.Now().UnixMilli())
+	nonce := NewNonce()
+	sign := CalcSign("-1", t, nonce, "", string(bodyBytes), "-")
+
+	loginURL := fmt.Sprintf("%s/ipc_web/user/login", c.BaseURL)
+	req, err := http.NewRequest(http.MethodPost, loginURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("identity", "-1")
+	req.Header.Set("t", t)
+	req.Header.Set("nonce", nonce)
+	req.Header.Set("sign", sign)
+	req.Header.Set("signVer", "1.1")
+	req.Header.Set("app", c.SourceApp)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("arenti: login request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var loginResp LoginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return fmt.Errorf("arenti: failed to decode login response: %w", err)
+	}
+
+	if loginResp.Code != "1001" {
+		return fmt.Errorf("arenti: login returned error code %s: %s", loginResp.Code, loginResp.Msg)
+	}
+
+	c.UserID = loginResp.Data.UserID
+	c.UserToken = loginResp.Data.UserToken
+	c.WssDomain = loginResp.Data.WssDomain
+	if loginResp.Data.CountryCode != "" {
+		c.CountryCode = loginResp.Data.CountryCode
+	}
+	if loginResp.Data.PhoneCode != "" {
+		c.PhoneCode = loginResp.Data.PhoneCode
+	}
+
+	return nil
+}
+
+func (c *Client) EnsureLogin() error {
+	c.mu.RLock()
+	hasToken := c.UserToken != ""
+	c.mu.RUnlock()
+
+	if hasToken {
+		return nil
+	}
+	return c.Login()
+}
+
+func (c *Client) doAuthRequest(method, path string, rawQuery string, bodyData []byte) ([]byte, error) {
+	if err := c.EnsureLogin(); err != nil {
+		return nil, err
+	}
+
+	c.mu.RLock()
+	userIDStr := fmt.Sprintf("%d", c.UserID)
+	userToken := c.UserToken
+	baseURL := c.BaseURL
+	appID := c.SourceApp
+	c.mu.RUnlock()
+
+	bodyStr := ""
+	if len(bodyData) > 0 {
+		bodyStr = string(bodyData)
+	}
+
+	t := fmt.Sprintf("%d", time.Now().UnixMilli())
+	nonce := NewNonce()
+	sign := CalcSign(userIDStr, t, nonce, rawQuery, bodyStr, userToken)
+
+	reqURL := fmt.Sprintf("%s%s", baseURL, path)
+	if rawQuery != "" {
+		reqURL += "?" + rawQuery
+	}
+
+	var bodyReader io.Reader
+	if len(bodyData) > 0 {
+		bodyReader = bytes.NewReader(bodyData)
+	}
+
+	req, err := http.NewRequest(method, reqURL, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("identity", userIDStr)
+	req.Header.Set("t", t)
+	req.Header.Set("nonce", nonce)
+	req.Header.Set("sign", sign)
+	req.Header.Set("signVer", "1.1")
+	req.Header.Set("app", appID)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return respBytes, nil
+}
+
+// GetDevices returns all discovered cameras from the user's account.
+func (c *Client) GetDevices() ([]Device, error) {
+	respBytes, err := c.doAuthRequest(http.MethodGet, "/ipc_web/device/list", "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var devListResp DeviceListResponse
+	if err := json.Unmarshal(respBytes, &devListResp); err != nil {
+		return nil, fmt.Errorf("arenti: decode device list failed: %w", err)
+	}
+
+	if devListResp.Code != "1001" {
+		return nil, fmt.Errorf("arenti: device list error code %s: %s", devListResp.Code, devListResp.Msg)
+	}
+
+	var allDevices []Device
+	allDevices = append(allDevices, devListResp.Data.Snap...)
+	allDevices = append(allDevices, devListResp.Data.Ipc...)
+	allDevices = append(allDevices, devListResp.Data.Nvr...)
+
+	return allDevices, nil
+}
+
+// GetDevice finds a device by name, serial number (with or without ppsl), or device ID.
+func (c *Client) GetDevice(target string) (*Device, error) {
+	devices, err := c.GetDevices()
+	if err != nil {
+		return nil, err
+	}
+
+	targetClean := strings.TrimSpace(strings.ToLower(target))
+	for _, dev := range devices {
+		if strings.ToLower(dev.DeviceName) == targetClean {
+			return &dev, nil
+		}
+		if strings.ToLower(dev.SnNum) == targetClean {
+			return &dev, nil
+		}
+		snWithoutPrefix := strings.TrimPrefix(strings.ToLower(dev.SnNum), "ppsl")
+		if snWithoutPrefix == targetClean {
+			return &dev, nil
+		}
+		if fmt.Sprintf("%d", dev.DeviceID) == targetClean {
+			return &dev, nil
+		}
+	}
+
+	return nil, fmt.Errorf("arenti: device not found: %s", target)
+}
+
+// GetDeviceStatus checks device connectivity status ("dormancy", "online", "offline").
+func (c *Client) GetDeviceStatus(deviceID string) (string, error) {
+	rawQuery := fmt.Sprintf("deviceid=%s", deviceID)
+	respBytes, err := c.doAuthRequest(http.MethodGet, "/ipc_web/iot/query_device_status", rawQuery, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var statusResp DeviceStatusResponse
+	if err := json.Unmarshal(respBytes, &statusResp); err != nil {
+		return "", err
+	}
+
+	for _, s := range statusResp.Data {
+		if s.DeviceID == deviceID {
+			return s.Status, nil
+		}
+	}
+
+	return "unknown", nil
+}
+
+// GetSignWss requests a WebSocket signaling ticket for MTS WebRTC connection.
+func (c *Client) GetSignWss(callee, deviceCode, expires string) (*SignWssResponse, error) {
+	if expires == "" {
+		expires = fmt.Sprintf("%d", time.Now().UnixMilli())
+	}
+	rawParams := fmt.Sprintf("expires=%s&method=mts:option&deviceid=%s&devicecode=%s",
+		expires, callee, deviceCode)
+
+	respBytes, err := c.doAuthRequest(http.MethodGet, "/ipc_web/iot_sign/wss", rawParams, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var signResp SignWssResponse
+	if err := json.Unmarshal(respBytes, &signResp); err != nil {
+		return nil, fmt.Errorf("arenti: decode iot_sign/wss response failed: %w", err)
+	}
+
+	if signResp.Code != "1001" {
+		return nil, fmt.Errorf("arenti: iot_sign/wss returned code %s: %s", signResp.Code, signResp.Msg)
+	}
+
+	return &signResp, nil
+}

--- a/pkg/arenti/conn.go
+++ b/pkg/arenti/conn.go
@@ -1,0 +1,541 @@
+package arenti
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/webrtc"
+	"github.com/gorilla/websocket"
+	pion "github.com/pion/webrtc/v4"
+)
+
+type Conn struct {
+	*webrtc.Conn
+
+	client    *Client
+	dev       *Device
+	isBattery bool
+	wsConn    *websocket.Conn
+	sessionID string
+	callerID  string
+	callee    string
+
+	ticker    *time.Ticker
+	done      chan struct{}
+	closeOnce sync.Once
+}
+
+var Log = func(format string, a ...any) {}
+
+func newRtcAPI() (*pion.API, error) {
+	m := &pion.MediaEngine{}
+	if err := m.RegisterCodec(pion.RTPCodecParameters{
+		RTPCodecCapability: pion.RTPCodecCapability{
+			MimeType:    pion.MimeTypeH264,
+			ClockRate:   90000,
+			SDPFmtpLine: "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f",
+		},
+		PayloadType: 96,
+	}, pion.RTPCodecTypeVideo); err != nil {
+		return nil, err
+	}
+	if err := m.RegisterCodec(pion.RTPCodecParameters{
+		RTPCodecCapability: pion.RTPCodecCapability{
+			MimeType:  pion.MimeTypePCMU,
+			ClockRate: 8000,
+		},
+		PayloadType: 0,
+	}, pion.RTPCodecTypeAudio); err != nil {
+		return nil, err
+	}
+	if err := m.RegisterCodec(pion.RTPCodecParameters{
+		RTPCodecCapability: pion.RTPCodecCapability{
+			MimeType:  pion.MimeTypePCMA,
+			ClockRate: 8000,
+		},
+		PayloadType: 8,
+	}, pion.RTPCodecTypeAudio); err != nil {
+		return nil, err
+	}
+	return pion.NewAPI(pion.WithMediaEngine(m)), nil
+}
+
+// NewProducer connects to an Arenti camera via WebRTC (MTS protocol) on-demand.
+func NewProducer(client *Client, dev *Device, rawURL string) (*Conn, error) {
+	callee := strings.TrimPrefix(dev.SnNum, "ppsl")
+	deviceCode := dev.HostKey
+
+	// 1. Generate unique session and caller IDs
+	sessionID := NewUUID()
+	callerIDBytes := make([]byte, 8)
+	if _, err := rand.Read(callerIDBytes); err != nil {
+		return nil, err
+	}
+	callerID := hex.EncodeToString(callerIDBytes)
+
+	// 2. Obtain WebSocket signaling ticket from REST API
+	expires := fmt.Sprintf("%d", time.Now().UnixMilli())
+	signResp, err := client.GetSignWss(callee, deviceCode, expires)
+	if err != nil {
+		return nil, fmt.Errorf("arenti: failed to obtain wss sign ticket: %w", err)
+	}
+
+	// 3. Connect to Meari signaling WebSocket gateway
+	wssDomain := client.WssDomain
+	if wssDomain == "" {
+		if strings.Contains(client.BaseURL, "web-us") {
+			wssDomain = "wss://wss-us.mearicloud.com"
+		} else {
+			wssDomain = "wss://wss-eu.mearicloud.com"
+		}
+	}
+
+	Log("arenti: connecting to wss %s (callee: %s)", wssDomain, callee)
+
+	header := http.Header{}
+	header.Set("Origin", "https://web.arenti.net")
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(wssDomain, header)
+	if err != nil {
+		return nil, fmt.Errorf("arenti: websocket dial failed: %w", err)
+	}
+
+	// 4. Send "hello"
+	helloMsg := map[string]interface{}{
+		"action": "req",
+		"cmd":    "mts",
+		"method": "hello",
+		"sid":    sessionID,
+	}
+	if err := wsConn.WriteJSON(helloMsg); err != nil {
+		_ = wsConn.Close()
+		return nil, fmt.Errorf("arenti: failed to send hello: %w", err)
+	}
+
+	// 5. Send "option" to obtain COTURN credentials
+	optionMsg := map[string]interface{}{
+		"action": "req",
+		"cmd":    "mts",
+		"method": "option",
+		"sid":    sessionID,
+		"auth": map[string]string{
+			"accessid":  signResp.Data.AccessID,
+			"signature": signResp.Data.Signature,
+			"token":     signResp.Data.Token,
+		},
+		"params": map[string]string{
+			"caller":     callerID,
+			"callee":     callee,
+			"devicecode": deviceCode,
+			"expires":    expires,
+		},
+	}
+	if err := wsConn.WriteJSON(optionMsg); err != nil {
+		_ = wsConn.Close()
+		return nil, fmt.Errorf("arenti: failed to send option: %w", err)
+	}
+
+	// 6. Read until COTURN credentials arrive in "option" response
+	_ = wsConn.SetReadDeadline(time.Now().Add(15 * time.Second))
+	var coturn TurnCredentials
+	for {
+		_, msgBytes, err := wsConn.ReadMessage()
+		if err != nil {
+			_ = wsConn.Close()
+			return nil, fmt.Errorf("arenti: read option response error: %w", err)
+		}
+
+		var rsp struct {
+			Action string          `json:"action"`
+			Cmd    string          `json:"cmd"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(msgBytes, &rsp); err == nil && rsp.Method == "option" {
+			if err := json.Unmarshal(rsp.Params, &coturn); err == nil && coturn.CoturnHost != "" {
+				break
+			}
+		}
+	}
+
+	if coturn.CoturnHost == "" {
+		_ = wsConn.Close()
+		return nil, errors.New("arenti: empty COTURN host received from cloud")
+	}
+
+	Log("arenti: received coturn %s:%d", coturn.CoturnHost, coturn.CoturnPort)
+
+	// 7. Initialize Pion PeerConnection with H264 baseline + audio
+	rtcAPI, err := newRtcAPI()
+	if err != nil {
+		_ = wsConn.Close()
+		return nil, err
+	}
+
+	iceServers := []pion.ICEServer{
+		{
+			URLs: []string{
+				fmt.Sprintf("turn:%s:%d?transport=udp", coturn.CoturnHost, coturn.CoturnPort),
+				fmt.Sprintf("stun:%s:%d", coturn.CoturnHost, coturn.CoturnPort),
+			},
+			Username:   coturn.Username,
+			Credential: coturn.Password,
+		},
+	}
+
+	pc, err := rtcAPI.NewPeerConnection(pion.Configuration{
+		ICEServers: iceServers,
+	})
+	if err != nil {
+		_ = wsConn.Close()
+		return nil, err
+	}
+
+	webrtcConn := webrtc.NewConn(pc)
+	webrtcConn.FormatName = "arenti/webrtc"
+	webrtcConn.Mode = core.ModeActiveProducer
+	webrtcConn.Protocol = "wss"
+	webrtcConn.URL = rawURL
+
+	isBattery := true
+	if strings.Contains(rawURL, "battery=false") || strings.Contains(rawURL, "battery=no") || strings.Contains(rawURL, "battery=0") {
+		isBattery = false
+	} else if strings.Contains(rawURL, "battery=true") || strings.Contains(rawURL, "battery=yes") || strings.Contains(rawURL, "battery=1") {
+		isBattery = true
+	} else if client.Battery != nil {
+		isBattery = *client.Battery
+	} else if dev != nil && dev.Category == "ipc" && dev.Battery == 0 {
+		isBattery = false
+	}
+
+	conn := &Conn{
+		Conn:      webrtcConn,
+		client:    client,
+		dev:       dev,
+		isBattery: isBattery,
+		wsConn:    wsConn,
+		sessionID: sessionID,
+		callerID:  callerID,
+		callee:    callee,
+		done:      make(chan struct{}),
+	}
+
+	// Listen for ICE candidates and forward to camera via WebSocket
+	webrtcConn.Listen(func(msg any) {
+		if c, ok := msg.(*pion.ICECandidate); ok && c != nil {
+			candJSON := c.ToJSON()
+			Log("arenti: sending local ICE candidate: %s", candJSON.Candidate)
+			candMsg := map[string]interface{}{
+				"action": "req",
+				"cmd":    "mts",
+				"method": "candidate",
+				"sid":    sessionID,
+				"params": map[string]interface{}{
+					"caller": callerID,
+					"callee": callee,
+					"candidate": map[string]interface{}{
+						"candidate":     candJSON.Candidate,
+						"sdpMid":        candJSON.SDPMid,
+						"sdpMLineIndex": candJSON.SDPMLineIndex,
+					},
+				},
+			}
+			_ = wsConn.WriteJSON(candMsg)
+		}
+	})
+
+	// Add transceivers for video and audio (recvonly)
+	if _, err := pc.AddTransceiverFromKind(pion.RTPCodecTypeVideo, pion.RTPTransceiverInit{
+		Direction: pion.RTPTransceiverDirectionRecvonly,
+	}); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if _, err := pc.AddTransceiverFromKind(pion.RTPCodecTypeAudio, pion.RTPTransceiverInit{
+		Direction: pion.RTPTransceiverDirectionRecvonly,
+	}); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	offerDesc, err := pc.CreateOffer(nil)
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	if err := pc.SetLocalDescription(offerDesc); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	// Filter SDP offer: Arenti/Meari devices reject extmap in video description
+	filteredSDP := formatOfferSDP(offerDesc.SDP)
+
+	// Send offer MTS message to wake camera and initiate stream
+	offerMsg := map[string]interface{}{
+		"action": "req",
+		"cmd":    "mts",
+		"method": "offer",
+		"sid":    sessionID,
+		"params": map[string]interface{}{
+			"caller":     callerID,
+			"callee":     callee,
+			"devicecode": deviceCode,
+			"sdp":        filteredSDP,
+			"settings": map[string]interface{}{
+				"method": "preview",
+				"streams": []map[string]interface{}{
+					{"channel": 1, "stream": 0},
+				},
+			},
+		},
+	}
+	if err := wsConn.WriteJSON(offerMsg); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	pc.OnICEConnectionStateChange(func(state pion.ICEConnectionState) {
+		Log("arenti: ICE connection state: %s", state)
+	})
+
+	pc.OnConnectionStateChange(func(state pion.PeerConnectionState) {
+		Log("arenti: peer connection state: %s", state)
+		if state == pion.PeerConnectionStateConnected {
+			Log("arenti: connected! Sending preview play command...")
+			playMsg := map[string]interface{}{
+				"action": "req",
+				"cmd":    "mts",
+				"method": "settings",
+				"sid":    sessionID,
+				"params": map[string]interface{}{
+					"caller": callerID,
+					"callee": callee,
+					"settings": map[string]interface{}{
+						"sid":    1001,
+						"method": "preview",
+						"streams": []map[string]interface{}{
+							{
+								"channel": 1,
+								"stream":  0,
+								"stop":    0,
+							},
+						},
+					},
+				},
+			}
+			_ = wsConn.WriteJSON(playMsg)
+		}
+	})
+
+	Log("arenti: offer sent (%d bytes), awaiting camera wake up...", len(filteredSDP))
+
+	// 8. Wait for SDP Answer from camera (up to 30s to allow battery cameras to wake up)
+	_ = wsConn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	var pendingCandidates []pion.ICECandidateInit
+	var answerSDP string
+	for {
+		_, msgBytes, err := wsConn.ReadMessage()
+		if err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("arenti: waiting for camera answer timed out or failed: %w", err)
+		}
+
+		var rsp struct {
+			Action string          `json:"action"`
+			Cmd    string          `json:"cmd"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(msgBytes, &rsp); err == nil {
+			if rsp.Method == "answer" || rsp.Method == "offer" {
+				var p struct {
+					SDP string `json:"sdp"`
+				}
+				if err := json.Unmarshal(rsp.Params, &p); err == nil && p.SDP != "" {
+					answerSDP = p.SDP
+					Log("arenti: camera answered (%d bytes)", len(answerSDP))
+					break
+				}
+			} else if rsp.Method == "candidate" {
+				if cand := parseCandidate(rsp.Params); cand != nil {
+					pendingCandidates = append(pendingCandidates, *cand)
+				}
+			}
+		}
+	}
+
+	if answerSDP == "" {
+		_ = conn.Close()
+		return nil, errors.New("arenti: empty SDP answer from camera")
+	}
+
+	if err := conn.Conn.SetAnswer(answerSDP); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("arenti: SetAnswer error: %w", err)
+	}
+
+	// Apply any candidates received before answer
+	for _, cand := range pendingCandidates {
+		Log("arenti: applying pending remote ICE candidate: %s", cand.Candidate)
+		_ = pc.AddICECandidate(cand)
+	}
+
+	// Clear read deadline for continuous streaming
+	_ = wsConn.SetReadDeadline(time.Time{})
+
+	// 9. Start 30s hello keepalive ticker
+	conn.ticker = time.NewTicker(30 * time.Second)
+	go conn.keepaliveLoop()
+
+	// 10. Start WebSocket message reading loop
+	go conn.readLoop(pc)
+
+	return conn, nil
+}
+
+func (c *Conn) keepaliveLoop() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-c.ticker.C:
+			keepalive := map[string]interface{}{
+				"action": "req",
+				"cmd":    "mts",
+				"method": "hello",
+				"sid":    c.sessionID,
+			}
+			_ = c.wsConn.WriteJSON(keepalive)
+		}
+	}
+}
+
+func (c *Conn) readLoop(pc *pion.PeerConnection) {
+	for {
+		_, msgBytes, err := c.wsConn.ReadMessage()
+		if err != nil {
+			// WebSocket closed or error -> stop producer
+			_ = c.Stop()
+			return
+		}
+
+		var rsp struct {
+			Action string          `json:"action"`
+			Cmd    string          `json:"cmd"`
+			Method string          `json:"method"`
+			ErrID  int             `json:"errid"`
+			ErrStr string          `json:"errstr"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(msgBytes, &rsp); err == nil {
+			switch rsp.Method {
+			case "candidate":
+				if cand := parseCandidate(rsp.Params); cand != nil {
+					Log("arenti: received remote ICE candidate: %s", cand.Candidate)
+					_ = pc.AddICECandidate(*cand)
+				}
+			case "settings":
+				Log("arenti: settings acknowledged by camera")
+			case "exception":
+				Log("arenti: exception: %d - %s", rsp.ErrID, rsp.ErrStr)
+			case "close":
+				Log("arenti: camera closed session")
+				_ = c.Stop()
+				return
+			}
+		}
+	}
+}
+
+func parseCandidate(rawParams json.RawMessage) *pion.ICECandidateInit {
+	var nested struct {
+		Candidate struct {
+			Candidate     string  `json:"candidate"`
+			SDPMid        *string `json:"sdpMid"`
+			SDPMLineIndex *uint16 `json:"sdpMLineIndex"`
+		} `json:"candidate"`
+	}
+	if err := json.Unmarshal(rawParams, &nested); err == nil && nested.Candidate.Candidate != "" {
+		return &pion.ICECandidateInit{
+			Candidate:     nested.Candidate.Candidate,
+			SDPMid:        nested.Candidate.SDPMid,
+			SDPMLineIndex: nested.Candidate.SDPMLineIndex,
+		}
+	}
+
+	var flat struct {
+		Candidate     string  `json:"candidate"`
+		SDPMid        *string `json:"sdpMid"`
+		SDPMLineIndex *uint16 `json:"sdpMLineIndex"`
+	}
+	if err := json.Unmarshal(rawParams, &flat); err == nil && flat.Candidate != "" {
+		return &pion.ICECandidateInit{
+			Candidate:     flat.Candidate,
+			SDPMid:        flat.SDPMid,
+			SDPMLineIndex: flat.SDPMLineIndex,
+		}
+	}
+
+	return nil
+}
+
+// Stop sends MTS "close" to put battery cameras back to sleep (saving battery) and closes resources.
+func (c *Conn) Stop() error {
+	c.closeOnce.Do(func() {
+		close(c.done)
+		if c.ticker != nil {
+			c.ticker.Stop()
+		}
+
+		if c.isBattery {
+			// Put battery camera back to sleep
+			closeMsg := map[string]interface{}{
+				"action": "req",
+				"cmd":    "mts",
+				"method": "close",
+				"sid":    c.sessionID,
+				"params": map[string]string{
+					"caller": c.callerID,
+					"callee": c.callee,
+				},
+			}
+			_ = c.wsConn.WriteJSON(closeMsg)
+		}
+		_ = c.wsConn.Close()
+	})
+
+	return c.Conn.Stop()
+}
+
+func (c *Conn) Close() error {
+	return c.Stop()
+}
+
+// formatOfferSDP removes extmap attributes from video description to ensure camera compatibility.
+func formatOfferSDP(sdp string) string {
+	lines := strings.Split(sdp, "\r\n")
+	var filtered []string
+	inVideo := false
+	for _, l := range lines {
+		if strings.HasPrefix(l, "m=video") {
+			inVideo = true
+		} else if strings.HasPrefix(l, "m=audio") || strings.HasPrefix(l, "m=application") {
+			inVideo = false
+		}
+		if inVideo && strings.HasPrefix(l, "a=extmap:") {
+			continue
+		}
+		filtered = append(filtered, l)
+	}
+	return strings.Join(filtered, "\r\n")
+}

--- a/pkg/arenti/types.go
+++ b/pkg/arenti/types.go
@@ -38,11 +38,13 @@ type Device struct {
 	Category     string `json:"category"`
 	Capability   string `json:"capability"`
 	IsOwner      int    `json:"isOwner"`
-	IconURL      string `json:"iconUrl"`
-	Version      string `json:"version"`
-	UpgradeVer   string `json:"upgradeVer"`
-	WifiStrength int    `json:"wifiStrength"`
-	Battery      int    `json:"battery"`
+	IconURL        string `json:"iconUrl"`
+	DeviceTypeName string `json:"deviceTypeName"`
+	Version        string `json:"version"`
+	UpgradeVer     string `json:"upgradeVer"`
+	WifiStrength   int    `json:"wifiStrength"`
+	Battery        int    `json:"battery"`
+	IP             string `json:"ip"`
 }
 
 // DeviceStatusResponse represents the response from /ipc_web/iot/query_device_status

--- a/pkg/arenti/types.go
+++ b/pkg/arenti/types.go
@@ -1,0 +1,140 @@
+package arenti
+
+import "encoding/json"
+
+// LoginResponse represents the response from /ipc_web/user/login
+type LoginResponse struct {
+	Code string `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		UserID      int64  `json:"userID"`
+		UserAccount string `json:"userAccount"`
+		UserToken   string `json:"userToken"`
+		WssDomain   string `json:"wssDomain"`
+		CountryCode string `json:"countryCode"`
+		PhoneCode   string `json:"phoneCode"`
+	} `json:"data"`
+}
+
+// DeviceListResponse represents the response from /ipc_web/device/list
+type DeviceListResponse struct {
+	Code string `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		Ipc  []Device `json:"ipc"`
+		Nvr  []Device `json:"nvr"`
+		Snap []Device `json:"snap"`
+	} `json:"data"`
+}
+
+// Device represents an Arenti/Meari camera device
+type Device struct {
+	DeviceID     int64  `json:"deviceID"`
+	DeviceName   string `json:"deviceName"`
+	SnNum        string `json:"snNum"`
+	HostKey      string `json:"hostKey"`
+	P2PID        string `json:"p2pID"`
+	Model        string `json:"model"`
+	Category     string `json:"category"`
+	Capability   string `json:"capability"`
+	IsOwner      int    `json:"isOwner"`
+	IconURL      string `json:"iconUrl"`
+	Version      string `json:"version"`
+	UpgradeVer   string `json:"upgradeVer"`
+	WifiStrength int    `json:"wifiStrength"`
+	Battery      int    `json:"battery"`
+}
+
+// DeviceStatusResponse represents the response from /ipc_web/iot/query_device_status
+type DeviceStatusResponse struct {
+	Code string         `json:"code"`
+	Msg  string         `json:"msg"`
+	Data []DeviceStatus `json:"data"`
+}
+
+// DeviceStatus represents runtime device connectivity state
+type DeviceStatus struct {
+	DeviceID string `json:"deviceid"`
+	Status   string `json:"status"` // "dormancy" | "online" | "offline"
+	Runtime  int    `json:"runtime"`
+}
+
+// SignWssResponse represents the response from /ipc_web/iot_sign/wss
+type SignWssResponse struct {
+	Code string `json:"code"`
+	Msg  string `json:"msg"`
+	Data struct {
+		AccessID  string `json:"accessid"`
+		Signature string `json:"signature"`
+		Token     string `json:"token"`
+	} `json:"data"`
+}
+
+// MtsMessage represents an MTS envelope on WebSocket
+type MtsMessage struct {
+	Action string          `json:"action"` // "req" | "rsp"
+	Cmd    string          `json:"cmd"`    // "mts"
+	Method string          `json:"method"` // "hello" | "option" | "offer" | "answer" | "close" | "candidate"
+	Sid    string          `json:"sid"`
+	Auth   *MtsAuth        `json:"auth,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+// MtsAuth carries the signaling ticket
+type MtsAuth struct {
+	AccessID  string `json:"accessid"`
+	Signature string `json:"signature"`
+	Token     string `json:"token"`
+}
+
+// MtsOptionParams are sent in the "option" request
+type MtsOptionParams struct {
+	Caller     string `json:"caller"`
+	Callee     string `json:"callee"`
+	DeviceCode string `json:"devicecode"`
+	Expires    string `json:"expires"`
+}
+
+// TurnCredentials returned in "option" response
+type TurnCredentials struct {
+	CoturnHost string `json:"coturn_host"`
+	CoturnIP   string `json:"coturn_ip"`
+	CoturnPort int    `json:"coturn_port"`
+	Username   string `json:"username"`
+	Password   string `json:"pwd"`
+}
+
+// MtsStream defines requested stream channel
+type MtsStream struct {
+	Channel int `json:"channel"`
+	Stream  int `json:"stream"`
+}
+
+// MtsSettings contains stream configuration in offer
+type MtsSettings struct {
+	Streams []MtsStream `json:"streams"`
+}
+
+// MtsOfferParams sent in "offer" request
+type MtsOfferParams struct {
+	Caller     string      `json:"caller"`
+	Callee     string      `json:"callee"`
+	DeviceCode string      `json:"devicecode"`
+	SDP        string      `json:"sdp"`
+	Settings   MtsSettings `json:"settings"`
+}
+
+// MtsAnswerParams received in "answer" response
+type MtsAnswerParams struct {
+	Caller     string `json:"caller,omitempty"`
+	Callee     string `json:"callee,omitempty"`
+	DeviceCode string `json:"devicecode,omitempty"`
+	SDP        string `json:"sdp"`
+}
+
+// MtsCloseParams sent in "close" request
+type MtsCloseParams struct {
+	Caller     string `json:"caller"`
+	Callee     string `json:"callee"`
+	DeviceCode string `json:"devicecode"`
+}

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -87,9 +87,10 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 			}
 		}
 
-		if c.Mode == core.ModePassiveProducer && remote.Kind() == webrtc.RTPCodecTypeVideo {
+		if (c.Mode == core.ModePassiveProducer || c.Mode == core.ModeActiveProducer) && remote.Kind() == webrtc.RTPCodecTypeVideo {
 			go func() {
 				pkts := []rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(remote.SSRC())}}
+				_ = pc.WriteRTCP(pkts) // send initial PLI immediately
 				for range time.NewTicker(time.Second * 2).C {
 					if err := pc.WriteRTCP(pkts); err != nil {
 						return

--- a/www/add.html
+++ b/www/add.html
@@ -377,6 +377,71 @@
     </script>
 
 
+    <button id="arenti">Arenti</button>
+    <div>
+        <form id="arenti-login-form">
+            <input type="email" name="email" placeholder="email / username" required>
+            <input type="password" name="password" placeholder="password" required>
+            <input type="text" name="country_code" placeholder="country code (e.g. US, DE)" value="US" size="4">
+            <select name="region">
+                <option value="">auto (by country)</option>
+                <option value="us">Americas (US)</option>
+                <option value="eu">Europe (EU)</option>
+            </select>
+            <button type="submit">login</button>
+        </form>
+        <form id="arenti-devices-form">
+            <select id="arenti-id" name="id" required></select>
+            <button type="submit">load devices</button>
+        </form>
+        <table id="arenti-table"></table>
+    </div>
+    <script>
+        async function arentiReload(ev) {
+            if (ev) ev.target.nextElementSibling.style.display = 'grid';
+
+            const r = await fetch('api/arenti', {'cache': 'no-cache'});
+            if (!r.ok) return;
+
+            const data = await r.json();
+            const users = document.getElementById('arenti-id');
+            if (Array.isArray(data) && data.length > 0 && typeof data[0] === 'string') {
+                users.innerHTML = data.map(item => `<option value="${item}">${item}</option>`).join('');
+            } else if (data && data.sources) {
+                drawTable(document.getElementById('arenti-table'), data);
+            }
+        }
+
+        document.getElementById('arenti').addEventListener('click', arentiReload);
+
+        document.getElementById('arenti-login-form').addEventListener('submit', async ev => {
+            ev.preventDefault();
+
+            const table = document.getElementById('arenti-table');
+            table.innerText = 'loading...';
+
+            const params = new URLSearchParams(new FormData(ev.target));
+            const r = await fetch('api/arenti', {method: 'POST', body: params});
+
+            if (!r.ok) {
+                table.innerText = (await r.text()) || 'Unknown error';
+                return;
+            }
+
+            const data = await r.json();
+            table.innerText = '';
+            drawTable(table, data);
+            arentiReload();
+        });
+
+        document.getElementById('arenti-devices-form').addEventListener('submit', async ev => {
+            ev.preventDefault();
+            const params = new URLSearchParams(new FormData(ev.target));
+            await getSources('arenti-table', 'api/arenti?' + params.toString());
+        });
+    </script>
+
+
     <button id="roborock">Roborock</button>
     <div>
         <form id="roborock-form">


### PR DESCRIPTION
### Summary

Adds native cloud streaming support for **Arenti** and **Meari** cameras (including sub-brands like Laxihub and white-label Meari devices) via WebRTC.

Arenti and Meari cameras are among the most popular and affordable smart cameras sold globally on AliExpress, Amazon, and other retail sites. However, most models (especially battery-powered and solar units) do not expose a local RTSP server. This integration allows users to stream these cameras directly in `go2rtc` with zero extra middleware.

---

### Key Features

* **Native WebRTC Ingestion**:
  * Authenticates with the Arenti cloud API (RSA encryption + HMAC-SHA256 request signing).
  * Establishes low-latency WebRTC streams using Arenti's cloud signaling and COTURN infrastructure.
  * Ingests H.264 video and PCM audio directly into go2rtc pipelines.

* **Battery & Dormancy Awareness**:
  * **Battery-powered cameras (default)**: Kept in deep sleep (dormancy) to save power. When a viewer requests the stream in go2rtc, the integration sends a wake-up signal to spin up the camera. When viewers disconnect, the session closes and the camera returns to deep sleep.
  * **Wired / AC-powered cameras**: Can be flagged via `battery: false` in config or `?battery=no` in URL to keep the stream permanently connected via preload.

* **Multi-Region & Auto-Routing**:
  * Automatic endpoint resolution based on ISO country code (defaults to `US`).
  * Explicit region selection supported: `us` (Americas) or `eu` (Europe & international), as well as custom server overrides.

* **Active Producer RTCP PLI Support**:
  * Updated `pkg/webrtc/conn.go` to send initial and periodic RTCP PLI (Picture Loss Indication) keyframe requests for `ModeActiveProducer`, ensuring clean and immediate video decoding upon connection.


#### Note on `pkg/webrtc/conn.go`:
* **RTCP PLI for `ModeActiveProducer`**: Previously, periodic RTCP Picture Loss Indication (PLI) packets were only transmitted for `ModePassiveProducer`. When dialing cloud WebRTC producers like Arenti (`ModeActiveProducer`), cameras require keyframe requests to initialize video decoding. Enabling PLI for active producers ensures prompt I-frame generation and prevents black screens/decoding delays upon stream connection.
* **Immediate Keyframe on Connect**: Added an initial `pc.WriteRTCP()` call before the 2-second ticker starts so a keyframe is requested immediately at millisecond 0, significantly reducing time-to-first-frame.


---

### Configuration Examples

#### 1. Via `go2rtc.yaml` (Single or Multi-Account)
```yaml
arenti:
  username: "user@example.com"
  password: "YourPassword"
  country_code: "US"       # optional, default "US"
  region: "us"             # optional: "us" or "eu"
  battery: true            # optional, default true (set false for wired cameras)

streams:
  front_door: arenti://Front Door Camera
  driveway: arenti://ppslaa0123456789