### PR TITLE
Fix media timestamps for xiaomi yunlu.door.sd2106

### DIFF
--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -137,8 +137,11 @@ func (c *Client) WriteCommand(data []byte) error {
 const (
 	ModelDafang  = "isa.camera.df3"
 	ModelLoockV2 = "loock.cateye.v02"
-	ModelC200    = "chuangmi.camera.046c04"
-	ModelC300    = "chuangmi.camera.72ac1"
+	// ModelYunluP50 is a smart door with a peephole camera.
+	// It reports media timestamps in microseconds instead of milliseconds.
+	ModelYunluP50 = "yunlu.door.sd2106"
+	ModelC200     = "chuangmi.camera.046c04"
+	ModelC300     = "chuangmi.camera.72ac1"
 	// ModelXiaofang looks like it has the same firmware as the ModelDafang.
 	// There is also an older model "isa.camera.isc5" that only works with the legacy protocol.
 	ModelXiaofang = "isa.camera.isc5c1"
@@ -248,6 +251,9 @@ func (c *Client) ReadPacket() (*Packet, error) {
 		// Dafang has ts in sec
 		// LoockV2 has ts in msec for video, but zero ts for audio
 		pkt.Timestamp = uint64(time.Now().UnixMilli())
+	case ModelYunluP50:
+		// YunluP50 has ts in usec
+		pkt.Timestamp = binary.LittleEndian.Uint64(hdr[16:]) / 1000
 	default:
 		pkt.Timestamp = binary.LittleEndian.Uint64(hdr[16:])
 	}


### PR DESCRIPTION
### Device

Yunlu smart door P50 (云鹿智能门P50), `yunlu.door.sd2106` — a smart door with a
built-in peephole camera. It works over `miss` / `cs2+tcp` and streams H265 +
PCMA once you write the source by hand.

### Symptom

Video plays for a fraction of a second and then stalls, so in a browser (MSE) or
a Home Assistant card it looks like a still image that only advances when you
reload. `ffmpeg -i rtsp://.../door -t 20 -c copy out.mp4` exits immediately and
writes 0 frames.

### Root cause

This device reports media timestamps in **microseconds**. `ReadPacket` assumes
milliseconds, so `TimeToRTP(pkt.Timestamp, 90000)` produces RTP timestamps 1000x
too large.

Measured packet spacing (`ffprobe -select_streams v -show_entries packet=pts_time`):

| stream | pts delta between frames |
|---|---|
| `xiaomi.camera.083ac1` (control) | ~0.061 s |
| `yunlu.door.sd2106` | **33.3 s / 66.7 s** alternating |

The device's own header field advances by ~33334 per frame at a real 20 fps
(50 ms), i.e. microseconds. Its timestamps are additionally quantized to a
33.33 ms grid, which is why the deltas alternate 33.3/66.7 instead of a flat 50.

The same stream through the fMP4 muxer (the path MSE uses) collapses the other
way:

| stream | video packets | fMP4 timeline duration |
|---|---|---|
| before | 204 | **0.206 s** |
| after | 194 | **9.63 s** (~20 fps) |

### Fix

Divide the reported timestamp by 1000 for this model, alongside the existing
per-model timestamp special cases.

### Verification

| check | before | after |
|---|---|---|
| RTSP pts delta | 33.3 s / 66.7 s | 0.033 s / 0.067 s |
| `stream.mp4` (MSE path) | 204 frames / 0.206 s | 194 frames / 9.63 s |
| `api/frame.jpeg` | ok | ok (2048x1536) |
| `ffmpeg -t 20 -c copy` | 0 frames | 361 frames / 18.05 s |
| `xiaomi.camera.083ac1` control | unaffected | unaffected |

Source used for testing:

```yaml
streams:
  yunlu_door:
    - xiaomi://<uid>:@192.168.5.37?did=<did>&model=yunlu.door.sd2106&subtype=4
```

### Two unrelated notes about this device, in case they are useful

1. **`subtype=2` produces no video on this device**, and 2 is the default for
   `hd`. Without an explicit `subtype` the source fails with
   `xiaomi: probe: no video`. Working values are 0, 1, 3 and 4
   (4 = 2048x1536, 0/3 = 1440x1080, 1 = 640x480); 5 and above give no video.
   Happy to add a `ModelYunluP50` default of `4` to `StartMedia` if you want it.

2. **`HasCamera()` filters this device out** of `GET /api/xiaomi`, because the
   model contains `.door.` rather than `.camera.` / `.cateye.` / `.feeder.`, so
   it never shows up in *WebUI > Add > Xiaomi* and has to be written by hand.
   I left that alone since `.door.` would also match door locks with no camera.

For what it is worth, this door has two cameras (peephole + a top-of-door AI
camera) and the vendor app shows both at once, but I could not reach the second
one through `miss`: `channel!=0` (`{"videoquality":-1,"videoquality2":N}`) yields
no video for N=0..5, and probing `cmdStreamCtrlReq` shows the firmware does not
recognize a `videoquality2` field at all (it validates `videoquality` — an
out-of-range value gets no ack — but silently ignores `videoquality2`, and every
other lens-ish key I tried). So the second lens looks like it is not exposed over
this protocol. This PR only fixes the timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
