### PR TITLE
streams: dial and redial with the producer mutex released

### DIFF
--- a/internal/streams/handlers.go
+++ b/internal/streams/handlers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
@@ -12,11 +13,37 @@ type Handler func(source string) (core.Producer, error)
 
 var handlers = map[string]Handler{}
 
+// handlersMu guards handlers and redirects. Registration is normally init-time
+// only, but GetProducer is now also reached from the bounded-dial goroutine in
+// producer.go, so the reads no longer all happen on the init goroutine. Locked
+// around map access only, never across a handler call, which can block for
+// seconds and may re-enter GetProducer via a redirect.
+var handlersMu sync.RWMutex
+
 func HandleFunc(scheme string, handler Handler) {
+	handlersMu.Lock()
 	handlers[scheme] = handler
+	handlersMu.Unlock()
+}
+
+func getHandler(scheme string) (Handler, bool) {
+	handlersMu.RLock()
+	defer handlersMu.RUnlock()
+	h, ok := handlers[scheme]
+	return h, ok
+}
+
+func getRedirect(scheme string) (Redirect, bool) {
+	handlersMu.RLock()
+	defer handlersMu.RUnlock()
+	r, ok := redirects[scheme]
+	return r, ok
 }
 
 func SupportedSchemes() []string {
+	handlersMu.RLock()
+	defer handlersMu.RUnlock()
+
 	uniqueKeys := make(map[string]struct{}, len(handlers)+len(redirects))
 	for scheme := range handlers {
 		uniqueKeys[scheme] = struct{}{}
@@ -35,11 +62,11 @@ func HasProducer(url string) bool {
 	if i := strings.IndexByte(url, ':'); i > 0 {
 		scheme := url[:i]
 
-		if _, ok := handlers[scheme]; ok {
+		if _, ok := getHandler(scheme); ok {
 			return true
 		}
 
-		if _, ok := redirects[scheme]; ok {
+		if _, ok := getRedirect(scheme); ok {
 			return true
 		}
 	}
@@ -51,7 +78,7 @@ func GetProducer(url string) (core.Producer, error) {
 	if i := strings.IndexByte(url, ':'); i > 0 {
 		scheme := url[:i]
 
-		if redirect, ok := redirects[scheme]; ok {
+		if redirect, ok := getRedirect(scheme); ok {
 			location, err := redirect(url)
 			if err != nil {
 				return nil, err
@@ -61,7 +88,7 @@ func GetProducer(url string) (core.Producer, error) {
 			}
 		}
 
-		if handler, ok := handlers[scheme]; ok {
+		if handler, ok := getHandler(scheme); ok {
 			return handler(url)
 		}
 	}
@@ -75,14 +102,16 @@ type Redirect func(url string) (string, error)
 var redirects = map[string]Redirect{}
 
 func RedirectFunc(scheme string, redirect Redirect) {
+	handlersMu.Lock()
 	redirects[scheme] = redirect
+	handlersMu.Unlock()
 }
 
 func Location(url string) (string, error) {
 	if i := strings.IndexByte(url, ':'); i > 0 {
 		scheme := url[:i]
 
-		if redirect, ok := redirects[scheme]; ok {
+		if redirect, ok := getRedirect(scheme); ok {
 			return redirect(url)
 		}
 	}

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/rtsp"
 )
 
 type state byte
@@ -34,6 +35,25 @@ type Producer struct {
 	state    state
 	mu       sync.Mutex
 	workerID int
+
+	// dialing is non-nil while a Dial() is in flight; it is closed when that
+	// dial finishes. Concurrent callers wait on the channel INSTEAD of on mu,
+	// so a slow dial can't freeze the producer. dialErr carries the result to
+	// those waiters so they don't each re-spawn the same failing source.
+	// Guarded by mu.
+	dialing chan struct{}
+	dialErr error
+
+	// epoch is bumped by every teardown (stop, forceReset). A dial that
+	// completes after its epoch changed is discarded instead of resurrecting
+	// a producer nobody asked for any more. Guarded by mu.
+	epoch int
+
+	// connFails counts consecutive instant Start() failures with the
+	// rtsp.ErrStartFromConn signature; connFailLimit of them in a row means
+	// the conn/receiver state is provably inconsistent and the producer gets
+	// force-reset to stateNone. Guarded by mu.
+	connFails int
 }
 
 const SourceTemplate = "{input}"
@@ -54,22 +74,135 @@ func (p *Producer) SetSource(s string) {
 	}
 }
 
+// Dial creates the underlying core.Producer if the producer has none yet.
+//
+// GetProducer can block for a long time: an exec source spawns a child and
+// then reads its first bytes, an RTSP source dials and sends DESCRIBE, an
+// HTTP source may accept the connection and never send a byte. Calling it
+// with p.mu held freezes the whole producer for that whole time, because
+// every other consumer's Dial and GetTrack, and stop(), all wait on the same
+// mutex. If the dial never returns, the freeze is permanent and only a
+// process restart clears it. The observed goroutine chain is
+// Dial -> GetProducer -> exec.handlePipe -> magic.Open, with later consumers
+// parked on sync.Mutex.Lock inside Dial.
+//
+// The dial now runs with mu released. A single-flight channel makes
+// concurrent consumers wait on the in-flight dial and share its error, so
+// only one child is spawned, and dialTimeout bounds the dial so a handler
+// that never returns cannot strand the producer.
 func (p *Producer) Dial() error {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 
-	if p.state == stateNone {
-		conn, err := GetProducer(p.url)
-		if err != nil {
-			return err
-		}
-
-		p.conn = conn
-		p.state = stateMedias
+	if p.state != stateNone {
+		p.mu.Unlock()
+		return nil
 	}
 
-	return nil
+	// Someone else is already dialing: wait on them, not on the mutex, so
+	// stop() and GetTrack() stay responsive for everyone else.
+	if ch := p.dialing; ch != nil {
+		p.mu.Unlock()
+
+		select {
+		case <-ch: // always closed, on success, failure and abandon
+		case <-time.After(dialTimeout): // defensive only
+			return ErrDialTimeout
+		}
+
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.state != stateNone {
+			return nil
+		}
+		return p.dialErr
+	}
+
+	ch := make(chan struct{})
+	p.dialing = ch
+	epoch := p.epoch
+	p.mu.Unlock()
+
+	conn, err := dialBounded(p.url)
+
+	p.mu.Lock()
+	if p.dialing == ch {
+		p.dialing = nil
+	}
+	if err == nil {
+		if p.state == stateNone && p.epoch == epoch {
+			p.conn = conn
+			p.state = stateMedias
+		} else {
+			// producer was rebuilt or torn down while we were dialing: drop our
+			// now-redundant connection rather than clobbering the live one or
+			// resurrecting a stopped producer with a live child process
+			err = ErrDialSuperseded
+			go func() { _ = conn.Stop() }()
+		}
+	}
+	p.dialErr = err
+	p.mu.Unlock()
+
+	close(ch)
+
+	return err
 }
+
+// dialBounded runs GetProducer with a dialTimeout backstop. A handler that
+// never returns, such as an exec child that writes no first byte or an HTTP
+// source that accepts the connection and then goes silent, must not block the
+// caller forever. On timeout the pending dial is handed to a reaper that
+// stops whatever it eventually produces, so abandoning it costs at most one
+// orphaned connection instead of a producer that never recovers.
+func dialBounded(url string) (core.Producer, error) {
+	type result struct {
+		conn core.Producer
+		err  error
+	}
+
+	done := make(chan result, 1)
+	go func() {
+		conn, err := GetProducer(url)
+		done <- result{conn, err}
+	}()
+
+	select {
+	case res := <-done:
+		return res.conn, res.err
+	case <-time.After(dialTimeout):
+		go func() {
+			if res := <-done; res.err == nil {
+				_ = res.conn.Stop()
+			}
+		}()
+
+		log.Error().Str("url", url).Msgf(
+			"[streams] producer dial exceeded %s, abandoning", dialTimeout,
+		)
+
+		return nil, ErrDialTimeout
+	}
+}
+
+// dialTimeout is the producer-level backstop on GetProducer. It sits well
+// above every handler's own bound, so it cannot cut short a dial that
+// succeeds today; it only fires where the current behaviour is to block
+// forever. That makes the guarantee source-agnostic: a handler that forgets
+// its own timeout can no longer strand the producer. The cost of firing is
+// one orphaned connection, which the reaper stops if it ever materialises.
+// It is a var, not a const, only so tests can shrink it.
+var dialTimeout = 90 * time.Second
+
+var (
+	// ErrDialSuperseded means a dial completed after the producer it was
+	// dialing for had already been torn down or rebuilt. The connection is
+	// discarded; the caller should just retry.
+	ErrDialSuperseded = errors.New("streams: dial superseded")
+
+	// ErrDialTimeout means GetProducer blew dialTimeout. The dial is abandoned
+	// and consumers get an error instead of parking on the producer forever.
+	ErrDialTimeout = errors.New("streams: dial timeout")
+)
 
 func (p *Producer) GetMedias() []*core.Media {
 	p.mu.Lock()
@@ -157,34 +290,112 @@ func (p *Producer) start() {
 	go p.worker(p.conn, p.workerID)
 }
 
+// connFailLimit is how many consecutive rtsp.ErrStartFromConn failures a
+// producer gets before forceReset. Each cycle is near-instant: dial, error,
+// then redial with retry=0 and so no backoff. Without a limit, a redialed
+// connection whose medias no longer match the stale receivers turns into a
+// hot error loop that fills the log with "start from CONN state".
+const connFailLimit = 3
+
 func (p *Producer) worker(conn core.Producer, workerID int) {
-	if err := conn.Start(); err != nil {
-		p.mu.Lock()
-		closed := p.workerID != workerID
-		p.mu.Unlock()
+	err := conn.Start()
 
-		if closed {
-			return
+	p.mu.Lock()
+	closed := p.workerID != workerID
+	if !closed {
+		if errors.Is(err, rtsp.ErrStartFromConn) {
+			p.connFails++
+		} else {
+			p.connFails = 0
 		}
+	}
+	fails := p.connFails
+	p.mu.Unlock()
 
+	if closed {
+		return
+	}
+
+	if err != nil {
 		log.Warn().Err(err).Str("url", p.url).Caller().Send()
+	}
+
+	if fails >= connFailLimit {
+		p.forceReset(workerID)
+		return
 	}
 
 	p.reconnect(workerID, 0)
 }
 
+// forceReset tears a stuck producer down to stateNone so the next consumer
+// redials from scratch, instead of hot-looping Start() errors against a
+// connection whose medias no longer match the receivers. It is only reached
+// after connFailLimit consecutive rtsp.ErrStartFromConn failures. Any
+// successful Start, or any other error, resets the counter, so a healthy or
+// merely flaky producer never hits it.
+func (p *Producer) forceReset(workerID int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.workerID != workerID {
+		return // someone else already took over
+	}
+
+	switch p.state {
+	case stateExternal, stateNone:
+		return
+	}
+
+	log.Warn().Str("url", p.url).Msgf(
+		"[streams] producer force-reset after %d consecutive CONN-state start failures",
+		connFailLimit,
+	)
+
+	p.workerID++ // invalidate stale workers
+	p.epoch++    // invalidate any dial still in flight
+
+	if p.conn != nil {
+		_ = p.conn.Stop()
+		p.conn = nil
+	}
+
+	p.state = stateNone
+	p.receivers = nil
+	p.senders = nil
+	p.connFails = 0
+}
+
 func (p *Producer) reconnect(workerID, retry int) {
+	p.mu.Lock()
+	if p.workerID != workerID {
+		log.Trace().Msgf("[streams] stop reconnect url=%s", p.url)
+		p.mu.Unlock()
+		return
+	}
+	url := p.url
+	p.mu.Unlock()
+
+	log.Debug().Msgf("[streams] retry=%d to url=%s", retry, url)
+
+	// Redial with p.mu released. GetProducer can block for a long time (exec
+	// spawn plus stream probe, RTSP dial), and holding the mutex across it
+	// freezes the whole producer: consumer Dial and GetTrack, and stop().
+	// An exec pipe probe against a source that never writes blocks here
+	// indefinitely, and the producer never recovers.
+	conn, err := dialBounded(url)
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if p.workerID != workerID {
 		log.Trace().Msgf("[streams] stop reconnect url=%s", p.url)
+		if conn != nil {
+			_ = conn.Stop()
+		}
 		return
 	}
 
-	log.Debug().Msgf("[streams] retry=%d to url=%s", retry, p.url)
-
-	conn, err := GetProducer(p.url)
 	if err != nil {
 		log.Debug().Msgf("[streams] producer=%s", err)
 
@@ -246,14 +457,23 @@ func (p *Producer) stop() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	switch p.state {
-	case stateExternal:
+	if p.state == stateExternal {
 		log.Trace().Msgf("[streams] skip stop external producer")
 		return
-	case stateNone:
+	}
+
+	// Invalidate any dial still in flight, in every state. A dial started for
+	// a consumer that has since gone away must not install its connection
+	// afterwards, because that leaves a running exec child with no consumers.
+	// This came for free while Dial held p.mu across the whole dial.
+	p.epoch++
+
+	if p.state == stateNone {
 		log.Trace().Msgf("[streams] skip stop none producer")
 		return
-	case stateStart:
+	}
+
+	if p.state == stateStart {
 		p.workerID++
 	}
 

--- a/internal/streams/producer_test.go
+++ b/internal/streams/producer_test.go
@@ -1,0 +1,325 @@
+package streams
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+	"github.com/AlexxIT/go2rtc/pkg/rtsp"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConn is a core.Producer whose Start() behaviour is scripted.
+type fakeConn struct {
+	core.Connection
+	start func() error
+	stops atomic.Int32
+}
+
+func (f *fakeConn) Start() error { return f.start() }
+
+func (f *fakeConn) Stop() error {
+	f.stops.Add(1)
+	return f.Connection.Stop()
+}
+
+func (p *Producer) snapshot() (s state, conn core.Producer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.state, p.conn
+}
+
+// TestForceResetAfterConsecutiveConnStateErrors: connFailLimit consecutive
+// rtsp.ErrStartFromConn failures must tear the producer down to stateNone
+// (conn closed and nil) instead of hot-looping dial, error, dial forever.
+// That is the signature of a dead camera: repeated `start from CONN state`.
+func TestForceResetAfterConsecutiveConnStateErrors(t *testing.T) {
+	var dials atomic.Int32
+
+	HandleFunc("wedgeconn", func(url string) (core.Producer, error) {
+		dials.Add(1)
+		return &fakeConn{start: func() error { return rtsp.ErrStartFromConn }}, nil
+	})
+
+	p := NewProducer("wedgeconn:cam")
+	require.NoError(t, p.Dial())
+
+	p.mu.Lock()
+	p.state = stateTracks // pretend a consumer got its track
+	p.mu.Unlock()
+
+	p.start()
+
+	require.Eventually(t, func() bool {
+		s, conn := p.snapshot()
+		return s == stateNone && conn == nil
+	}, 5*time.Second, 10*time.Millisecond, "producer must force-reset to stateNone")
+
+	// initial dial + (connFailLimit-1) redials, then reset instead of redial
+	require.Equal(t, int32(connFailLimit), dials.Load())
+
+	// and the producer must be dialable again (fresh consumer recovers)
+	require.NoError(t, p.Dial())
+	s, conn := p.snapshot()
+	require.Equal(t, stateMedias, s)
+	require.NotNil(t, conn)
+}
+
+// TestNoResetOnOtherErrors: non-CONN errors must NOT force-reset. They take
+// the ordinary supervised reconnect path and the counter resets every time.
+func TestNoResetOnOtherErrors(t *testing.T) {
+	var dials atomic.Int32
+
+	HandleFunc("flaky", func(url string) (core.Producer, error) {
+		dials.Add(1)
+		return &fakeConn{start: func() error { return errors.New("eof") }}, nil
+	})
+
+	p := NewProducer("flaky:cam")
+	require.NoError(t, p.Dial())
+
+	p.mu.Lock()
+	p.state = stateTracks
+	p.mu.Unlock()
+
+	p.start()
+
+	require.Eventually(t, func() bool {
+		return dials.Load() >= connFailLimit+2
+	}, 5*time.Second, 10*time.Millisecond, "reconnect loop must keep running")
+
+	s, _ := p.snapshot()
+	require.NotEqual(t, stateNone, s, "must not force-reset on non-CONN errors")
+
+	p.stop() // shut the loop down
+}
+
+// TestConnFailCounterResetBySuccess: a successful Start() between CONN-state
+// errors resets the counter, so a recovering producer is never torn down.
+func TestConnFailCounterResetBySuccess(t *testing.T) {
+	var dials atomic.Int32
+
+	HandleFunc("blip", func(url string) (core.Producer, error) {
+		n := dials.Add(1)
+		return &fakeConn{start: func() error {
+			if n%2 == 1 {
+				return rtsp.ErrStartFromConn
+			}
+			// "healthy" session: runs for a bit, then clean exit
+			time.Sleep(50 * time.Millisecond)
+			return nil
+		}}, nil
+	})
+
+	p := NewProducer("blip:cam")
+	require.NoError(t, p.Dial())
+
+	p.mu.Lock()
+	p.state = stateTracks
+	p.mu.Unlock()
+
+	p.start()
+
+	require.Eventually(t, func() bool {
+		return dials.Load() >= 2*connFailLimit
+	}, 5*time.Second, 10*time.Millisecond)
+
+	s, _ := p.snapshot()
+	require.NotEqual(t, stateNone, s, "alternating errors must never accumulate to a reset")
+
+	p.stop()
+}
+
+// TestReconnectDoesNotHoldMutexWhileDialing: regression test for the
+// deadlock signature: GetProducer blocking (a dead-camera exec pipe
+// probe) must NOT freeze the producer mutex; stop() has to complete promptly
+// and the late dial result must be discarded (conn stopped).
+func TestReconnectDoesNotHoldMutexWhileDialing(t *testing.T) {
+	block := make(chan struct{})
+	late := &fakeConn{start: func() error { return nil }}
+	first := true
+
+	HandleFunc("hangdial", func(url string) (core.Producer, error) {
+		if first {
+			first = false
+			return &fakeConn{start: func() error { return errors.New("eof") }}, nil
+		}
+		<-block // simulate exec pipe probe blocking on a dead camera
+		return late, nil
+	})
+
+	p := NewProducer("hangdial:cam")
+	require.NoError(t, p.Dial())
+
+	p.mu.Lock()
+	p.state = stateTracks
+	p.mu.Unlock()
+
+	p.start() // worker errors instantly, reconnect runs, 2nd dial blocks
+
+	time.Sleep(100 * time.Millisecond) // let reconnect reach the blocked dial
+
+	// with the old code this deadlocked forever on p.mu
+	done := make(chan struct{})
+	go func() {
+		p.stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop() blocked behind a dialing reconnect: producer mutex deadlock")
+	}
+
+	// unblock the stale dial: its conn must be stopped, not installed
+	close(block)
+	require.Eventually(t, func() bool {
+		return late.stops.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond, "stale dial result must be stopped and discarded")
+
+	_, conn := p.snapshot()
+	require.Nil(t, conn)
+}
+
+// TestDialDoesNotHoldMutexWhileDialing: regression test for the last
+// GetProducer-under-p.mu call site. A blocked first dial must not freeze the
+// producer: stop() and a second consumer's Dial have to make progress.
+func TestDialDoesNotHoldMutexWhileDialing(t *testing.T) {
+	block := make(chan struct{})
+	late := &fakeConn{start: func() error { return nil }}
+
+	HandleFunc("hangfirstdial", func(url string) (core.Producer, error) {
+		<-block
+		return late, nil
+	})
+
+	p := NewProducer("hangfirstdial:cam")
+
+	dialed := make(chan error, 1)
+	go func() { dialed <- p.Dial() }()
+
+	time.Sleep(100 * time.Millisecond) // let the dial block
+
+	// with upstream code this parks on p.mu until the dial returns
+	stopped := make(chan struct{})
+	go func() {
+		p.stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop() blocked behind Dial's GetProducer: producer mutex freeze")
+	}
+
+	close(block)
+	require.Error(t, <-dialed, "a dial that lands after stop() must not install its conn")
+
+	require.Eventually(t, func() bool {
+		return late.stops.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond, "superseded dial result must be stopped")
+
+	_, conn := p.snapshot()
+	require.Nil(t, conn)
+}
+
+// TestConcurrentDialIsSingleFlight: N consumers racing to attach to the same
+// cold producer must spawn exactly ONE underlying connection (one exec child),
+// not one each.
+func TestConcurrentDialIsSingleFlight(t *testing.T) {
+	var dials atomic.Int32
+	release := make(chan struct{})
+
+	HandleFunc("slowdial", func(url string) (core.Producer, error) {
+		dials.Add(1)
+		<-release
+		return &fakeConn{start: func() error { return nil }}, nil
+	})
+
+	p := NewProducer("slowdial:cam")
+
+	const n = 8
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func() { errs <- p.Dial() }()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(release)
+
+	for i := 0; i < n; i++ {
+		select {
+		case err := <-errs:
+			require.NoError(t, err)
+		case <-time.After(3 * time.Second):
+			t.Fatal("concurrent Dial did not return")
+		}
+	}
+
+	require.Equal(t, int32(1), dials.Load(), "single-flight: exactly one GetProducer")
+
+	s, conn := p.snapshot()
+	require.Equal(t, stateMedias, s)
+	require.NotNil(t, conn)
+}
+
+// TestDialTimeoutAbandonsAndRecovers: a handler that never returns must not
+// strand the producer. The dial is abandoned with ErrDialTimeout, waiters are
+// woken with the same error, the producer stays dialable, and the orphaned
+// connection is reaped if it ever materialises.
+func TestDialTimeoutAbandonsAndRecovers(t *testing.T) {
+	old := dialTimeout
+	dialTimeout = 200 * time.Millisecond
+	defer func() { dialTimeout = old }()
+
+	block := make(chan struct{})
+	orphan := &fakeConn{start: func() error { return nil }}
+	var dials atomic.Int32
+
+	HandleFunc("neverdial", func(url string) (core.Producer, error) {
+		if dials.Add(1) == 1 {
+			<-block // first dial hangs forever
+			return orphan, nil
+		}
+		return &fakeConn{start: func() error { return nil }}, nil
+	})
+
+	p := NewProducer("neverdial:cam")
+
+	first := make(chan error, 1)
+	go func() { first <- p.Dial() }()
+
+	time.Sleep(50 * time.Millisecond)
+	waiter := make(chan error, 1)
+	go func() { waiter <- p.Dial() }() // parks on the in-flight dial
+
+	select {
+	case err := <-first:
+		require.ErrorIs(t, err, ErrDialTimeout)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Dial did not honour dialTimeout")
+	}
+
+	select {
+	case err := <-waiter:
+		require.ErrorIs(t, err, ErrDialTimeout, "waiter must be woken with an error, not parked")
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter parked on an abandoned dial")
+	}
+
+	// producer must be dialable again rather than permanently wedged
+	require.NoError(t, p.Dial())
+	s, conn := p.snapshot()
+	require.Equal(t, stateMedias, s)
+	require.NotNil(t, conn)
+
+	// the abandoned dial's connection is reaped when it finally arrives
+	close(block)
+	require.Eventually(t, func() bool {
+		return orphan.stops.Load() == 1
+	}, 2*time.Second, 10*time.Millisecond, "orphaned dial result must be stopped")
+}

--- a/pkg/rtsp/producer.go
+++ b/pkg/rtsp/producer.go
@@ -7,6 +7,13 @@ import (
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 
+// ErrStartFromConn means Start() was called while the connection is still in
+// CONN state: dialed, but with no track set up. This usually happens when
+// DESCRIBE succeeded but the medias no longer match the existing receivers,
+// so SetupMedia was never called. internal/streams counts consecutive
+// occurrences and force-resets the producer.
+var ErrStartFromConn = errors.New("start from CONN state")
+
 func (c *Conn) GetTrack(media *core.Media, codec *core.Codec) (*core.Receiver, error) {
 	core.Assert(media.Direction == core.DirectionRecvonly)
 
@@ -61,7 +68,7 @@ func (c *Conn) Start() (err error) {
 		case StateNone:
 			err = nil
 		case StateConn:
-			err = errors.New("start from CONN state")
+			err = ErrStartFromConn
 		case StateSetup:
 			switch c.mode {
 			case core.ModeActiveProducer:


### PR DESCRIPTION
I run go2rtc with exec sources under Frigate and kept hitting streams that hung
until a restart. The cause is that go2rtc opens a source while holding that stream's
lock, so if the open never finishes, every other viewer, and even stop, waits forever.
This PR opens the source with the lock released and puts a time limit on the attempt.

Opening a source, the dial, is done while the producer's lock is held (`Producer.Dial`,
`Producer.reconnect`). A producer is go2rtc's connection to one source. So a dial that
never returns blocks every other consumer's dial and track read, and `stop()` too. In
pipe mode go2rtc reads the program's output itself. The dial then blocks on the first 4
bytes (`handlePipe`). This dials with the lock released. Consumers arriving together
share one dial in flight rather than queueing. An epoch counter stops a late dial
installing a connection after a stop or reset. A 90 s backstop now bounds the dial
itself (`dialBounded`), well above every handler's own bound. Three consecutive "start
from CONN state" failures now force-reset the producer. Before, it redialed with no
backoff.

Measured: two clients on `exec:sleep 3600`, `GET /api/stream.mp4?src=test`, curl capped
at 200 s.

    master c245815:  client 1 no response at 200 s, client 2 no response at 200 s
    this branch:     client 1 HTTP 500 at 90.08 s, client 2 HTTP 500 at 88.08 s

A SIGQUIT dump at 30 s has 1 goroutine parked in `sync.Mutex.Lock` on master, 0 here.
The process keeps serving after both clients fail.

Test: `internal/streams/producer_test.go` adds
`TestReconnectDoesNotHoldMutexWhileDialing`, `TestDialDoesNotHoldMutexWhileDialing`,
`TestConcurrentDialIsSingleFlight`, `TestDialTimeoutAbandonsAndRecovers`,
`TestForceResetAfterConsecutiveConnStateErrors`, `TestNoResetOnOtherErrors` and
`TestConnFailCounterResetBySuccess`, all passing under `-race`. `TestRecursion` and
`TestTempate` fail in this package on master c245815 as well. This branch does not
change them.

Refs #2481
Generated with the help of Claude.
