### PR TITLE
exec: apply starttimeout to the pipe flow probe

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -116,7 +116,7 @@ func execHandle(rawURL string) (prod core.Producer, err error) {
 	}
 
 	if path == "" {
-		prod, err = handlePipe(rawURL, cmd)
+		prod, err = handlePipe(rawURL, cmd, timeout)
 	} else {
 		prod, err = handleRTSP(rawURL, cmd, path, timeout)
 	}
@@ -128,7 +128,7 @@ func execHandle(rawURL string) (prod core.Producer, err error) {
 	return
 }
 
-func handlePipe(source string, cmd *shell.Command) (core.Producer, error) {
+func handlePipe(source string, cmd *shell.Command, timeout time.Duration) (core.Producer, error) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
@@ -152,19 +152,50 @@ func handlePipe(source string, cmd *shell.Command) (core.Producer, error) {
 		return nil, err
 	}
 
-	prod, err := magic.Open(rd)
-	if err != nil {
-		return nil, fmt.Errorf("exec/pipe: %w\n%s", err, cmd.Stderr)
+	// Probe in a goroutine so a child that produces no output cannot block
+	// the dial forever. handleRTSP has always bounded startup with
+	// starttimeout; handlePipe did not, so an exec child that hangs before
+	// its first byte leaves magic.Open blocked indefinitely inside
+	// streams.Producer, and the producer never recovers. Use the same
+	// starttimeout parameter and the same 30s default as handleRTSP.
+	type probeResult struct {
+		prod core.Producer
+		err  error
 	}
+	probe := make(chan probeResult, 1)
 
-	if info, ok := prod.(core.Info); ok {
-		info.SetProtocol("pipe")
-		setRemoteInfo(info, source, cmd.Args)
+	go func() {
+		prod, err := magic.Open(rd)
+		if err != nil {
+			err = fmt.Errorf("exec/pipe: %w\n%s", err, cmd.Stderr)
+		}
+		probe <- probeResult{prod, err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		// No data from the app within starttimeout. Close kills the child,
+		// which closes stdout and unblocks the probe goroutine.
+		log.Error().Str("source", source).Msg("[exec] pipe timeout")
+		_ = cmd.Close()
+		return nil, errors.New("exec: timeout")
+	case res := <-probe:
+		if res.err != nil {
+			return nil, res.err
+		}
+
+		if info, ok := res.prod.(core.Info); ok {
+			info.SetProtocol("pipe")
+			setRemoteInfo(info, source, cmd.Args)
+		}
+
+		log.Debug().Stringer("launch", time.Since(ts)).Msg("[exec] run pipe")
+
+		return res.prod, nil
 	}
-
-	log.Debug().Stringer("launch", time.Since(ts)).Msg("[exec] run pipe")
-
-	return prod, nil
 }
 
 func handleRTSP(source string, cmd *shell.Command, path string, timeout time.Duration) (core.Producer, error) {

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package exec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	log = zerolog.Nop() // package log is normally set by Init()
+}
+
+// TestPipeProbeTimeout: an exec pipe source that never produces output must
+// fail with a timeout instead of blocking GetProducer forever. magic.Open
+// used to block indefinitely on a child that never writes a byte.
+func TestPipeProbeTimeout(t *testing.T) {
+	ts := time.Now()
+
+	prod, err := execHandle("exec:sleep 60#starttimeout=2")
+
+	require.Nil(t, prod)
+	require.ErrorContains(t, err, "timeout")
+	require.Less(t, time.Since(ts), 10*time.Second)
+	require.GreaterOrEqual(t, time.Since(ts), 2*time.Second)
+}
+
+// TestPipeProbeError: a child whose output matches no known magic must fail
+// fast with the probe error, not with the timeout. This proves the probe
+// result path is wired up.
+func TestPipeProbeError(t *testing.T) {
+	_, err := execHandle("exec:echo garbage-not-a-stream#starttimeout=10")
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "exec: timeout")
+}


### PR DESCRIPTION
Same setup as the issue. When an exec program starts but never sends video, for
example ffmpeg pointed at a camera that is down, the stream is stuck for good. go2rtc
already has a start timeout for RTSP sources, and this PR makes it apply to pipe
sources too.

The RTSP path bounds startup with that timeout, 30 s by default (`handleRTSP`). The pipe
path, where go2rtc reads the program's output itself, does not (`handlePipe`). It waits
for the first 4 bytes with no timeout at all (`magic.Open`). So the dial never returns,
and the producer, go2rtc's connection to that source, never recovers. This runs the
probe in a goroutine, bounded by the same `starttimeout` parameter. The default is still
30 s. On timeout it closes the command. That closes the output, unblocks the probe, and
fails the dial.

Measured: one client on `exec:sleep 3600#starttimeout=5`,
`GET /api/stream.mp4?src=test`, curl capped at 60 s.

    master c245815:  no response, cut off at 60.00 s
    this branch:     HTTP 500 at 5.00 s

Test: `internal/exec/exec_test.go` adds `TestPipeProbeTimeout`, which requires
`exec:sleep 60#starttimeout=2` to return an error in about two seconds instead of
hanging, and `TestPipeProbeError`. The package passes in 2.0 s.

Refs #2481
Generated with the help of Claude.
