### PR TITLE
shell: kill the child's process group when Close is not enough

### DIFF
--- a/pkg/shell/command.go
+++ b/pkg/shell/command.go
@@ -3,17 +3,26 @@ package shell
 import (
 	"context"
 	"os/exec"
+	"time"
 )
+
+// killGrace is how long a child gets to exit after Close() fires the kill
+// signal, before the whole process group is sent SIGKILL. It is also the
+// default WaitDelay, so Wait() cannot hang forever on pipes held open by an
+// unkillable child or a straggling grandchild.
+const killGrace = 5 * time.Second
 
 // Command like exec.Cmd, but with support:
 // - io.Closer interface
 // - Wait from multiple places
 // - Done channel
+// - kill escalation: Close() sends the Cancel signal, then after killGrace SIGKILLs the group
 type Command struct {
 	*exec.Cmd
-	ctx    context.Context
-	cancel context.CancelFunc
-	err    error
+	ctx      context.Context
+	cancel   context.CancelFunc
+	err      error
+	waitDone chan struct{}
 }
 
 func NewCommand(s string) *Command {
@@ -21,7 +30,10 @@ func NewCommand(s string) *Command {
 	args := QuoteSplit(s)
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.SysProcAttr = procAttr
-	return &Command{cmd, ctx, cancel, nil}
+	// bound Wait() even if the child ignores the kill signal or a grandchild
+	// inherited our pipes; exec's killtimeout param overrides this
+	cmd.WaitDelay = killGrace
+	return &Command{cmd, ctx, cancel, nil, make(chan struct{})}
 }
 
 func (c *Command) Start() error {
@@ -32,6 +44,7 @@ func (c *Command) Start() error {
 	go func() {
 		c.err = c.Cmd.Wait()
 		c.cancel() // release context resources
+		close(c.waitDone)
 	}()
 
 	return nil
@@ -55,5 +68,32 @@ func (c *Command) Done() <-chan struct{} {
 
 func (c *Command) Close() error {
 	c.cancel()
+	go c.ensureKill()
 	return nil
+}
+
+// ensureKill makes sure Close() cannot leave the child, or its descendants,
+// running. The context cancel above fires Cmd.Cancel: Process.Kill by
+// default, or the configured exec killsignal, which the child is free to
+// trap. A killsignal of 15 plus a wrapper that ignores SIGTERM is enough.
+// os/exec's WaitDelay then SIGKILLs the direct child, but only the direct
+// child, so grandchildren survive a single-pid kill. Once the child is
+// reaped, or killGrace expires without a reap, SIGKILL the whole process
+// group to sweep stragglers. If that still does not reap it, for example a
+// process stuck in uninterruptible sleep, nothing more can be done from
+// userspace, and WaitDelay has already unblocked the reader side.
+func (c *Command) ensureKill() {
+	select {
+	case <-c.waitDone:
+		// reaped, but a grandchild may have survived: sweep the group
+	case <-time.After(killGrace):
+		// not even reaped: kill signal ignored or never sent, force it
+		if proc := c.Process; proc != nil {
+			_ = proc.Kill()
+		}
+	}
+
+	if proc := c.Process; proc != nil {
+		killProcessGroup(proc.Pid)
+	}
 }

--- a/pkg/shell/command_test.go
+++ b/pkg/shell/command_test.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+package shell
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// groupAlive reports whether any RUNNING (non-zombie) process still exists
+// in pid's process group. A plain kill(-pgid, 0) probe would count zombies:
+// orphaned grandchildren reparent to the test process's pid 1, which never
+// reaps them. So scan /proc and check pgrp + state instead.
+func groupAlive(pgid int) bool {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		panic(err)
+	}
+	for _, e := range entries {
+		if _, err := strconv.Atoi(e.Name()); err != nil {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + e.Name() + "/stat")
+		if err != nil {
+			continue // process gone between readdir and read
+		}
+		// stat: pid (comm) state ppid pgrp ... and comm may contain spaces,
+		// so split after the LAST ')'
+		i := strings.LastIndexByte(string(stat), ')')
+		fields := strings.Fields(string(stat[i+1:]))
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[0] == "Z" {
+			continue
+		}
+		if fields[2] == strconv.Itoa(pgid) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCloseEscalatesToProcessGroupKill: a child that traps the configured
+// killsignal (SIGTERM) and has a grandchild must still be fully gone within
+// killGrace plus some slack after Close().
+func TestCloseEscalatesToProcessGroupKill(t *testing.T) {
+	// trap makes sh ignore SIGTERM; the foreground sleep is a grandchild a
+	// single-pid kill would never reach
+	cmd := NewCommand(`sh -c "trap : TERM; while :; do sleep 60; done"`)
+	// mimic exec's killsignal=15 override, the signal the child ignores
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+
+	// let sh spawn its sleep grandchild
+	time.Sleep(300 * time.Millisecond)
+	require.True(t, groupAlive(pid))
+
+	ts := time.Now()
+	require.NoError(t, cmd.Close())
+
+	// SIGTERM is trapped, so only the killGrace escalation can reap the
+	// group (sh AND the sleep grandchild)
+	require.Eventually(t, func() bool {
+		return !groupAlive(pid)
+	}, killGrace+5*time.Second, 100*time.Millisecond)
+
+	elapsed := time.Since(ts)
+	require.GreaterOrEqual(t, elapsed, killGrace,
+		"group died before escalation: test setup no longer exercises it")
+	t.Logf("process group reaped %s after Close()", elapsed)
+}
+
+// TestCloseKillsPromptlyByDefault: without a killsignal override the default
+// Cancel (SIGKILL) reaps a plain child well before the escalation grace.
+func TestCloseKillsPromptlyByDefault(t *testing.T) {
+	cmd := NewCommand("sleep 60")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+
+	require.NoError(t, cmd.Close())
+
+	require.Eventually(t, func() bool {
+		return !groupAlive(pid)
+	}, 3*time.Second, 50*time.Millisecond)
+}

--- a/pkg/shell/procattr.go
+++ b/pkg/shell/procattr.go
@@ -5,3 +5,7 @@ package shell
 import "syscall"
 
 var procAttr *syscall.SysProcAttr
+
+// killProcessGroup: no Setpgid outside linux. ensureKill's Process.Kill
+// already did everything we can do portably.
+func killProcessGroup(pid int) {}

--- a/pkg/shell/procattr_linux.go
+++ b/pkg/shell/procattr_linux.go
@@ -2,5 +2,13 @@ package shell
 
 import "syscall"
 
-// will stop child if parent died (even with SIGKILL)
-var procAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGTERM}
+//   - Pdeathsig will stop child if parent died (even with SIGKILL)
+//   - Setpgid puts the child in its own process group so Command.ensureKill
+//     can SIGKILL the whole tree, grandchildren (e.g. ffmpeg spawned via a
+//     shell wrapper) included, which a plain Process.Kill never reaches
+var procAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGTERM, Setpgid: true}
+
+// killProcessGroup sends SIGKILL to pid's entire process group.
+func killProcessGroup(pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+}


### PR DESCRIPTION
I noticed that after go2rtc stopped a stream, the ffmpeg it had started through a
shell wrapper kept running and held the camera and the encoder. This PR kills every
process started for that source, not only the first one.

`Command.Close` cancels the context, and that signals the direct child only. With
`killsignal` set to a signal the child can catch, a wrapper that ignores it never exits.
An `exec: sh -c "... ffmpeg ..."` source runs ffmpeg as a grandchild, which a single-pid
kill never reaches. This starts the child in its own process group (`Setpgid`). That is
a set of processes the system can signal at once. After `Close` it allows a 5 s grace,
then sends SIGKILL to the whole group. `WaitDelay` gets the same grace. The wait then
cannot hang on pipes a straggling grandchild still holds open. The process group and the
group kill are Linux-only. Other platforms keep the existing single-process kill.

Measured with a probe that starts `sh -c "trap : TERM; sleep 300"`, sends the signal
`#killsignal=15` sends, then reads /proc 10 s after `Close()`.

    master c245815:  child_alive=true   grandchild_alive=true
    this branch:     child_alive=false  grandchild_alive=false

On master the direct child survives as well as the grandchild. `WaitDelay` is unset, so
a caught signal is never escalated.

Test: `pkg/shell/command_test.go` adds `TestCloseEscalatesToProcessGroupKill`, which
confirms both a SIGTERM-trapping child and its `sleep` grandchild are gone from /proc
after `Close`, and `TestCloseKillsPromptlyByDefault`. The package passes in 5.4 s.

Refs #1243
Generated with the help of Claude.
