### PR TITLE
webrtc: reuse a compatible Receiver when the remote transmits on another payload type (Nest cold-consumer starvation)

### DIFF
--- a/pkg/webrtc/producer.go
+++ b/pkg/webrtc/producer.go
@@ -33,6 +33,21 @@ func (c *Conn) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver, e
 	case core.ModePassiveProducer, core.ModeActiveProducer:
 		// Passive producers: OBS Studio via WHIP or Browser
 		// Active producers: go2rtc as WebRTC client or WebTorrent
+		//
+		// The remote may answer one media with several payload types and then
+		// transmit on one that is not the first (Google Nest/SDM answers an
+		// H264 offer with two payload types and streams on the second). A
+		// consumer that attached before the first RTP packet already owns a
+		// Receiver for the first codec, so OnTrack must reuse it instead of
+		// creating a second Receiver that no consumer is wired to. Only a
+		// compatible codec is adopted (same name, clock rate and channels);
+		// a switch to a different codec still gets its own Receiver.
+		for _, track := range c.Receivers {
+			if track.Media == media && track.Codec.Match(codec) {
+				track.Codec = codec
+				return track, nil
+			}
+		}
 
 	default:
 		panic(core.Caller())


### PR DESCRIPTION
## Problem

A remote peer may answer one media with several payload types and then transmit on one that is not the first. Google Nest (SDM) does this for H264: go2rtc's offer lists three H264 payload types (96, 97, 98); Google's answer keeps 96 and 98 and the camera streams on 98 (High profile, `profile-level-id=64001f`).

`Conn.GetTrack` deduplicates receivers by `*Codec` pointer. A consumer that attaches **before the first RTP packet** already holds a `Receiver` for the first codec of the media. When `OnTrack` fires, `getMediaCodec` resolves the transmitted payload type to a different `*Codec`, the exact lookup misses, and a second `Receiver` is created that no consumer is wired to. Every cold consumer starves forever; a consumer that attaches later binds to the fed receiver and works.

This is #2389 and #2386 (and the "open it in VLC first, then Frigate works" reports in the Frigate discussions). It is dial-order dependent, which is why it looks intermittent.

## Fix

In the producer branch of `Conn.GetTrack`, before creating a new `Receiver`, reuse an existing one for the same `Media` whose codec is compatible (`Codec.Match`: same name, clock rate and channels) and adopt the transmitted codec on it. A switch to a genuinely different codec (e.g. H264 to VP8) still falls through to the create path, as today. This is the same mechanism as #2375, with the codec-compatibility guard suggested in that PR's review, and it also updates the receiver's codec so `/api/streams` and later consumers see the payload type actually in use.

## Measurements (first-generation Nest Doorbell, wired, `nest:` source, host networking)

Test: consumer A (`/api/stream.mp4`) attaches at dial time and holds 40 s; consumer B attaches 12 s later for 20 s.

| build | A (cold) | B (warm) | video receivers in `/api/streams` |
|---|---|---|---|
| v1.9.10 unpatched | 0 bytes in 40 s | 3.1 MB, first byte 1.2 s | two: id 3 with `childs` and no bytes, id 6 with all bytes and no children |
| master (c245815) + this patch | 2.3 MB, first byte 6.2 s | 0.9 MB, first byte 0.13 s | one, with the consumer as its child |

The 6 s first byte on the cold consumer is ICE setup plus the wait for the first keyframe; this camera sends SPS+IDR from the first packet and every 2 to 3 s after, so no keyframe request was needed for this test.

Nothing else changes for producers that answer with a single payload type: the exact-pointer lookup still hits first.

Fixes #2389, fixes #2386.
