### PR TITLE
Onvif camera controls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Push
+name: Build Docker Image
 
 on:
   workflow_dispatch:
@@ -8,112 +8,13 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
-  build-binaries:
-    name: Build binaries
-    runs-on: ubuntu-latest
-    env: { CGO_ENABLED: 0 }
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with: { go-version: '1.25' }
-
-      - name: Build go2rtc_win64
-        env: { GOOS: windows, GOARCH: amd64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_win64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_win64, path: go2rtc.exe }
-
-      - name: Build go2rtc_win32
-        env: { GOOS: windows, GOARCH: 386 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_win32
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_win32, path: go2rtc.exe }
-
-      - name: Build go2rtc_win_arm64
-        env: { GOOS: windows, GOARCH: arm64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_win_arm64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_win_arm64, path: go2rtc.exe }
-
-      - name: Build go2rtc_linux_amd64
-        env: { GOOS: linux, GOARCH: amd64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_linux_amd64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_linux_amd64, path: go2rtc }
-
-      - name: Build go2rtc_linux_i386
-        env: { GOOS: linux, GOARCH: 386 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_linux_i386
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_linux_i386, path: go2rtc }
-
-      - name: Build go2rtc_linux_arm64
-        env: { GOOS: linux, GOARCH: arm64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_linux_arm64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_linux_arm64, path: go2rtc }
-
-      - name: Build go2rtc_linux_arm
-        env: { GOOS: linux, GOARCH: arm, GOARM: 7 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_linux_arm
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_linux_arm, path: go2rtc }
-
-      - name: Build go2rtc_linux_armv6
-        env: { GOOS: linux, GOARCH: arm, GOARM: 6 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_linux_armv6
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_linux_armv6, path: go2rtc }
-
-      - name: Build go2rtc_linux_mipsel
-        env: { GOOS: linux, GOARCH: mipsle }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_linux_mipsel
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_linux_mipsel, path: go2rtc }
-
-      - name: Build go2rtc_mac_amd64
-        env: { GOOS: darwin, GOARCH: amd64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_mac_amd64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_mac_amd64, path: go2rtc }
-
-      - name: Build go2rtc_mac_arm64
-        env: { GOOS: darwin, GOARCH: arm64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_mac_arm64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_mac_arm64, path: go2rtc }
-
-      - name: Build go2rtc_freebsd_amd64
-        env: { GOOS: freebsd, GOARCH: amd64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_freebsd_amd64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_freebsd_amd64, path: go2rtc }
-
-      - name: Build go2rtc_freebsd_arm64
-        env: { GOOS: freebsd, GOARCH: arm64 }
-        run: go build -ldflags "-s -w" -trimpath
-      - name: Upload go2rtc_freebsd_arm64
-        uses: actions/upload-artifact@v4
-        with: { name: go2rtc_freebsd_arm64, path: go2rtc }
-
-  docker-master:
-    name: Build docker master
+  docker:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -123,13 +24,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            name=${{ github.repository }},enable=${{ github.event.repository.fork == false }}
-            ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}},enable=false
             type=match,pattern=v(.*),group=1
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -137,15 +36,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GitHub Container Registry
-        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -153,7 +44,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -163,118 +54,8 @@ jobs:
             linux/arm/v6
             linux/arm/v7
             linux/arm64/v8
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  docker-hardware:
-    name: Build docker hardware
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Docker meta
-        id: meta-hw
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=${{ github.repository }},enable=${{ github.event.repository.fork == false }}
-            ghcr.io/${{ github.repository }}
-          flavor: |
-            suffix=-hardware,onlatest=true
-            latest=auto
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}},enable=false
-            type=match,pattern=v(.*),group=1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        if: github.event_name == 'push'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/hardware.Dockerfile
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta-hw.outputs.tags }}
-          labels: ${{ steps.meta-hw.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  docker-rockchip:
-    name: Build docker rockchip
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Docker meta
-        id: meta-rk
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            name=${{ github.repository }},enable=${{ github.event.repository.fork == false }}
-            ghcr.io/${{ github.repository }}
-          flavor: |
-            suffix=-rockchip,onlatest=true
-            latest=auto
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}},enable=false
-            type=match,pattern=v(.*),group=1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub
-        if: github.event_name == 'push' && github.event.repository.fork == false
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        if: github.event_name == 'push'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/rockchip.Dockerfile
-          platforms: linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta-rk.outputs.tags }}
-          labels: ${{ steps.meta-rk.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,17 @@ on:
       - 'master'
     tags:
       - 'v*'
+  # Weekly rebuild so the published image picks up CVE fixes in the
+  # upstream Alpine and Python base layers between tagged releases.
+  # Without this, the master/latest images' OS package set is frozen
+  # at the last push to master — and Alpine ships package updates
+  # constantly. Sunday 04:00 UTC = low-traffic window for both build
+  # runners and any downstream pulls.
+  #
+  # Pattern adopted from upstream PR
+  # https://github.com/AlexxIT/go2rtc/pull/2242.
+  schedule:
+    - cron: '0 4 * * 0'
 
 permissions:
   contents: read
@@ -55,6 +66,18 @@ jobs:
             linux/arm/v7
             linux/arm64/v8
           push: true
+          # Re-resolve FROM golang:${GO_VERSION}-alpine and
+          # FROM python:${PYTHON_VERSION}-alpine against the registry on
+          # every build. When Alpine ships a refreshed base image (which
+          # happens whenever any included apk package is updated), this
+          # bumps the layer SHA and invalidates the GitHub-Actions cache
+          # for downstream layers — forcing the `apk add` instructions to
+          # re-run and pick up current OS package versions. Without
+          # pull:true a cached layer could indefinitely re-use a
+          # vulnerable apk install even though the FROM tag now points
+          # at a newer image. Coupled with the weekly schedule above,
+          # this gives a steady CVE-fix refresh between tagged releases.
+          pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,6 @@ on:
       - 'master'
     tags:
       - 'v*'
-  # Weekly rebuild so the published image picks up CVE fixes in the
-  # upstream Alpine and Python base layers between tagged releases.
-  # Without this, the master/latest images' OS package set is frozen
-  # at the last push to master — and Alpine ships package updates
-  # constantly. Sunday 04:00 UTC = low-traffic window for both build
-  # runners and any downstream pulls.
-  #
-  # Pattern adopted from upstream PR
-  # https://github.com/AlexxIT/go2rtc/pull/2242.
-  schedule:
-    - cron: '0 4 * * 0'
 
 permissions:
   contents: read
@@ -66,17 +55,6 @@ jobs:
             linux/arm/v7
             linux/arm64/v8
           push: true
-          # Re-resolve FROM golang:${GO_VERSION}-alpine and
-          # FROM python:${PYTHON_VERSION}-alpine against the registry on
-          # every build. When Alpine ships a refreshed base image (which
-          # happens whenever any included apk package is updated), this
-          # bumps the layer SHA and invalidates the GitHub-Actions cache
-          # for downstream layers — forcing the `apk add` instructions to
-          # re-run and pick up current OS package versions. Without
-          # pull:true a cached layer could indefinitely re-use a
-          # vulnerable apk install even though the FROM tag now points
-          # at a newer image. Coupled with the weekly schedule above,
-          # this gives a steady CVE-fix refresh between tagged releases.
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .idea/
 .tmp/
+.claude/
 
 go2rtc.yaml
 go2rtc.json
 
+go2rtc-local.tar
 go2rtc_freebsd*
 go2rtc_linux*
 go2rtc_mac*
@@ -22,3 +24,4 @@ website/.vitepress/dist
 node_modules
 package-lock.json
 CLAUDE.md
+settings.json

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,8 @@ and any go2rtc Nest source, not just the Nest+UniFi combination that
 exposed them.
 
 Each item below is independently revertable. Tested against
-UniFi Protect 7.1.60 + Google Nest (wired ethernet + WiFi cam) as
-the primary client/source combination.
+UniFi Protect 7.1.60 + [Google Nest Battery Camera](https://store.google.com/gb/product/nest_cam_battery?hl=en-GB)
+as the primary client/source combination.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,38 @@ as the primary client/source combination.
   occasionally failed adoption. Stub responses (empty configurations)
   cleanly declare "no imaging features supported".
 
+### 4b. Documented: ONVIF server does not authenticate requests
+
+- **Files:** `internal/onvif/README.md`
+- **Change:** Added a "Security" subsection to the ONVIF README
+  documenting that go2rtc's ONVIF server dispatches every
+  operation without parsing or verifying the SOAP
+  `wsse:UsernameToken` element. Credentials prompted for by
+  NVR/HA adoption tools (UniFi Protect, Home Assistant, etc.) are
+  decorative; any value succeeds. The note covers what IS still
+  protected (the underlying RTSP/HTTP stream URLs, which carry
+  their own auth) and what is NOT (camera-setup metadata
+  enumeration via `GetProfiles`,
+  `GetVideoEncoderConfiguration`, etc.). Recommends treating the
+  go2rtc API port as trusted-network only.
+- **Why:** Operators integrating go2rtc with NVRs typically see
+  a credential prompt during adoption and assume those
+  credentials are validated server-side. They aren't — and
+  exposing the ONVIF endpoint beyond a trusted network would
+  leak camera-setup details to unauthenticated callers. This is
+  upstream behaviour, not specific to this fork; the note exists
+  to make the implicit explicit. No code change.
+- **Upstream fix in progress (not adopted here):** the open
+  pull request https://github.com/AlexxIT/go2rtc/pull/2231 adds
+  WS-Security `UsernameToken` validation to the ONVIF server,
+  gated by dedicated `onvif.username` / `onvif.password` config
+  keys and with a `GetSystemDateAndTime` carve-out so clients
+  can compute clock skew before generating password digests.
+  Tracking the PR rather than merging it locally — this fork
+  prefers to wait for upstream review. The README links to the
+  PR so operators who need authenticated ONVIF in their own
+  deployment know where to find a reference implementation.
+
 ---
 
 ## RTSP Server

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,6 +130,27 @@ primary client/source combination.
   reconnected and waited for Google's next scheduled keyframe. With the
   fix, cold-start recovery is typically <5s.
 
+### 8b. Silent-stream detection for ActiveProducer sources
+
+- **Files:** `pkg/webrtc/conn.go`
+- **Change:** Added a 10-second `SetReadDeadline()` on the
+  `TrackRemote.Read()` call in the OnTrack loop, applied only for
+  `ModeActiveProducer`. When the deadline fires, the peer connection
+  is closed, which triggers `OnConnectionStateChange` → standard
+  reconnect cascade. PassiveProducer (browser → go2rtc) keeps the
+  blocking-read behaviour because legitimate silence (user mute,
+  paused webcam) is common.
+- **Why:** Nest's cloud SFU occasionally stops sending RTP but keeps
+  the WebRTC peer connection technically alive (ICE keepalives still
+  flowing, no `Disconnected` state event from pion). Without an
+  explicit read deadline, `Read()` blocked indefinitely on silence —
+  go2rtc believed the source was healthy while downstream consumers
+  (audio ffmpeg, UniFi) timed out one by one. Recovery only happened
+  ~95 seconds later when pion's failure-detection timer maxed out and
+  fired the state change. With the deadline, recovery completes in
+  ~17 seconds (10s deadline + ~6s for Nest WebRTC re-establishment),
+  a 5-6x improvement in observed recording-gap duration.
+
 ---
 
 ## Nest Source

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -360,14 +360,13 @@ as the primary client/source combination.
 - **Why:** Google OAuth access tokens for the Smart Device Management
   API expire after ~60 minutes. Each Nest stream session also runs
   up to ~60 minutes, so it's normal for an extend to land on a
-  freshly-expired token — empirically observed (2026-05-22 09:36
-  outage): an extend after the OAuth boundary 401'd, the broken
-  `refreshToken()` no-op'd, the retry 401'd again, the extend
-  goroutine gave up, and the stream silently died at its next
-  `expires_at`. With the fix, the same boundary now shows
-  `[nest] extend got 401, refreshing OAuth token` → `[nest] OAuth
-  token refreshed` → `[nest] extend ok` in quick succession; stream
-  continues uninterrupted.
+  freshly-expired token. Without the fix, an extend after the OAuth
+  boundary 401s, the broken `refreshToken()` no-ops, the retry 401s
+  again, the extend goroutine gives up, and the stream silently dies
+  at its next `expires_at`. With the fix, the same boundary now
+  shows `[nest] extend got 401, refreshing OAuth token` →
+  `[nest] OAuth token refreshed` → `[nest] extend ok` in quick
+  succession; stream continues uninterrupted.
 
 ---
 
@@ -460,12 +459,13 @@ as the primary client/source combination.
   that cap, the upstream silently stops delivering packets and the
   current reconnect path takes ~30-40 s to notice and recover
   (inner-ffmpeg 5 s read timeout → 3 retries × 10 s → finally
-  declare EOF → producer reconnect). Empirically observed gap
-  cadence: **01:59, 03:05, 04:11, 05:17, 06:23, 07:30 — exactly
-  ~66 minutes apart**. A proactive refresh at 55 min hits while
-  upstream is still healthy, allowing the swap to complete inside
-  the producer's already-overlap-friendly reconnect flow before
-  the old session goes silent.
+  declare EOF → producer reconnect). Without proactive refresh,
+  recording gaps recur on a roughly ~66-minute cadence (the 60-min
+  cap plus a few minutes of residual delivery and detection
+  latency). A proactive refresh at 55 min hits while upstream is
+  still healthy, allowing the swap to complete inside the
+  producer's already-overlap-friendly reconnect flow before the
+  old session goes silent.
 - **Why a generic interface, not a Nest-only hook:** The same
   pattern applies to any cloud-mediated stream with a session
   lifetime (Ring, Arlo, Tuya, etc. all have analogous limits).
@@ -512,17 +512,18 @@ as the primary client/source combination.
     the stream's resulting consumer count — without that, a
     `producer.stop()` that follows can't be tied to the last-consumer
     teardown vs. one of several simultaneous removals.
-- **Why:** A failure at ~15:20 with the kick fix already deployed
-  showed two blind spots in the existing logs:
-  1. After the kick + reconnect, ffmpeg ADTS warnings (audio) kept
-     appearing for ~17 minutes — so audio was flowing — but we had
-     no way to tell whether video was also flowing. UniFi recording
-     was frozen the whole window. The heartbeat would have shown
-     `dpackets=0` on the H264 track immediately.
-  2. Between the last ADTS warning and the next consumer attach,
-     ~6 minutes elapsed with no log activity. The stopProducers /
-     RemoveConsumer traces close that gap by surfacing the decision
-     branches that were previously implicit.
+- **Why:** Two blind spots in the existing logs made the "silent
+  stall" class of failures hard to diagnose:
+  1. After a kick + reconnect, ffmpeg ADTS warnings (audio) kept
+     appearing for many minutes — so audio was flowing — but there
+     was no way to tell whether video was also flowing while UniFi
+     recording sat frozen. The heartbeat surfaces this as
+     `dpackets=0` on the affected track immediately.
+  2. Multi-minute gaps with no log activity at all were ambiguous:
+     was nothing happening, or was something happening silently?
+     The `stopProducers` decision trace + the consumer-removed
+     remaining count surface the decision branches that were
+     previously implicit.
 - **No new tests:** Both additions are diagnostic logs at debug/trace
   level with no behavior change; covered by existing tests
   (compilation + `TestKickConsumers`).
@@ -564,11 +565,11 @@ as the primary client/source combination.
     age=55m0s session=...` (info)
 - **Why:** Before this, both successful extends and OAuth refreshes
   were completely silent, and failure cases produced only a generic
-  error string with no context. The 2026-05-22 09:36 outage took
-  ~10 message turns to diagnose because we were guessing whether
-  extends were firing at all; with this logging, the next OAuth-
-  boundary issue (12:51) was diagnosed from a single grep through
-  the log.
+  error string with no context — making it impossible to tell from
+  logs alone whether extends were firing, whether a 401 was being
+  refreshed, or whether the refresh itself was failing. With this
+  logging, any OAuth/extend issue is diagnosable from a single
+  filtered pass through the log.
 
 ---
 
@@ -611,17 +612,13 @@ as the primary client/source combination.
 - **Why:** UniFi Protect 7.1.69's RTSP recording subsystem treats an
   SSRC change mid-session as "the stream I was recording has
   ended" and stops writing to disk — even though the RTSP/TCP
-  session stays alive and packets keep arriving. Empirically
-  confirmed (2026-05-22 12:43 outage): the proactive reconnect
-  ran cleanly, the new Nest WebRTC session was healthy, extends
-  worked, and go2rtc was forwarding packets — but UniFi's recorder
-  silently stopped at the moment of the SSRC change. With the
-  continuity rewrite, the proactive reconnect is invisible at the
-  RTP layer; UniFi keeps writing straight through. Empirical
-  validation: 6+ hours of continuous recording across multiple
-  proactive reconnects, with the only stoppage attributable to a
-  separate UniFi Protect bug (RTSP-client freeze affecting all
-  3rd-party cameras simultaneously, recovered by Protect restart).
+  session stays alive and packets keep arriving. Without the
+  rewrite, every proactive reconnect (section 12b) silently stops
+  UniFi recording at the moment of the SSRC change. With the
+  rewrite, the proactive reconnect is invisible at the RTP layer
+  and UniFi keeps writing straight through. Validated against
+  several hours of continuous recording across multiple proactive
+  reconnects.
 - **Why at the Receiver level, not per-Sender:** All consumers of a
   producer's track see the same Receiver. Rewriting once in the
   Receiver's `Input` closure means a single state machine handles

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,34 +130,25 @@ primary client/source combination.
   reconnected and waited for Google's next scheduled keyframe. With the
   fix, cold-start recovery is typically <5s.
 
-### 8b. Silent-stream detection for ActiveProducer video tracks
+### 8b. Silent-stream detection (REVERTED)
 
-- **Files:** `pkg/webrtc/conn.go`
-- **Change:** Added a 20-second `SetReadDeadline()` on the
-  `TrackRemote.Read()` call in the OnTrack loop, applied only for
-  `ModeActiveProducer` *and only on the video track*. When the
-  deadline fires, the peer connection is closed, which triggers
-  `OnConnectionStateChange` → standard reconnect cascade.
-- **Why:** Nest's cloud SFU occasionally stops sending RTP but keeps
-  the WebRTC peer connection technically alive (ICE keepalives still
-  flowing, no `Disconnected` state event from pion). Without an
-  explicit read deadline, `Read()` blocked indefinitely on silence —
-  go2rtc believed the source was healthy while downstream consumers
-  (audio ffmpeg, UniFi) timed out one by one. Recovery only happened
-  ~95 seconds later when pion's failure-detection timer maxed out and
-  fired the state change. With the deadline, recovery completes in
-  ~25 seconds (20s deadline + ~6s for Nest WebRTC re-establishment).
-- **Why video-only:** WebRTC Opus encoders commonly use DTX
-  (discontinuous transmission); legitimate room silence produces zero
-  audio packets. An initial implementation applied the deadline to
-  all tracks and incorrectly tore down the connection every time the
-  scene went acoustically quiet, killing the video stream that was
-  working fine. Video tracks have no equivalent legitimate-silence
-  scenario — with PLI requests every 10s (item 8 above), an IDR
-  should arrive every ~10s minimum.
-- **Why PassiveProducer is exempt:** browser-pushed sources may
-  legitimately go silent on both audio (mute) and video (camera off),
-  and forcing reconnect there would be wrong.
+An attempt to use `SetReadDeadline()` on `TrackRemote.Read()` to
+detect silent upstream Nest streams faster (replacing pion's ~95s
+failure detection with ~25s detection) was reverted. The faster
+detection paradoxically broke UniFi Protect: when go2rtc restarted
+the Nest source quickly, UniFi's RTSP session was still alive but
+holding the previous Nest WebRTC session's SPS/PPS values. New RTP
+frames arrived with new codec params that didn't match UniFi's
+decoder state, freezing the video until manual Protect restart.
+
+The original ~95s detection window allowed UniFi's own session
+timeout to fire first, so UniFi disconnected and reconnected with
+fresh SDP. Fast detection skipped that natural recovery path.
+
+Proper fix would force RTSP consumers to disconnect when the source
+restarts (so they reconnect with fresh SDP). Not implemented here —
+left as a follow-up. The original ~95s detection is acceptable
+given how infrequent these events are in practice.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -175,6 +175,18 @@ as the primary client/source combination.
   and pick up the new producer's SDP. The natural list cleanup happens
   in each consumer's transport handler (e.g. `tcpHandler` in
   `internal/rtsp` calls `RemoveConsumer` when its loop exits).
+- **Grace period:** When the last consumer disconnects (which happens
+  cascade-style during a kick), `stopProducers()` would normally tear
+  down the producer we just reconnected — and a slow reconnect from
+  the kicked client would then have to wait for a fresh cold-start of
+  the producer (~6s for Nest WebRTC), often timing out and entering
+  a long back-off cycle (observed 7-minute recording gaps).
+  To prevent this, `kickConsumers()` bumps the `s.pending` counter
+  for a 30-second grace window — long enough for typical UniFi
+  reconnect (1–3s) plus margin for cloud-API throttling on
+  successive Nest WebRTC re-establishments. `stopProducers()` already
+  short-circuits when `pending > 0`, so the producer stays warm and
+  the reconnecting client lands cleanly on it.
 - **Earlier failed attempt (now reverted):** A `SetReadDeadline()`-
   based fast silence detection (commits 58f1495, 9a1ad59, 1254ea9)
   tried to reduce the ~95s detection latency for terminal silences.
@@ -183,8 +195,9 @@ as the primary client/source combination.
   relied on. The kick-consumers fix in this commit addresses the
   underlying codec-refresh problem directly, so fast detection could
   be safely re-introduced in a follow-up if desired.
-- **Test coverage:** `TestKickConsumers` (3 sub-tests: empty,
-  multiple, no list mutation), `TestNewStreamLinksProducers` (3
+- **Test coverage:** `TestKickConsumers` (4 sub-tests: empty,
+  multiple, no list mutation, grace-period pending bump/release),
+  `TestNewStreamLinksProducers` (3
   sub-tests: single string, []string, []any construction paths),
   `TestRedactSourceURL` (6 sub-tests covering nest, rtsp with auth,
   ffmpeg, fragment-only, empty). Uses a `mockConsumer` implementing

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,25 +130,91 @@ primary client/source combination.
   reconnected and waited for Google's next scheduled keyframe. With the
   fix, cold-start recovery is typically <5s.
 
-### 8b. Silent-stream detection (REVERTED)
+### 8b. Kick downstream consumers on Producer reconnect
 
-An attempt to use `SetReadDeadline()` on `TrackRemote.Read()` to
-detect silent upstream Nest streams faster (replacing pion's ~95s
-failure detection with ~25s detection) was reverted. The faster
-detection paradoxically broke UniFi Protect: when go2rtc restarted
-the Nest source quickly, UniFi's RTSP session was still alive but
-holding the previous Nest WebRTC session's SPS/PPS values. New RTP
-frames arrived with new codec params that didn't match UniFi's
-decoder state, freezing the video until manual Protect restart.
+- **Files:** `internal/streams/producer.go`, `internal/streams/stream.go`,
+  `internal/streams/play.go`, `internal/streams/stream_test.go`,
+  `pkg/core/connection.go`
+- **Change:** Added a `stream *Stream` back-reference to `Producer` so
+  it can notify its parent stream after a successful reconnect.
+  Stream gains a `kickConsumers(reason string)` method that snapshots
+  the consumer list, gathers the remote addresses via a small
+  `remoteAddrer` interface (satisfied by anything embedding
+  `*core.Connection`), and calls `Stop()` on each consumer. The
+  reconnect path in `Producer.reconnect()` invokes this (in a
+  goroutine to avoid holding the producer mutex during downstream
+  teardown). `core.Connection` gains a `GetRemoteAddr()` accessor
+  method that makes the address available via the interface without
+  introducing an import cycle.
+- **Why:** When a Producer (e.g. Nest WebRTC) reconnects, the new
+  source typically has different codec parameters (SPS/PPS in a fresh
+  WebRTC SDP). The existing `receiver.Replace(track)` swaps the
+  upstream track silently — downstream RTSP consumers (UniFi Protect)
+  keep their session alive but their decoder is configured for the
+  *previous* SDP. New RTP frames arrive with incompatible bitstream
+  parameters → frozen video until manual reconnect.
+  By kicking consumers on reconnect, they're forced to re-DESCRIBE
+  and pick up the new producer's SDP. The natural list cleanup happens
+  in each consumer's transport handler (e.g. `tcpHandler` in
+  `internal/rtsp` calls `RemoveConsumer` when its loop exits).
+- **Earlier failed attempt (now reverted):** A `SetReadDeadline()`-
+  based fast silence detection (commits 58f1495, 9a1ad59, 1254ea9)
+  tried to reduce the ~95s detection latency for terminal silences.
+  The 25s fast recovery paradoxically broke UniFi because it bypassed
+  the natural session-timeout recovery path that the 95s detection
+  relied on. The kick-consumers fix in this commit addresses the
+  underlying codec-refresh problem directly, so fast detection could
+  be safely re-introduced in a follow-up if desired.
+- **Test coverage:** `TestKickConsumers` (3 sub-tests: empty,
+  multiple, no list mutation), `TestNewStreamLinksProducers` (3
+  sub-tests: single string, []string, []any construction paths),
+  `TestRedactSourceURL` (6 sub-tests covering nest, rtsp with auth,
+  ffmpeg, fragment-only, empty). Uses a `mockConsumer` implementing
+  `core.Consumer` with an atomic Stop counter.
 
-The original ~95s detection window allowed UniFi's own session
-timeout to fire first, so UniFi disconnected and reconnected with
-fresh SDP. Fast detection skipped that natural recovery path.
+### 8c. Streams logging: info/warn levels + credential redaction
 
-Proper fix would force RTSP consumers to disconnect when the source
-restarts (so they reconnect with fresh SDP). Not implemented here —
-left as a follow-up. The original ~95s detection is acceptable
-given how infrequent these events are in practice.
+- **Files:** `internal/streams/producer.go`, `internal/streams/stream.go`
+- **Change (logging levels):** Source reconnect cycles are now
+  surfaced at multiple log levels for operational visibility:
+  - `INF [streams] producer reconnecting source=<scheme>:` fires once
+    at the start of a reconnect cycle (retry=0). Lets operators
+    running at `log.level=info` see source-outage events without
+    enabling debug.
+  - `WRN [streams] producer reconnect still failing source=… retry=5`
+    fires once when retries pass the 5-second-backoff threshold, so
+    persistent outages bubble up to warn-level without per-retry
+    noise.
+  - `INF [streams] producer reconnected source=…` fires after a
+    successful reconnect, pairing with the "reconnecting" line to
+    confirm recovery happened.
+  - Per-retry `[streams] retry=N to url=…` lines stay at debug to
+    avoid log volume when a source is flapping.
+- **Change (kick log):** The `[streams] kicking consumers` log line
+  now includes a `remotes=` array so a single grep on the kick event
+  tells you exactly which downstream clients were notified, no
+  cross-referencing with subsequent `[rtsp] disconnect` lines needed.
+- **Change (credential redaction):** Added a `redactSourceURL()`
+  helper that strips the URL query (and fragment) before logging.
+  Applied to all `p.url` occurrences in `internal/streams/producer.go`
+  (5 existing log calls plus the 3 new info/warn ones). Source URLs
+  like `nest:?client_id=…&client_secret=…&refresh_token=…` are now
+  logged as `nest:` only. Other credential-bearing schemes
+  (RTSP with `user:pass@host`) were already covered by
+  `pkg/creds.SecretWriter`'s `userinfoRegexp`; this fix closes the
+  query-string credential leak.
+- **Why:** The pre-fix logs printed full producer URLs at multiple
+  levels including warn. For Nest sources the URL carries OAuth
+  credentials in the query string — sharing any log file (e.g.
+  pasting into an issue tracker or chat) leaked the secret. With the
+  redaction, log lines stay useful for diagnosis (you can still see
+  the source scheme + path) but no credentials appear.
+- **Deliberately not redacted:** `[echo]` log of script output, `[expr]`
+  source URL, `[api] request` query strings, `[onvif]` SOAP bodies.
+  Each is either lower-risk (PasswordDigest is an HMAC, not plain
+  text) or has legitimate non-credential information that would be
+  lost by blunt redaction. Worth revisiting individually if a specific
+  use case requires it.
 
 ---
 
@@ -204,6 +270,21 @@ given how infrequent these events are in practice.
   tell which session was which. With the new fields, sessions are
   trivially greppable by `remote=192.168.5.1` or
   `user_agent=GStreamer/1.26.10`.
+
+### 11b. Warn on RTSP DESCRIBE / ANNOUNCE of unknown stream
+
+- **Files:** `internal/rtsp/rtsp.go`
+- **Change:** When an RTSP client requests a stream name that doesn't
+  exist in `streams.Get(name)`, the handler now logs a warn-level line
+  with stream name, remote address, and user-agent before returning.
+  Previously the request was rejected silently.
+- **Why:** Most common cause is a configuration mismatch — the client
+  (UniFi Protect, VLC, Frigate) is pointed at a stream name that
+  doesn't exist in the current go2rtc.yaml. Symptom from the client
+  side is "can't adopt" or "stream unavailable" with no go2rtc-side
+  signal to confirm. The warn line ("stream not found",
+  "stream not found (ANNOUNCE)") gives operators an immediate
+  pointer at the problem without enabling debug.
 
 ### 12. Structured logging across HTTP / WebSocket / ONVIF / MP4
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -368,6 +368,90 @@ as the primary client/source combination.
   `[nest] OAuth token refreshed` → `[nest] extend ok` in quick
   succession; stream continues uninterrupted.
 
+### 10c. ExtendStream 409/429 transient-status retry with exponential backoff
+
+- **Files:** `pkg/nest/api.go`, `pkg/nest/api_test.go`
+- **Change:** `ExtendStream()` is now a retry loop (maxRetries=3)
+  that distinguishes three retryable status classes:
+  - **401 Unauthorized** — token expired; refresh and retry
+    immediately (existing behaviour from §10b, now folded into the
+    same loop).
+  - **409 Conflict / 429 Too Many Requests** — transient server-side
+    condition; back off and retry. Initial back-off is 30 s,
+    doubled on each subsequent failure. Exposed as the package
+    variable `extendBackoffInitial` so tests can shorten it.
+  - **5xx and other non-retryable codes** — surface as error
+    immediately (not retried; the producer-level reconnect
+    machinery is the right place to absorb those).
+  Each retry attempt logs at warn level with the status, attempt
+  count, max attempts, and backoff duration.
+- **Why:** Google's SDM API returns 429 under client-side rate
+  limiting (which an aggressive extend loop can trigger after
+  many proactive reconnects) and 409 under transient session
+  conflicts. The previous implementation would surface either as
+  a hard error, killing the extend goroutine and forcing the
+  stream to die at its current `expires_at`. With the retry
+  loop, short-lived API hiccups are absorbed without disrupting
+  the stream.
+- **Test coverage:** `TestExtendStreamRetry` (6 sub-tests) drives
+  the retry loop with an `httptest` server hooked in via the new
+  `extendURI` package var: happy path (200), 429-then-200,
+  409-then-200, retry exhaustion (three consecutive 429s), 5xx
+  fail-fast, and backoff doubling between attempts. Uses
+  `extendBackoffInitial = 1ms` to keep tests fast.
+
+### 10d. Nest API hardening: HTTP timeouts + PeerConnection leak fixes
+
+- **Files:** `pkg/nest/api.go`, `pkg/nest/client.go`,
+  `internal/nest/init.go`
+- **Change:** Three latent reliability issues in the Nest API
+  surface, fixed together:
+  - **HTTP client timeout: `time.Second * 5000` → `10 * time.Second`**
+    in every `*http.Client` constructed by `NewAPI`, `GetDevices`,
+    `ExchangeSDP`, `GenerateRtspStream`, `StopRTSPStream`, and
+    `ExtendStream`. The 5000-second value is almost certainly a
+    typo for 5; with it, any hung Google API call could block a
+    go2rtc goroutine for ~83 minutes before timing out.
+  - **`PeerConnection` cleanup on `rtcConn` error paths.** The
+    WebRTC dial routine now calls `pc.Close()` whenever
+    `CreateCompleteOffer`, `ExchangeSDP`, or `SetAnswer` fails
+    before returning. Without this, every failed dial attempt
+    leaked a `PeerConnection` (UDP sockets, ICE state, DTLS
+    context); over many retry cycles under upstream throttling
+    or transient network issues this would slowly exhaust the
+    process's UDP-port and goroutine budget. Each close logs
+    at debug level with the original error for traceability.
+  - **`defer res.Body.Close()` added to `GenerateRtspStream` and
+    `StopRTSPStream`.** The original code only closed the response
+    body via the implicit JSON-decoder path on the success branch;
+    a non-200 response or a decode error left the body open,
+    leaking the underlying connection back to the pool.
+  - **Typo fixes:** `cliendID` → `clientID`, `cliendSecret` →
+    `clientSecret`, `compataiility` → `compatibility` in
+    `pkg/nest/client.go` and `internal/nest/init.go`.
+- **Why:** These bugs are independent of the OAuth/extend logic
+  we already fixed, but they all affect the long-term resource
+  hygiene of the Nest integration. The 5000-s timeout is the
+  most consequential — under any Google-side hang it would
+  silently park a goroutine for over an hour, holding state and
+  delaying error detection well past the points where the
+  proactive-reconnect (§12b) or extend-retry (§10c) machinery
+  could otherwise help.
+- **Source:** Items independently identified in the upstream PRs
+  https://github.com/AlexxIT/go2rtc/pull/2194 and
+  https://github.com/AlexxIT/go2rtc/pull/2128.
+- **Note (lessons learned):** These two upstream PRs were not
+  discovered until *after* the bulk of the Nest/UniFi reliability
+  work in this fork (§8b through §15) had been written and
+  deployed. Both PRs predate this fork's troubleshooting and
+  would have shortcut several rounds of diagnosis — particularly
+  the 5000-second HTTP timeout, which we missed entirely until
+  reading PR #2194. Future investigations into the Nest
+  integration (or any other upstream-maintained source) should
+  start with a scan of the upstream issue tracker and open PRs
+  before reaching for the debugger; this would have saved
+  multiple debugging sessions here.
+
 ---
 
 ## Observability
@@ -661,6 +745,12 @@ Additional tests added in this iteration:
   single-session passthrough, mid-stream SSRC change anchoring,
   relative-spacing preservation, and Replace state transfer to
   successor.
+- `pkg/nest/api_test.go::TestExtendStreamRetry` (6 sub-tests) —
+  covers the new ExtendStream retry loop (section 10c): happy
+  path, 429-then-success, 409-then-success, retry exhaustion
+  with three consecutive 429s, 5xx fail-fast (only 401/409/429
+  retried), and backoff doubling between attempts. Uses an
+  `httptest` server hooked in via the `extendURI` package var.
 - `internal/streams/stream_test.go::TestKickConsumers` (6 sub-tests
   including internal-loop-skip and grace-period bump/release —
   see section 8b/8b-1).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,30 @@
 # Local Changes
 
-Fork-local fixes against upstream `AlexxIT/go2rtc` from this debugging session.
-All changes target compliance with the underlying protocols (RFC 2326 for
-RTSP, ONVIF Profile S, Google Nest Device Access API) and observability
-improvements. Each item is independently revertable.
+This fork's changes focus on **improving the reliability of the
+Nest → go2rtc → UniFi Protect pipeline**. Out of the box, that
+end-to-end path has several latent problems: UniFi adoption doesn't
+negotiate audio, RTSP keepalive methods aren't acknowledged so
+sessions die every ~30 seconds, the Nest stream extension is
+fire-once so the stream silently dies at ~10 minutes, and when the
+upstream Nest source reconnects, downstream UniFi consumers get stuck
+on stale codec parameters and freeze until manual restart.
 
-Tested against UniFi Protect 7.1.60 + Google Nest (wired+WiFi) as the
-primary client/source combination.
+The patches in this file address each of those layers — ONVIF profile
+contents, RTSP method handling (RFC 2326 compliance), Nest stream
+extension lifecycle, WebRTC keyframe requests, and consumer-refresh
+on source reconnect — along with observability improvements
+(structured logs with remote IP / User-Agent, info/warn levels for
+source-outage events, credential redaction of source URLs in log
+output).
+
+The fixes are general-purpose: they help any RFC-2326 RTSP client
+talking to go2rtc (UniFi, Frigate, Synology Surveillance, Axis, etc.)
+and any go2rtc Nest source, not just the Nest+UniFi combination that
+exposed them.
+
+Each item below is independently revertable. Tested against
+UniFi Protect 7.1.60 + Google Nest (wired ethernet + WiFi cam) as
+the primary client/source combination.
 
 ---
 
@@ -303,22 +321,6 @@ primary client/source combination.
 - **Why:** Consistent observability across all client-facing surfaces.
   Same grep patterns work for any client interaction regardless of
   protocol.
-
----
-
-## Suggested upstream PR grouping
-
-If contributing back to AlexxIT/go2rtc, these changes group naturally
-into five focused PRs:
-
-1. **ONVIF improvements** — items 1, 2, 3, 4
-2. **RTSP compliance + keepalives** — items 5, 6, 7
-3. **Nest source robustness** — items 9, 10
-4. **WebRTC PLI for active producers** — item 8
-5. **Observability** — items 11, 12
-
-Each PR is independent of the others (no cross-dependencies between
-groups) and addresses a coherent area.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,230 @@
+# Local Changes
+
+Fork-local fixes against upstream `AlexxIT/go2rtc` from this debugging session.
+All changes target compliance with the underlying protocols (RFC 2326 for
+RTSP, ONVIF Profile S, Google Nest Device Access API) and observability
+improvements. Each item is independently revertable.
+
+Tested against UniFi Protect 7.1.60 + Google Nest (wired+WiFi) as the
+primary client/source combination.
+
+---
+
+## ONVIF
+
+### 1. ONVIF profile advertises AAC audio
+
+- **Files:** `pkg/onvif/server.go`
+- **Change:** `appendProfile` now emits `<tt:AudioSourceConfiguration>` and
+  `<tt:AudioEncoderConfiguration>` (AAC, 48 kHz, 64 kbps) alongside the
+  existing video configurations. New top-level builders
+  `GetAudioSourcesResponse`, `GetAudioSourceConfigurationsResponse`,
+  `GetAudioEncoderConfigurationsResponse` replace the previous empty stubs.
+- **Why:** ONVIF clients that gate audio track setup on profile contents
+  (UniFi Protect 3rd-party adoption is one) wouldn't issue RTSP SETUP for
+  the audio track if no `AudioEncoderConfiguration` was present, even
+  though the SDP from DESCRIBE included an audio track.
+- **Impact:** UniFi Protect (and similarly strict ONVIF clients) now show
+  the "Enable Audio" toggle and successfully negotiate the audio stream.
+
+### 2. Singular AudioSourceConfiguration / AudioEncoderConfiguration
+
+- **Files:** `pkg/onvif/server.go`
+- **Change:** Added `GetAudioSourceConfigurationResponse` and
+  `GetAudioEncoderConfigurationResponse` (singular variants). Added
+  matching operation constants and `StaticResponse` routing.
+- **Why:** ONVIF Media Service spec requires both singular and plural
+  variants of every Configuration getter. Previously only the plural
+  forms were implemented; clients probing the singular forms got 400.
+
+### 3. Proper POSIX TZ format
+
+- **Files:** `pkg/onvif/helpers.go`
+- **Change:** Rewrote `GetPosixTZ` to produce IEEE 1003.1 POSIX TZ
+  strings (`UTC0`, `EST5`, `JST-9`) instead of the previous non-standard
+  `GMT±HH:MM` format. Sign convention now follows POSIX (reversed from
+  ISO 8601). Zone name comes from Go's `time.Zone()` and respects the
+  container's `$TZ` env var or `/etc/timezone`.
+- **Why:** The previous output was non-conformant per ONVIF spec which
+  references POSIX. Strict clients ignored it; clients that parsed it
+  saw incorrect signs for east-of-UTC zones.
+
+### 4. Imaging service stub
+
+- **Files:** `pkg/onvif/server.go`, `pkg/onvif/envelope.go`,
+  `internal/onvif/onvif.go`
+- **Change:** Added imaging service to `GetCapabilities` and
+  `GetServices` advertisements. Added stub responses for
+  `GetImagingSettings`, `GetOptions`, `GetMoveOptions`, `GetStatus`, and
+  `GetServiceCapabilities` (the latter routed by URL path since it's
+  shared between Media and Imaging services). Added `timg:` namespace
+  to the SOAP envelope prefix.
+- **Why:** Some clients (Frigate, newer Synology Surveillance) probe the
+  imaging service during adoption. Without it they logged warnings and
+  occasionally failed adoption. Stub responses (empty configurations)
+  cleanly declare "no imaging features supported".
+
+---
+
+## RTSP Server
+
+### 5. GET_PARAMETER / SET_PARAMETER during session setup
+
+- **Files:** `pkg/rtsp/server.go`, `pkg/rtsp/conn.go`
+- **Change:** Added `MethodGetParameter` / `MethodSetParameter` constants
+  and a case in the `Accept()` method switch that returns `200 OK` for
+  both. Added these methods to the `Public:` header in the OPTIONS
+  response.
+- **Why:** RFC 2326 §10.8/§10.9 define these as keepalive methods.
+  Before this fix the server fell through to `default` which returned
+  an error and closed the TCP connection, killing any client (UniFi
+  Protect, Axis cameras) that uses these as keepalives during setup.
+
+### 6. GET_PARAMETER / SET_PARAMETER during steady state (after PLAY)
+
+- **Files:** `pkg/rtsp/conn.go`
+- **Change:** The `handleTCPData` steady-state read loop recognised
+  `GET_`/`SET_` prefixes but only emitted responses for `OPTIONS`.
+  Extended to respond `200 OK` to `GET_PARAMETER`, `SET_PARAMETER`, and
+  `PAUSE` in steady state. Added `TEARDOWN` handler that acknowledges
+  and closes the connection. Unknown methods now get
+  `455 Method Not Valid In This State`.
+- **Why:** This was the most impactful fix of the session. UniFi Protect
+  sends `SET_PARAMETER` every ~30s as a keepalive. Previously the request
+  was read and logged via the listener but no response was written, so
+  UniFi's request timeout expired, UniFi tore down the TCP connection,
+  and the consumer cycled into reconnect → mid-GOP green frames →
+  "Camera Lost Wired Connection" indefinitely. This fix made UniFi
+  sessions hold indefinitely.
+
+### 7. RFC 2326 compliance pass
+
+- **Files:** `pkg/rtsp/server.go`, `pkg/rtsp/conn.go`
+- **Changes:**
+  - Unknown methods now return `501 Not Implemented` with an `Allow:`
+    header (was: connection-drop). Per RFC 2326 §11.4 and §1.4.
+  - `PAUSE` returns `200 OK` rather than falling through to the unknown
+    method case.
+  - Session ID is now generated only on the **first** SETUP within a
+    client session; subsequent SETUPs reuse the same ID. Per RFC 2326
+    §10.4. Previously each SETUP generated a fresh random ID.
+
+---
+
+## WebRTC Source
+
+### 8. PLI requests for ActiveProducer + immediate PLI on track setup
+
+- **Files:** `pkg/webrtc/conn.go`
+- **Change:** The existing periodic-PLI ticker (which fires every 2s for
+  PassiveProducer video tracks) now also fires for `ModeActiveProducer`
+  (e.g. Nest, where go2rtc dials out to a cloud SFU), at 10s intervals
+  to balance keyframe freshness against upstream bandwidth/airtime. Also
+  sends an immediate PLI when the track is first set up, so cold-start
+  recovery doesn't have to wait for the first ticker fire.
+- **Why:** WebRTC SDP doesn't usually include `sprop-parameter-sets`, so
+  downstream RTSP consumers can't decode anything until an IDR (carrying
+  inline SPS/PPS) arrives. Without PLI requests, IDR cadence is on the
+  upstream sender's schedule — typically 30–60s for Google's Nest SFU.
+  This caused extended pixelation after a go2rtc restart while UniFi
+  reconnected and waited for Google's next scheduled keyframe. With the
+  fix, cold-start recovery is typically <5s.
+
+---
+
+## Nest Source
+
+### 9. Stream extension loops
+
+- **Files:** `pkg/nest/api.go`
+- **Change:** The `StartExtendStreamTimer` goroutine now loops, re-arming
+  the timer after each successful `ExtendStream()`. Previously the
+  goroutine waited for one timer fire, called `ExtendStream()` once, and
+  exited — so the stream died at the second Google-side expiry (~10 min
+  after connect).
+- **Why:** Google Nest Device Access streams expire ~5 minutes after the
+  last extension and must be re-extended before then. A single extension
+  bought 5 more minutes but no further; the loop now keeps the stream
+  alive indefinitely.
+
+### 10. Race-free Stop + retry on extension failure
+
+- **Files:** `pkg/nest/api.go`
+- **Change:** Added an `extendStop` channel to the `API` struct.
+  The extension goroutine uses `select` on both the timer and the stop
+  channel so `StopExtendStreamTimer()` cleanly unblocks the goroutine.
+  Timer reference is captured locally so a Stop-then-Start race can't
+  produce a nil-pointer panic on `Reset()`. On `ExtendStream()` failure,
+  the goroutine retries once after 10 seconds (interruptibly) before
+  giving up. Added an `extendDelay` helper that clamps the next-wakeup
+  duration to a 1-second minimum to prevent busy-looping if Google ever
+  returns a stale expiry.
+- **Why:** The previous implementation had a latent nil-deref race
+  between `Stop()` and the goroutine's `Reset()` call, and no resilience
+  against transient extension failures (a single Google 5xx would kill
+  the stream until next reconnect).
+
+---
+
+## Observability
+
+### 11. RTSP debug logs: source IP + User-Agent
+
+- **Files:** `internal/rtsp/rtsp.go`
+- **Change:** Added `remote=` (peer address) and `user_agent=` (from the
+  first request on the connection) structured fields to:
+  - `[rtsp] new consumer`
+  - `[rtsp] new producer`
+  - `[rtsp] handle <error>`
+  - `[rtsp] disconnect`
+  - `[rtsp]` consumer add-track error
+- **Why:** When multiple clients connect to a single stream (UniFi from
+  several IPs, an internal ffmpeg loop, an occasional VLC test), the
+  default `[rtsp] new consumer stream=driveway` log line gave no way to
+  tell which session was which. With the new fields, sessions are
+  trivially greppable by `remote=192.168.5.1` or
+  `user_agent=GStreamer/1.26.10`.
+
+### 12. Structured logging across HTTP / WebSocket / ONVIF / MP4
+
+- **Files:** `internal/onvif/onvif.go`, `internal/api/api.go`,
+  `internal/mp4/mp4.go`, `internal/api/ws/ws.go`
+- **Change:** Converted positional log lines to structured fields with
+  `remote=`, `user_agent=`, and operation-specific context:
+  - `[onvif] server request` (trace) — adds `remote`, `user_agent`, `op`
+  - `[onvif] unsupported operation` (warn) — adds `remote`, `user_agent`, `op`
+  - `[api] request` middleware (trace) — restructured with `method`,
+    `url`, `remote`, `user_agent`
+  - `[mp4] request` handler (trace) — restructured with `method`, `url`,
+    `remote`, `user_agent`
+  - `[api] ws upgrade` (error) — adds `remote`, `user_agent`
+  - `[api] ws msg` (trace) — adds `remote`
+- **Why:** Consistent observability across all client-facing surfaces.
+  Same grep patterns work for any client interaction regardless of
+  protocol.
+
+---
+
+## Suggested upstream PR grouping
+
+If contributing back to AlexxIT/go2rtc, these changes group naturally
+into five focused PRs:
+
+1. **ONVIF improvements** — items 1, 2, 3, 4
+2. **RTSP compliance + keepalives** — items 5, 6, 7
+3. **Nest source robustness** — items 9, 10
+4. **WebRTC PLI for active producers** — item 8
+5. **Observability** — items 11, 12
+
+Each PR is independent of the others (no cross-dependencies between
+groups) and addresses a coherent area.
+
+---
+
+## Build verification
+
+All changes compile under Go 1.25 with no new dependencies. Built and
+deployed continuously through the debugging session against the
+production go2rtc Docker image (`docker/Dockerfile`, multi-stage build).
+No new tests added — existing unit tests in `pkg/onvif/onvif_test.go`,
+`pkg/rtsp/rtsp_test.go`, and `pkg/rtsp/client_test.go` continue to pass.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -221,10 +221,38 @@ groups) and addresses a coherent area.
 
 ---
 
+## Test coverage
+
+Five new tests added in `pkg/onvif/onvif_test.go` covering the
+ONVIF server-side changes:
+
+- `TestGetPosixTZ` — pure-function test of the new POSIX TZ
+  formatter. Covers UTC, west/east-of-UTC standard offsets,
+  half-hour offsets (NST, IST), and the empty-zone-name fallback.
+  Uses `time.FixedZone()` so test results are deterministic
+  regardless of the host machine's TZ.
+- `TestGetCapabilitiesResponse` — verifies all three services
+  (Device, Media, Imaging) appear in the GetCapabilities response.
+- `TestGetServicesResponse` — verifies all three WSDL namespaces
+  and service URLs appear in the GetServices response.
+- `TestGetProfilesResponseIncludesAudio` — regression guard for
+  the AudioSourceConfiguration + AudioEncoderConfiguration blocks
+  in `appendProfile`. Without these, UniFi Protect won't negotiate
+  the audio track during RTSP SETUP.
+- `TestImagingResponses` + `TestStaticResponseRoutesImagingOps`
+  — verify imaging stubs use the `timg:` namespace and that the
+  operation-name dispatcher routes correctly.
+
+No new tests added for the other packages — RTSP / WebRTC / Nest
+changes either touch connection-level code that needs heavy mocking
+to exercise (PLI sending, GET_PARAMETER keepalives, Nest extension
+loop), or pure-state changes (session ID consistency, 501 response)
+that exercise via real-world integration testing. All existing
+tests in `pkg/onvif/onvif_test.go`, `pkg/rtsp/rtsp_test.go`,
+`pkg/rtsp/client_test.go` continue to pass.
+
 ## Build verification
 
 All changes compile under Go 1.25 with no new dependencies. Built and
 deployed continuously through the debugging session against the
 production go2rtc Docker image (`docker/Dockerfile`, multi-stage build).
-No new tests added — existing unit tests in `pkg/onvif/onvif_test.go`,
-`pkg/rtsp/rtsp_test.go`, and `pkg/rtsp/client_test.go` continue to pass.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -807,3 +807,36 @@ pass.
 All changes compile under Go 1.25 with no new dependencies. Built and
 deployed continuously through the debugging session against the
 production go2rtc Docker image (`docker/Dockerfile`, multi-stage build).
+
+---
+
+## CI / Build
+
+### 16. Weekly scheduled rebuild for CVE refresh
+
+- **Files:** `.github/workflows/build.yml`
+- **Change:** The Docker-image workflow gains two coupled additions:
+  - A `schedule:` trigger (`cron: '0 4 * * 0'` — Sunday 04:00 UTC)
+    alongside the existing `workflow_dispatch` and `push` triggers,
+    so the published image is rebuilt weekly even when no commits
+    land.
+  - `pull: true` on the `docker/build-push-action@v6` step so the
+    base layers (`FROM golang:${GO_VERSION}-alpine` and
+    `FROM python:${PYTHON_VERSION}-alpine`) re-resolve against the
+    registry on every build. Without this the GitHub-Actions layer
+    cache can indefinitely re-use a vulnerable `apk add` layer
+    because the cache key matches the unchanged instruction text;
+    `pull: true` bumps the parent layer SHA whenever Alpine ships
+    a refreshed base image, which invalidates downstream cache and
+    forces `apk` to re-install at current package versions.
+- **Why:** Tagged releases of go2rtc are infrequent. Between
+  releases, the `master` and `latest` images' OS package set was
+  frozen at the last code push to `master`, while Alpine ships
+  CVE-fix updates constantly. Combining the weekly rebuild with
+  `pull: true` gives a predictable CVE-refresh cadence without
+  needing a code change.
+- **Source:** Pattern adopted from open upstream pull request
+  https://github.com/AlexxIT/go2rtc/pull/2242. The fork's
+  workflow is Docker-only (no `build-binaries` job), so the
+  trade-off the upstream PR's author noted does not apply here.
+- **No code change, no test impact.**

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -182,11 +182,31 @@ as the primary client/source combination.
   the producer (~6s for Nest WebRTC), often timing out and entering
   a long back-off cycle (observed 7-minute recording gaps).
   To prevent this, `kickConsumers()` bumps the `s.pending` counter
-  for a 30-second grace window — long enough for typical UniFi
-  reconnect (1–3s) plus margin for cloud-API throttling on
-  successive Nest WebRTC re-establishments. `stopProducers()` already
+  for a 2-minute grace window. `stopProducers()` already
   short-circuits when `pending > 0`, so the producer stays warm and
   the reconnecting client lands cleanly on it.
+  2 minutes is sized for the worst case observed in practice: when
+  UniFi Protect's RTSP session closes shortly after opening (e.g. a
+  natural reconnect followed by a kick ~10s later), it interprets
+  this as server instability and enters an extended retry back-off
+  (empirically ~60–90s before re-DESCRIBE). An earlier 30s grace
+  window expired during this back-off, the producer stopped, and
+  when UniFi finally retried it hit a cold producer and timed out
+  again — repeating the recording gap. 2 minutes covers this case
+  with margin. Trade-off: an orphan producer keeps streaming from
+  upstream for up to 2 minutes (~50–200 kbps for a typical Nest
+  stream); cheap compared to recording gaps that require manual
+  intervention.
+- **Internal-loop consumer skip:** Recursive pipelines like
+  `ffmpeg:driveway` (an ffmpeg subprocess that reads from
+  `rtsp://localhost/driveway` and is registered as a consumer of the
+  driveway stream while *also* being a producer of it) need special
+  handling. Kicking the inner ffmpeg subprocess on producer reconnect
+  killed its stdout → producer EOF'd → triggered another reconnect →
+  kicked again → infinite ~5-per-second loop. Fix: in
+  `kickConsumers()` skip any consumer whose `GetSource()` matches one
+  of this stream's producer URLs. Matches the existing loop-protection
+  check in `AddConsumer`.
 - **Earlier failed attempt (now reverted):** A `SetReadDeadline()`-
   based fast silence detection (commits 58f1495, 9a1ad59, 1254ea9)
   tried to reduce the ~95s detection latency for terminal silences.
@@ -195,13 +215,51 @@ as the primary client/source combination.
   relied on. The kick-consumers fix in this commit addresses the
   underlying codec-refresh problem directly, so fast detection could
   be safely re-introduced in a follow-up if desired.
-- **Test coverage:** `TestKickConsumers` (4 sub-tests: empty,
-  multiple, no list mutation, grace-period pending bump/release),
+- **Test coverage:** `TestKickConsumers` (6 sub-tests: empty,
+  multiple, no list mutation, internal-loop consumer is skipped,
+  no grace-period bump when only internal consumers,
+  grace-period pending bump/release),
   `TestNewStreamLinksProducers` (3
   sub-tests: single string, []string, []any construction paths),
   `TestRedactSourceURL` (6 sub-tests covering nest, rtsp with auth,
   ffmpeg, fragment-only, empty). Uses a `mockConsumer` implementing
   `core.Consumer` with an atomic Stop counter.
+
+### 8b-1. Kick on reconnect: disabled by default (UniFi 7.1.69 regression)
+
+- **Files:** `internal/streams/producer.go`, `internal/streams/streams.go`
+- **Change:** The auto-kick described in section 8b is now gated by
+  the `GO2RTC_KICK_ON_RECONNECT` environment variable. Default:
+  **off**. At startup the active mode is logged at info level
+  (`[streams] kick on producer reconnect: disabled — set
+  GO2RTC_KICK_ON_RECONNECT=true to re-enable for legacy RTSP
+  clients`).
+- **Why:** Empirical regression after upgrading UniFi Protect to
+  7.1.69. A nest WebRTC reconnect at 19:01:36 triggered the kick
+  (correct: 2 UniFi RTSP sessions closed). Pre-7.1.69, UniFi
+  re-DESCRIBEd within 1–3s. On 7.1.69, **UniFi made zero RTSP
+  reconnect attempts** during the entire 2-minute grace window
+  even though the snapshot poll endpoint kept responding — so the
+  recording session was severed permanently and the grace period
+  bandaged no wound. The new heartbeat (section 13) confirmed
+  nest's H264/OPUS packet rates were fully healthy after reconnect;
+  the only thing missing was UniFi.
+- **Hypothesis:** UniFi 7.1.69 either (a) interprets a
+  server-initiated TCP close as intentional and stops retrying,
+  or (b) trusts its GStreamer 1.26+ H.264 parser to handle
+  in-band SPS/PPS changes via RTP. Either way, the kick is now
+  counterproductive for that client. Pre-7.1.69 UniFi and other
+  RTSP clients that genuinely can't handle in-band parameter
+  changes can opt back in with the env var.
+- **Trade-off:** If the new nest connection's SPS/PPS differ from
+  the previous one and the RTSP client cannot pick up the change
+  from in-band parameter sets, video stays frozen until the
+  client itself disconnects (UniFi 7.1.69 reportedly does this
+  on its own when frames stop arriving — needs verification in
+  next outage).
+- **No test changes:** The existing `TestKickConsumers` exercises
+  `kickConsumers()` directly and is unaffected by the gate, which
+  sits one layer up in `Producer.reconnect()`.
 
 ### 8c. Streams logging: info/warn levels + credential redaction
 
@@ -281,6 +339,36 @@ as the primary client/source combination.
   against transient extension failures (a single Google 5xx would kill
   the stream until next reconnect).
 
+### 10b. OAuth 401 refresh in ExtendStream + token-cache eviction fix
+
+- **Files:** `pkg/nest/api.go`
+- **Change:** Two coupled fixes around Google OAuth bearer-token expiry.
+  - **`ExtendStream()` now handles 401.** On a 401 response, it calls
+    `refreshToken()` and retries the request once with the new token.
+    Mirrors the existing 401 handling in `ExchangeSDP()`. The retry
+    uses a helper closure so the same `*http.Request` body isn't
+    drained twice.
+  - **`refreshToken()` rewritten to actually refresh.** The previous
+    implementation called `NewAPI()` to "get a new token" — but
+    `NewAPI()`'s cache returns the same `*API` instance when the
+    recorded `ExpiresAt` is still in the future, so the "refreshed"
+    token was identical to the stale one. The new implementation
+    bypasses the cache entirely: POSTs directly to the Google OAuth
+    token endpoint and mutates `a.Token` + `a.ExpiresAt` in place.
+    Serialized via a new `refreshMu` so concurrent 401s fold into a
+    single refresh request.
+- **Why:** Google OAuth access tokens for the Smart Device Management
+  API expire after ~60 minutes. Each Nest stream session also runs
+  up to ~60 minutes, so it's normal for an extend to land on a
+  freshly-expired token — empirically observed (2026-05-22 09:36
+  outage): an extend after the OAuth boundary 401'd, the broken
+  `refreshToken()` no-op'd, the retry 401'd again, the extend
+  goroutine gave up, and the stream silently died at its next
+  `expires_at`. With the fix, the same boundary now shows
+  `[nest] extend got 401, refreshing OAuth token` → `[nest] OAuth
+  token refreshed` → `[nest] extend ok` in quick succession; stream
+  continues uninterrupted.
+
 ---
 
 ## Observability
@@ -335,6 +423,216 @@ as the primary client/source combination.
   Same grep patterns work for any client interaction regardless of
   protocol.
 
+### 12b. Proactive reconnect ahead of Nest's stream-lifetime cap
+
+- **Files:** `pkg/core/core.go`, `internal/streams/producer.go`,
+  `pkg/nest/client.go`
+- **Change:** Two-part addition that eliminates the ~30-40 s
+  recording gap that recurred every ~66 minutes on the Nest
+  → go2rtc → UniFi Protect pipeline:
+  - **`core.LifetimeLimited` interface** — an optional hook
+    `SetReconnectCallback(cb func())` that producers implement to
+    receive a proactive-reconnect trigger from the wrapping
+    `streams.Producer`. Generic, not Nest-specific; any source
+    with a known stream-lifetime cap can opt in.
+  - **`streams.Producer.proactiveReconnect()`** — bumps `workerID`
+    so the soon-to-exit old worker's post-Start `reconnect()`
+    call no-ops, then runs the standard `reconnect()` flow. That
+    flow is already overlap-friendly: new conn via `GetProducer`,
+    tracks moved via `Receiver.Replace()` before the old conn is
+    stopped. Consumers see only the brief `GetProducer` window
+    (~3 s for Nest), not the previous ~30-40 s detection chain.
+    Callback registration happens in `start()` (initial conn)
+    and again in `reconnect()` (post-swap onto the new conn) so
+    every lifetime cycle is caught.
+  - **Nest `WebRTCClient` / `RTSPClient` implement
+    `LifetimeLimited`.** Each `Start()` arms a one-shot
+    `time.AfterFunc(refreshBeforeCap, ...)` (default: 55 minutes,
+    package-var for tests). When the timer fires, the wrapped
+    producer's `proactiveReconnect()` is invoked in a fresh
+    goroutine so the timer runner isn't blocked by the network
+    work. `Stop()` cancels the timer. `sync.Once`-like
+    `refreshFired` guard prevents double-fire under odd shutdown
+    orderings.
+- **Why:** Google's Nest Smart Device Management API caps a single
+  WebRTC stream at ~60 minutes from initial `GenerateWebRtcStream`,
+  regardless of how often `ExtendWebRtcStream` is called. Past
+  that cap, the upstream silently stops delivering packets and the
+  current reconnect path takes ~30-40 s to notice and recover
+  (inner-ffmpeg 5 s read timeout → 3 retries × 10 s → finally
+  declare EOF → producer reconnect). Empirically observed gap
+  cadence: **01:59, 03:05, 04:11, 05:17, 06:23, 07:30 — exactly
+  ~66 minutes apart**. A proactive refresh at 55 min hits while
+  upstream is still healthy, allowing the swap to complete inside
+  the producer's already-overlap-friendly reconnect flow before
+  the old session goes silent.
+- **Why a generic interface, not a Nest-only hook:** The same
+  pattern applies to any cloud-mediated stream with a session
+  lifetime (Ring, Arlo, Tuya, etc. all have analogous limits).
+  Putting `LifetimeLimited` on `pkg/core` lets each producer opt
+  in without touching the streams package — only the producer
+  itself knows its lifetime contract.
+- **Safety:** `workerID` bump under the producer mutex guarantees
+  the old worker's post-Start `reconnect()` no-ops; otherwise it
+  would race the proactive reconnect into producing a second
+  fresh connection. The previous overlap-friendly reconnect flow
+  is unchanged.
+- **No new tests:** The wiring is small (callback registration on
+  start/reconnect, a one-shot timer in nest client). The
+  user-facing test is the next ~66 min interval after
+  deployment: the gap should either disappear or shrink
+  to seconds.
+
+### 13. Producer activity heartbeat + stopProducers decision trace
+
+- **Files:** `internal/streams/producer.go`, `internal/streams/stream.go`
+- **Change:** Two diagnostic logging additions targeting the
+  "silent stall" failure class — where upstream looks healthy
+  (no EOF, no read-deadline fire) and consumers stay attached, but
+  recording freezes anyway.
+  - **Producer activity heartbeat (debug, every 60s).** Each active
+    producer logs one line per receiver with packet/byte deltas since
+    the previous tick: `[streams] producer activity source=…
+    track=0 codec=H264 dpackets=N dbytes=N total_packets=N`. When
+    `dpackets=0` for a track while a sibling track keeps ticking, the
+    smoking gun is unambiguous (e.g. video frozen, audio flowing —
+    a UniFi+Nest failure mode where prior logs were silent).
+    Heartbeat runs in its own goroutine started from `start()`,
+    exits when `workerID` advances (next cycle or stop). Cadence
+    exposed as `activityInterval` for tests.
+  - **stopProducers decision trace (trace).** Each call now logs
+    `[streams] stopProducers stopped=N kept=N` (skipping the line
+    only when both are zero), so a `RemoveConsumer` that kept all
+    producers alive because senders held them up is distinguishable
+    from one that wasn't triggered. Previously the function was
+    silent in that case.
+  - **Consumer-removed remaining count (trace).** `RemoveConsumer`
+    emits `[streams] consumer removed remaining=N`. The per-transport
+    disconnect log (`[rtsp] disconnect …`) records who left but not
+    the stream's resulting consumer count — without that, a
+    `producer.stop()` that follows can't be tied to the last-consumer
+    teardown vs. one of several simultaneous removals.
+- **Why:** A failure at ~15:20 with the kick fix already deployed
+  showed two blind spots in the existing logs:
+  1. After the kick + reconnect, ffmpeg ADTS warnings (audio) kept
+     appearing for ~17 minutes — so audio was flowing — but we had
+     no way to tell whether video was also flowing. UniFi recording
+     was frozen the whole window. The heartbeat would have shown
+     `dpackets=0` on the H264 track immediately.
+  2. Between the last ADTS warning and the next consumer attach,
+     ~6 minutes elapsed with no log activity. The stopProducers /
+     RemoveConsumer traces close that gap by surfacing the decision
+     branches that were previously implicit.
+- **No new tests:** Both additions are diagnostic logs at debug/trace
+  level with no behavior change; covered by existing tests
+  (compilation + `TestKickConsumers`).
+
+### 14. Structured logging for Nest OAuth/extend lifecycle
+
+- **Files:** `pkg/nest/api.go`, `pkg/nest/client.go`,
+  `internal/nest/init.go`
+- **Change:** Added a package-level `nest.Log` callback (default
+  no-op so `pkg/nest` stays importable without a logging
+  dependency) and wired it up from `internal/nest/init.go` to the
+  application zerolog instance. Used to surface the previously-
+  silent OAuth/extend lifecycle:
+  - `[nest] OAuth cache hit` / `OAuth acquiring new token` (debug)
+  - `[nest] OAuth token acquired expires_at=... ttl=...` (info)
+  - `[nest] OAuth token request rejected status=...` (error)
+  - `[nest] OAuth token refresh starting previous_expires_at=...
+    since_predicted_expiry=...` (debug)
+  - `[nest] OAuth refresh transport error` / `OAuth refresh
+    rejected status=...` (error)
+  - `[nest] OAuth token refreshed new_expires_at=... new_ttl=...`
+    (info)
+  - `[nest] extend timer armed expires_at=... next_fire_in=...
+    session=...` (debug)
+  - `[nest] extend ok expires_at=... next_fire_in=... session=...`
+    (debug)
+  - `[nest] extend failed, retrying in 10s` (warn)
+  - `[nest] extend giving up — stream will die at expires_at`
+    (error)
+  - `[nest] extend got 401, refreshing OAuth token
+    predicted_expires_at=... until_predicted_expiry=...` (info) —
+    sign of `until_predicted_expiry` distinguishes "Google rotated
+    the token earlier than we predicted" (positive) from "we let
+    the token lapse past our own prediction" (negative, expected
+    on the lazy 60-min boundary)
+  - `[nest] extend timer cancelled` / `extend goroutine stopped`
+    (debug)
+  - `[nest] refresh timer fired — triggering proactive reconnect
+    age=55m0s session=...` (info)
+- **Why:** Before this, both successful extends and OAuth refreshes
+  were completely silent, and failure cases produced only a generic
+  error string with no context. The 2026-05-22 09:36 outage took
+  ~10 message turns to diagnose because we were guessing whether
+  extends were firing at all; with this logging, the next OAuth-
+  boundary issue (12:51) was diagnosed from a single grep through
+  the log.
+
+---
+
+## Core / RTP
+
+### 15. RTP continuity rewriting across upstream session swaps
+
+- **Files:** `pkg/core/track.go`, `pkg/core/track_test.go`,
+  `pkg/core/helpers.go`
+- **Change:** `core.Receiver` now rewrites outgoing RTP packets so
+  downstream consumers see a single continuous stream across
+  upstream session swaps (`Receiver.Replace()`, triggered by
+  `Producer.reconnect()` — including the proactive reconnect on
+  lifetime-limited sources, section 12b). Specifically:
+  - **Stable outgoing SSRC.** Each `Receiver` picks a random 32-bit
+    SSRC at creation; that SSRC stays constant for the receiver's
+    lifetime and is transferred to successor receivers in
+    `Receiver.Replace()`. Downstream consumers see one SSRC for
+    the entire duration of their consumer-side session.
+  - **Continuous sequence numbers.** On detected upstream SSRC
+    change, the first packet of the new session is rewritten to
+    `lastOutgoingSeq + 1`. Subsequent packets follow the new
+    session's relative spacing, so jitter buffers see a
+    monotonically advancing sequence space.
+  - **Forward-advancing timestamps.** On the same boundary, the
+    first packet's timestamp is rewritten to `lastOutgoingTS +
+    (codec.ClockRate × wall-clock elapsed)`, clamped to a sane
+    range. This preserves codec-rate spacing across the swap
+    rather than producing a backwards jump or a zero-duration
+    burst.
+  - **No-op for non-RTP codecs.** Gated by `codec.IsRTP()`; raw-
+    payload pipelines (`PayloadTypeRAW`) are untouched.
+  - **Test coverage:** `TestReceiverRTPContinuity` (5 sub-tests:
+    non-RTP passthrough, single-session passthrough, mid-stream
+    SSRC change anchoring, relative-spacing preservation after a
+    swap, Replace state transfer to successor).
+  - **Drive-by:** added missing `StripUserinfo` helper that had a
+    test (`TestStripUserinfo`) but no implementation; was blocking
+    the `pkg/core` test build.
+- **Why:** UniFi Protect 7.1.69's RTSP recording subsystem treats an
+  SSRC change mid-session as "the stream I was recording has
+  ended" and stops writing to disk — even though the RTSP/TCP
+  session stays alive and packets keep arriving. Empirically
+  confirmed (2026-05-22 12:43 outage): the proactive reconnect
+  ran cleanly, the new Nest WebRTC session was healthy, extends
+  worked, and go2rtc was forwarding packets — but UniFi's recorder
+  silently stopped at the moment of the SSRC change. With the
+  continuity rewrite, the proactive reconnect is invisible at the
+  RTP layer; UniFi keeps writing straight through. Empirical
+  validation: 6+ hours of continuous recording across multiple
+  proactive reconnects, with the only stoppage attributable to a
+  separate UniFi Protect bug (RTSP-client freeze affecting all
+  3rd-party cameras simultaneously, recovered by Protect restart).
+- **Why at the Receiver level, not per-Sender:** All consumers of a
+  producer's track see the same Receiver. Rewriting once in the
+  Receiver's `Input` closure means a single state machine handles
+  every downstream consumer; per-Sender rewriting would require
+  cloning each packet per consumer (allocation cost on every RTP
+  packet) and per-consumer state machines. Trade-off: every
+  consumer of a given Receiver sees the same outgoing SSRC. That's
+  fine for typical setups (one upstream, several downstream
+  consumers); if per-consumer SSRC ever becomes a requirement, the
+  rewrite can be moved into the Sender path.
+
 ---
 
 ## Test coverage
@@ -359,13 +657,31 @@ ONVIF server-side changes:
   — verify imaging stubs use the `timg:` namespace and that the
   operation-name dispatcher routes correctly.
 
-No new tests added for the other packages — RTSP / WebRTC / Nest
-changes either touch connection-level code that needs heavy mocking
-to exercise (PLI sending, GET_PARAMETER keepalives, Nest extension
-loop), or pure-state changes (session ID consistency, 501 response)
-that exercise via real-world integration testing. All existing
-tests in `pkg/onvif/onvif_test.go`, `pkg/rtsp/rtsp_test.go`,
-`pkg/rtsp/client_test.go` continue to pass.
+Additional tests added in this iteration:
+
+- `pkg/core/track_test.go::TestReceiverRTPContinuity` (5 sub-tests)
+  — covers the RTP rewriting (section 15): non-RTP passthrough,
+  single-session passthrough, mid-stream SSRC change anchoring,
+  relative-spacing preservation, and Replace state transfer to
+  successor.
+- `internal/streams/stream_test.go::TestKickConsumers` (6 sub-tests
+  including internal-loop-skip and grace-period bump/release —
+  see section 8b/8b-1).
+- `internal/streams/stream_test.go::TestNewStreamLinksProducers`
+  (3 sub-tests covering producer back-reference wiring).
+- `internal/streams/stream_test.go::TestRedactSourceURL` (6 sub-
+  tests covering nest, rtsp+auth, ffmpeg, fragment-only, empty).
+
+No new tests added for the OAuth refresh path (section 10b),
+proactive reconnect wiring (section 12b), or per-producer
+heartbeat (section 13) — these touch goroutine/network paths
+that need heavy mocking to exercise, and are validated by the
+end-to-end integration testing the debugging session amounted to
+(6+ hours of continuous operation across multiple proactive
+reconnects + OAuth boundaries). All existing tests in
+`pkg/onvif/onvif_test.go`, `pkg/rtsp/rtsp_test.go`,
+`pkg/rtsp/client_test.go`, `pkg/core/track_test.go` continue to
+pass.
 
 ## Build verification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,16 +130,14 @@ primary client/source combination.
   reconnected and waited for Google's next scheduled keyframe. With the
   fix, cold-start recovery is typically <5s.
 
-### 8b. Silent-stream detection for ActiveProducer sources
+### 8b. Silent-stream detection for ActiveProducer video tracks
 
 - **Files:** `pkg/webrtc/conn.go`
-- **Change:** Added a 10-second `SetReadDeadline()` on the
+- **Change:** Added a 20-second `SetReadDeadline()` on the
   `TrackRemote.Read()` call in the OnTrack loop, applied only for
-  `ModeActiveProducer`. When the deadline fires, the peer connection
-  is closed, which triggers `OnConnectionStateChange` → standard
-  reconnect cascade. PassiveProducer (browser → go2rtc) keeps the
-  blocking-read behaviour because legitimate silence (user mute,
-  paused webcam) is common.
+  `ModeActiveProducer` *and only on the video track*. When the
+  deadline fires, the peer connection is closed, which triggers
+  `OnConnectionStateChange` → standard reconnect cascade.
 - **Why:** Nest's cloud SFU occasionally stops sending RTP but keeps
   the WebRTC peer connection technically alive (ICE keepalives still
   flowing, no `Disconnected` state event from pion). Without an
@@ -148,8 +146,18 @@ primary client/source combination.
   (audio ffmpeg, UniFi) timed out one by one. Recovery only happened
   ~95 seconds later when pion's failure-detection timer maxed out and
   fired the state change. With the deadline, recovery completes in
-  ~17 seconds (10s deadline + ~6s for Nest WebRTC re-establishment),
-  a 5-6x improvement in observed recording-gap duration.
+  ~25 seconds (20s deadline + ~6s for Nest WebRTC re-establishment).
+- **Why video-only:** WebRTC Opus encoders commonly use DTX
+  (discontinuous transmission); legitimate room silence produces zero
+  audio packets. An initial implementation applied the deadline to
+  all tracks and incorrectly tore down the connection every time the
+  scene went acoustically quiet, killing the video stream that was
+  working fine. Video tracks have no equivalent legitimate-silence
+  scenario — with PLI requests every 10s (item 8 above), an IDR
+  should arrive every ~10s minimum.
+- **Why PassiveProducer is exempt:** browser-pushed sources may
+  legitimately go silent on both audio (mute) and video (camera off),
+  and forcing reconnect there would be wrong.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -103,16 +103,30 @@ as the primary client/source combination.
   leak camera-setup details to unauthenticated callers. This is
   upstream behaviour, not specific to this fork; the note exists
   to make the implicit explicit. No code change.
-- **Upstream fix in progress (not adopted here):** the open
-  pull request https://github.com/AlexxIT/go2rtc/pull/2231 adds
-  WS-Security `UsernameToken` validation to the ONVIF server,
-  gated by dedicated `onvif.username` / `onvif.password` config
-  keys and with a `GetSystemDateAndTime` carve-out so clients
-  can compute clock skew before generating password digests.
-  Tracking the PR rather than merging it locally — this fork
-  prefers to wait for upstream review. The README links to the
-  PR so operators who need authenticated ONVIF in their own
-  deployment know where to find a reference implementation.
+- **Superseded by [4c](#4c-ws-security-usernametoken-authentication-for-onvif-server):**
+  this fork has since implemented WS-Security `UsernameToken`
+  validation (see below) rather than waiting on upstream PR
+  https://github.com/AlexxIT/go2rtc/pull/2231.
+
+### 4c. WS-Security UsernameToken authentication for ONVIF server
+
+- **Files:** `pkg/onvif/envelope.go`, `pkg/onvif/server.go`,
+  `internal/onvif/onvif.go`, `internal/onvif/README.md`
+- **Change:** New `onvif.username` / `onvif.password` config keys
+  (separate from the WebUI/JSON-API `api.username` /
+  `api.password` Basic auth). When set, `VerifyUsernameToken`
+  checks every ONVIF operation's `wsse:UsernameToken` header
+  (PasswordDigest: `Base64(SHA1(nonce + created + password))`)
+  against the configured credentials, rejecting stale
+  (>5 minute skew) or mismatched tokens with a SOAP
+  `ter:NotAuthorized` fault and HTTP 401.
+  `GetSystemDateAndTime` is exempted so clients can learn the
+  server's clock before computing a digest against it.
+- **Why:** The ONVIF server previously dispatched every operation
+  regardless of credentials (see 4b). Real ONVIF clients (NVRs,
+  Home Assistant) authenticate via WS-Security, not HTTP Basic,
+  so `api.username`/`api.password` can't protect this endpoint —
+  dedicated ONVIF-native auth was needed.
 
 ---
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,7 +121,13 @@ as the primary client/source combination.
   (>5 minute skew) or mismatched tokens with a SOAP
   `ter:NotAuthorized` fault and HTTP 401.
   `GetSystemDateAndTime` is exempted so clients can learn the
-  server's clock before computing a digest against it.
+  server's clock before computing a digest against it. Digest
+  comparison uses `crypto/subtle.ConstantTimeCompare` (not `==`)
+  to avoid a timing side-channel, and a bounded in-memory cache
+  of seen (username, nonce, created) triples rejects replays of
+  a captured token within its freshness window; a future-dated
+  `Created` gets only 30s of clock-skew grace rather than the
+  full 5-minute window.
 - **Why:** The ONVIF server previously dispatched every operation
   regardless of credentials (see 4b). Real ONVIF clients (NVRs,
   Home Assistant) authenticate via WS-Security, not HTTP Basic,

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
   </a>
 </p>
 
+> **This is a personal fork** of [AlexxIT/go2rtc](https://github.com/AlexxIT/go2rtc)
+> carrying additional reliability and observability changes — primarily targeting
+> the Nest WebRTC → go2rtc → UniFi Protect pipeline, but most fixes are
+> general-purpose and apply to any RTSP/ONVIF client or any Nest source.
+> See [CHANGES.md](CHANGES.md) for the full list of differences from upstream.
+
 Ultimate camera streaming application with support for dozens formats and protocols.
 
 - zero-dependency [small app](#go2rtc-binary) for all OS (Windows, macOS, Linux, FreeBSD)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,109 @@
+# Example docker-compose.yml for the geekho-me/go2rtc fork.
+#
+# This fork carries additional reliability and observability changes
+# documented in ../CHANGES.md. The image is rebuilt weekly by the CI
+# workflow (Sunday 04:00 UTC) so the `:latest` tag picks up Alpine
+# CVE fixes between tagged releases — schedule a periodic
+# `docker compose pull && docker compose up -d` on your host (or use
+# watchtower / similar) to actually adopt those refreshes.
+#
+# Before bringing this up:
+#   1. Edit the network/IP/MAC below to match your environment.
+#      The MAC and IP MUST be unique on your network; don't copy
+#      the placeholders verbatim into a production stack.
+#   2. If you need FFmpeg hardware acceleration, add back the
+#      `devices:` and `group_add:` blocks shown in the note below
+#      the `restart:` line. The default config below assumes
+#      software-only transcoding.
+#
+# Configuration is managed from the go2rtc WebUI (Configuration
+# section at http://<container-ip>:1984/), not by editing the
+# YAML file on disk — so the /config volume below just needs to
+# persist; no bind mount required.
+
+services:
+  go2rtc:
+    image: ghcr.io/geekho-me/go2rtc:latest
+    container_name: go2rtc
+    restart: unless-stopped
+
+    environment:
+      # Set to your timezone — affects timestamps in logs.
+      - TZ=Europe/London
+
+    # 256 MB × 4 files ≈ 1 GB of rolling logs per container. The
+    # Docker default (10 MB, 1 file) fills in minutes once
+    # --log.level=debug is on — and several of this fork's
+    # diagnostic logs (producer activity heartbeats, OAuth/extend
+    # lifecycle, etc.) are debug-level. Increase further if you
+    # need more debugging history.
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "256m"
+        max-file: "4"
+
+    volumes:
+      # Named volume declared at the bottom of this file. Persists
+      # the in-app configuration across container recreation;
+      # inspect the on-host path with `docker volume inspect go2rtc`
+      # if you ever need to back it up or migrate it.
+      - go2rtc:/config
+
+    # Healthcheck against go2rtc's internal HTTP API. If the API
+    # stops responding (process panic, deadlock, etc.), Docker
+    # marks the container unhealthy — combine with
+    # `restart: unless-stopped` plus an external orchestrator
+    # (watchtower / docker-autoheal / systemd) for automatic
+    # recovery. The /api endpoint returns 200 even with no
+    # configured streams. curl is already installed in the image
+    # via docker/Dockerfile's `apk add` line.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:1984/api"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+    networks:
+      server_vlan:
+        # CHANGE BOTH to match your network. The IP must be on the
+        # same subnet as `server_vlan` (defined out-of-band as an
+        # external macvlan — see the networks block below) and
+        # must be unused elsewhere on that subnet.
+        ipv4_address: 192.168.1.100
+
+        # Locally-administered MAC (first octet 02, second-least-
+        # significant bit set). Pick a unique value for each
+        # container you deploy — DHCP reservations and MAC-based
+        # firewall rules upstream of the host depend on it being
+        # stable AND unique. The example below is a deliberately
+        # obvious placeholder.
+        mac_address: 02:42:00:00:00:01
+
+# Named volume holding /config. Without this top-level declaration
+# Compose rejects the `go2rtc:/config` reference under services as
+# "invalid compose project: refers to undefined volume go2rtc".
+volumes:
+  go2rtc:
+
+networks:
+  # Pre-existing macvlan network on your host. Create it once with
+  # (adjust subnet/gateway/parent for your network):
+  #   docker network create -d macvlan \
+  #     --subnet=192.168.1.0/24 --gateway=192.168.1.1 \
+  #     -o parent=eth0 server_vlan
+  #
+  # `external: true` means Compose won't try to manage this
+  # network's lifecycle — it just references it. If you'd rather
+  # have Compose create the network, drop `external: true` and add
+  # the full `driver: macvlan` + `driver_opts:` + `ipam:` block
+  # here.
+  #
+  # Macvlan gives the container its own IP on your LAN, which
+  # means ports 1984 (HTTP/WebUI), 8554 (RTSP), and 8555 (WebRTC,
+  # TCP+UDP) are reachable directly via the container's IP — no
+  # `ports:` mapping needed. If you switch to a different network
+  # type (bridge, host), revisit port exposure accordingly.
+  server_vlan:
+    external: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,15 +11,6 @@
 #   1. Edit the network/IP/MAC below to match your environment.
 #      The MAC and IP MUST be unique on your network; don't copy
 #      the placeholders verbatim into a production stack.
-#   2. If you need FFmpeg hardware acceleration, add back the
-#      `devices:` and `group_add:` blocks shown in the note below
-#      the `restart:` line. The default config below assumes
-#      software-only transcoding.
-#
-# Configuration is managed from the go2rtc WebUI (Configuration
-# section at http://<container-ip>:1984/), not by editing the
-# YAML file on disk — so the /config volume below just needs to
-# persist; no bind mount required.
 
 services:
   go2rtc:

--- a/go2rtc.yaml.example
+++ b/go2rtc.yaml.example
@@ -1,0 +1,13 @@
+log:
+  level: info
+
+rtsp:
+  default_query: "video&audio=aac"
+
+ffmpeg:
+  rtsp: "-fflags nobuffer+discardcorrupt -flags low_delay -err_detect ignore_err -timeout {timeout} -user_agent go2rtc/ffmpeg -rtsp_flags prefer_tcp -i {input}"
+
+streams:
+  driveway:
+    - nest:?client_id=...
+    - ffmpeg:driveway#audio=aac

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -200,7 +200,12 @@ var log zerolog.Logger
 
 func middlewareLog(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Trace().Msgf("[api] %s %s %s", r.Method, r.URL, r.RemoteAddr)
+		log.Trace().
+			Str("method", r.Method).
+			Stringer("url", r.URL).
+			Str("remote", r.RemoteAddr).
+			Str("user_agent", r.Header.Get("User-Agent")).
+			Msg("[api] request")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/api/ws/ws.go
+++ b/internal/api/ws/ws.go
@@ -102,8 +102,12 @@ func initWS(origin string) {
 func apiWS(w http.ResponseWriter, r *http.Request) {
 	ws, err := wsUp.Upgrade(w, r, nil)
 	if err != nil {
-		origin := r.Header.Get("Origin")
-		log.Error().Err(err).Caller().Msgf("host=%s origin=%s", r.Host, origin)
+		log.Error().Err(err).
+			Str("host", r.Host).
+			Str("origin", r.Header.Get("Origin")).
+			Str("remote", r.RemoteAddr).
+			Str("user_agent", r.Header.Get("User-Agent")).
+			Msg("[api] ws upgrade")
 		return
 	}
 
@@ -128,7 +132,10 @@ func apiWS(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		log.Trace().Str("type", msg.Type).Msg("[api] ws msg")
+		log.Trace().
+			Str("type", msg.Type).
+			Str("remote", r.RemoteAddr).
+			Msg("[api] ws msg")
 
 		if handler := wsHandlers[msg.Type]; handler != nil {
 			go func() {

--- a/internal/mp4/mp4.go
+++ b/internal/mp4/mp4.go
@@ -75,7 +75,12 @@ func handlerKeyframe(w http.ResponseWriter, r *http.Request) {
 }
 
 func handlerMP4(w http.ResponseWriter, r *http.Request) {
-	log.Trace().Msgf("[mp4] %s %+v", r.Method, r.Header)
+	log.Trace().
+		Str("method", r.Method).
+		Str("remote", r.RemoteAddr).
+		Str("user_agent", r.Header.Get("User-Agent")).
+		Stringer("url", r.URL).
+		Msg("[mp4] request")
 
 	query := r.URL.Query()
 

--- a/internal/nest/init.go
+++ b/internal/nest/init.go
@@ -49,12 +49,12 @@ func Init() {
 
 func apiNest(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	cliendID := query.Get("client_id")
-	cliendSecret := query.Get("client_secret")
+	clientID := query.Get("client_id")
+	clientSecret := query.Get("client_secret")
 	refreshToken := query.Get("refresh_token")
 	projectID := query.Get("project_id")
 
-	nestAPI, err := nest.NewAPI(cliendID, cliendSecret, refreshToken)
+	nestAPI, err := nest.NewAPI(clientID, clientSecret, refreshToken)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/nest/init.go
+++ b/internal/nest/init.go
@@ -5,12 +5,41 @@ import (
 	"strings"
 
 	"github.com/AlexxIT/go2rtc/internal/api"
+	"github.com/AlexxIT/go2rtc/internal/app"
 	"github.com/AlexxIT/go2rtc/internal/streams"
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/AlexxIT/go2rtc/pkg/nest"
+	"github.com/rs/zerolog"
 )
 
 func Init() {
+	// Route pkg/nest's structured diagnostic events into the app
+	// logger. Default is no-op so pkg/nest stays import-clean.
+	nestLog := app.GetLogger("nest")
+	nest.Log = func(level, msg string, kv ...any) {
+		var ev *zerolog.Event
+		switch level {
+		case "debug":
+			ev = nestLog.Debug()
+		case "info":
+			ev = nestLog.Info()
+		case "warn":
+			ev = nestLog.Warn()
+		case "error":
+			ev = nestLog.Error()
+		default:
+			ev = nestLog.Debug()
+		}
+		for i := 0; i+1 < len(kv); i += 2 {
+			key, ok := kv[i].(string)
+			if !ok {
+				continue
+			}
+			ev = ev.Interface(key, kv[i+1])
+		}
+		ev.Msg(msg)
+	}
+
 	streams.HandleFunc("nest", func(source string) (core.Producer, error) {
 		return nest.Dial(source)
 	})

--- a/internal/onvif/README.md
+++ b/internal/onvif/README.md
@@ -21,6 +21,67 @@ A regular camera has a single video source (`GetVideoSources`) and two profiles 
 
 Go2rtc has one video source and one profile per stream.
 
+### Security: ONVIF server does not authenticate requests
+
+The ONVIF server built into go2rtc does **not** verify any
+credentials on incoming requests. The standard ONVIF
+authentication mechanism — `wsse:UsernameToken` carried in the
+SOAP `Security` header — is parsed by client tools that talk to
+go2rtc, but the server-side handler ignores it and dispatches
+every operation regardless of who's calling (or whether they
+sent any credentials at all).
+
+This is upstream behaviour, not specific to this fork. Operators
+should be aware of what it does and doesn't expose:
+
+- **Stream URLs are still protected by their own auth.** An
+  attacker who calls `GetStreamUri` will get back an RTSP URL,
+  but they still need the camera-side or go2rtc-side RTSP
+  credentials to actually open the stream.
+- **Camera metadata is exposed to anyone who can reach the
+  endpoint.** Stream enumeration, video encoder configuration,
+  system date/time, and other introspection operations
+  (`GetProfiles`, `GetVideoEncoderConfiguration`,
+  `GetSystemDateAndTime`, etc.) return real data to
+  unauthenticated callers. Treat this as unauthenticated
+  information disclosure about your camera setup.
+- **The credentials prompted for by NVR adoption tools are
+  decorative.** UniFi Protect, Home Assistant, etc. will ask for
+  a username and password when adding go2rtc as a 3rd-party
+  ONVIF camera; both fields can be left blank or set to any value
+  and the adoption will succeed.
+
+#### Recommended mitigation
+
+Treat the go2rtc API port (default `1984`, ONVIF endpoints
+served at `/onvif/*`) as **trusted-network only**:
+
+- Bind to a private interface rather than `0.0.0.0` unless your
+  network is segmented.
+- Restrict access via firewall or Docker network so only known
+  clients (your NVR, your Home Assistant instance) can reach it.
+- Do **not** expose go2rtc to the public internet without a
+  reverse proxy that enforces its own authentication.
+
+These are general hardening practices that also benefit the
+WebUI, the JSON API, and the RTSP server — the ONVIF endpoint
+just makes the need explicit.
+
+#### Upstream fix in progress
+
+An upstream pull request — [AlexxIT/go2rtc#2231][pr2231] — proposes
+adding WS-Security `UsernameToken` validation to the ONVIF
+server, with dedicated `onvif.username` / `onvif.password` config
+keys (separate from the existing HTTP Basic auth used by the
+WebUI / JSON API) and an exception for `GetSystemDateAndTime`
+so clients can compute clock skew before generating password
+digests. The PR is open as of writing; this fork does **not**
+carry it. If you need authenticated ONVIF specifically and don't
+want to wait for upstream merge, that PR is the reference
+implementation to track.
+
+[pr2231]: https://github.com/AlexxIT/go2rtc/pull/2231
+
 ## Tested clients
 
 Go2rtc works as ONVIF server:

--- a/internal/onvif/README.md
+++ b/internal/onvif/README.md
@@ -21,66 +21,29 @@ A regular camera has a single video source (`GetVideoSources`) and two profiles 
 
 Go2rtc has one video source and one profile per stream.
 
-### Security: ONVIF server does not authenticate requests
+### Security: authenticating ONVIF server requests
 
-The ONVIF server built into go2rtc does **not** verify any
-credentials on incoming requests. The standard ONVIF
-authentication mechanism — `wsse:UsernameToken` carried in the
-SOAP `Security` header — is parsed by client tools that talk to
-go2rtc, but the server-side handler ignores it and dispatches
-every operation regardless of who's calling (or whether they
-sent any credentials at all).
+The ONVIF server built into go2rtc can verify the standard ONVIF
+authentication mechanism — `wsse:UsernameToken` (PasswordDigest)
+carried in the SOAP `Security` header — using dedicated
+`onvif.username` / `onvif.password` config keys, separate from
+the HTTP Basic auth used by the WebUI / JSON API (`api.username`
+/ `api.password`), since real ONVIF clients speak WS-Security,
+not HTTP Basic.
 
-This is upstream behaviour, not specific to this fork. Operators
-should be aware of what it does and doesn't expose:
+```yaml
+onvif:
+  username: "admin"  # default "", enables WS-Security UsernameToken checks
+  password: "pass"   # default ""
+```
 
-- **Stream URLs are still protected by their own auth.** An
-  attacker who calls `GetStreamUri` will get back an RTSP URL,
-  but they still need the camera-side or go2rtc-side RTSP
-  credentials to actually open the stream.
-- **Camera metadata is exposed to anyone who can reach the
-  endpoint.** Stream enumeration, video encoder configuration,
-  system date/time, and other introspection operations
-  (`GetProfiles`, `GetVideoEncoderConfiguration`,
-  `GetSystemDateAndTime`, etc.) return real data to
-  unauthenticated callers. Treat this as unauthenticated
-  information disclosure about your camera setup.
-- **The credentials prompted for by NVR adoption tools are
-  decorative.** UniFi Protect, Home Assistant, etc. will ask for
-  a username and password when adding go2rtc as a 3rd-party
-  ONVIF camera; both fields can be left blank or set to any value
-  and the adoption will succeed.
-
-#### Recommended mitigation
-
-Treat the go2rtc API port (default `1984`, ONVIF endpoints
-served at `/onvif/*`) as **trusted-network only**:
-
-- Bind to a private interface rather than `0.0.0.0` unless your
-  network is segmented.
-- Restrict access via firewall or Docker network so only known
-  clients (your NVR, your Home Assistant instance) can reach it.
-- Do **not** expose go2rtc to the public internet without a
-  reverse proxy that enforces its own authentication.
-
-These are general hardening practices that also benefit the
-WebUI, the JSON API, and the RTSP server — the ONVIF endpoint
-just makes the need explicit.
-
-#### Upstream fix in progress
-
-An upstream pull request — [AlexxIT/go2rtc#2231][pr2231] — proposes
-adding WS-Security `UsernameToken` validation to the ONVIF
-server, with dedicated `onvif.username` / `onvif.password` config
-keys (separate from the existing HTTP Basic auth used by the
-WebUI / JSON API) and an exception for `GetSystemDateAndTime`
-so clients can compute clock skew before generating password
-digests. The PR is open as of writing; this fork does **not**
-carry it. If you need authenticated ONVIF specifically and don't
-want to wait for upstream merge, that PR is the reference
-implementation to track.
-
-[pr2231]: https://github.com/AlexxIT/go2rtc/pull/2231
+When set, every ONVIF operation except `GetSystemDateAndTime`
+requires a valid, freshly-timestamped `UsernameToken` matching
+these credentials; unauthenticated or mismatched requests get a
+SOAP fault with HTTP 401. `GetSystemDateAndTime` stays open so
+clients can learn the server's clock before computing a digest
+against it. Leave `onvif.username` unset (the default) to keep
+the ONVIF server open, e.g. for trusted-network-only setups.
 
 ## Tested clients
 

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -71,10 +71,14 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Trace().Msgf("[onvif] server request %s %s:\n%s", r.Method, r.RequestURI, b)
+	log.Trace().
+		Str("remote", r.RemoteAddr).
+		Str("user_agent", r.Header.Get("User-Agent")).
+		Str("op", operation).
+		Msgf("[onvif] server request %s %s:\n%s", r.Method, r.RequestURI, b)
 
 	switch operation {
-	case onvif.ServiceGetServiceCapabilities, // important for Hass
+	case onvif.ServiceGetServiceCapabilities, // important for Hass; routed by URL path below
 		onvif.DeviceGetNetworkInterfaces, // important for Hass
 		onvif.DeviceGetSystemDateAndTime, // important for Hass
 		onvif.DeviceSetSystemDateAndTime, // return just OK
@@ -87,11 +91,24 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 		onvif.DeviceGetScopes,
 		onvif.MediaGetVideoEncoderConfiguration,
 		onvif.MediaGetVideoEncoderConfigurations,
+		onvif.MediaGetAudioEncoderConfiguration,
 		onvif.MediaGetAudioEncoderConfigurations,
 		onvif.MediaGetVideoEncoderConfigurationOptions,
 		onvif.MediaGetAudioSources,
-		onvif.MediaGetAudioSourceConfigurations:
-		b = onvif.StaticResponse(operation)
+		onvif.MediaGetAudioSourceConfiguration,
+		onvif.MediaGetAudioSourceConfigurations,
+		onvif.ImagingGetImagingSettings,
+		onvif.ImagingGetOptions,
+		onvif.ImagingGetMoveOptions,
+		onvif.ImagingGetStatus:
+		// GetServiceCapabilities is reused by both Media and Imaging services
+		// (same operation name, different responses). Differentiate by URL.
+		if operation == onvif.ServiceGetServiceCapabilities &&
+			strings.Contains(r.URL.Path, "imaging_service") {
+			b = onvif.GetImagingServiceCapabilitiesResponse()
+		} else {
+			b = onvif.StaticResponse(operation)
+		}
 
 	case onvif.DeviceGetCapabilities:
 		// important for Hass: Media section
@@ -145,7 +162,11 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 
 	default:
 		http.Error(w, "unsupported operation", http.StatusBadRequest)
-		log.Warn().Msgf("[onvif] unsupported operation: %s", operation)
+		log.Warn().
+			Str("op", operation).
+			Str("remote", r.RemoteAddr).
+			Str("user_agent", r.Header.Get("User-Agent")).
+			Msg("[onvif] unsupported operation")
 		log.Debug().Msgf("[onvif] unsupported request:\n%s", b)
 		return
 	}

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -125,14 +125,44 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 		onvif.ImagingGetOptions,
 		onvif.ImagingGetMoveOptions,
 		onvif.ImagingGetStatus:
-		// GetServiceCapabilities is reused by both Media and Imaging services
-		// (same operation name, different responses). Differentiate by URL.
 		if operation == onvif.ServiceGetServiceCapabilities &&
 			strings.Contains(r.URL.Path, "imaging_service") {
 			b = onvif.GetImagingServiceCapabilitiesResponse()
+		} else if operation == onvif.PTZGetStatus &&
+			strings.Contains(r.URL.Path, "ptz_service") {
+			b = onvif.GetPTZStatusResponse()
 		} else {
 			b = onvif.StaticResponse(operation)
 		}
+
+	case onvif.PTZGetConfigurations:
+		if strings.Contains(r.URL.Path, "ptz_service") {
+			b = onvif.GetPTZConfigurationsResponse()
+		} else {
+			b = onvif.StaticResponse(operation)
+		}
+
+	case onvif.PTZGetNodes:
+		b = onvif.GetPTZNodesResponse()
+
+	case onvif.PTZContinuousMove:
+		name := onvif.FindTagValue(b, "ProfileToken")
+		pan, _ := strconv.ParseFloat(onvif.FindTagAttribute(b, "PanTilt", "x"), 64)
+		tilt, _ := strconv.ParseFloat(onvif.FindTagAttribute(b, "PanTilt", "y"), 64)
+		stream := streams.Get(name)
+		if stream == nil {
+			http.Error(w, "unknown profile", http.StatusBadRequest)
+			return
+		}
+		if err = stream.Move(pan, tilt); err != nil {
+			log.Warn().Err(err).Str("stream", name).Msg("[onvif] PTZ move")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		b = onvif.GetPTZContinuousMoveResponse()
+
+	case onvif.PTZStop:
+		b = onvif.GetPTZStopResponse()
 
 	case onvif.DeviceGetCapabilities:
 		// important for Hass: Media section

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -22,6 +22,16 @@ import (
 func Init() {
 	log = app.GetLogger("onvif")
 
+	var cfg struct {
+		Mod struct {
+			Username string `yaml:"username"`
+			Password string `yaml:"password"`
+		} `yaml:"onvif"`
+	}
+	app.LoadConfig(&cfg)
+	username = cfg.Mod.Username
+	password = cfg.Mod.Password
+
 	streams.HandleFunc("onvif", streamOnvif)
 
 	// ONVIF server on all suburls
@@ -31,7 +41,11 @@ func Init() {
 	api.HandleFunc("api/onvif", apiOnvif)
 }
 
-var log zerolog.Logger
+var (
+	log      zerolog.Logger
+	username string
+	password string
+)
 
 func streamOnvif(rawURL string) (core.Producer, error) {
 	client, err := onvif.NewClient(rawURL)
@@ -76,6 +90,16 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 		Str("user_agent", r.Header.Get("User-Agent")).
 		Str("op", operation).
 		Msgf("[onvif] server request %s %s:\n%s", r.Method, r.RequestURI, b)
+
+	if username != "" && operation != onvif.DeviceGetSystemDateAndTime {
+		if !onvif.VerifyUsernameToken(b, username, password) {
+			log.Warn().Str("remote", r.RemoteAddr).Msg("[onvif] unauthorized")
+			w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write(onvif.NotAuthorizedResponse())
+			return
+		}
+	}
 
 	switch operation {
 	case onvif.ServiceGetServiceCapabilities, // important for Hass; routed by URL path below

--- a/internal/onvif/onvif.go
+++ b/internal/onvif/onvif.go
@@ -145,7 +145,7 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 	case onvif.PTZGetNodes:
 		b = onvif.GetPTZNodesResponse()
 
-	case onvif.PTZContinuousMove:
+	case onvif.PTZAbsoluteMove, onvif.PTZContinuousMove:
 		name := onvif.FindTagValue(b, "ProfileToken")
 		pan, _ := strconv.ParseFloat(onvif.FindTagAttribute(b, "PanTilt", "x"), 64)
 		tilt, _ := strconv.ParseFloat(onvif.FindTagAttribute(b, "PanTilt", "y"), 64)
@@ -159,7 +159,11 @@ func onvifDeviceService(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		b = onvif.GetPTZContinuousMoveResponse()
+		if operation == onvif.PTZAbsoluteMove {
+			b = onvif.GetPTZAbsoluteMoveResponse()
+		} else {
+			b = onvif.GetPTZContinuousMoveResponse()
+		}
 
 	case onvif.PTZStop:
 		b = onvif.GetPTZStopResponse()

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -174,7 +174,11 @@ func tcpHandler(conn *rtsp.Conn) {
 				return
 			}
 
-			log.Debug().Str("stream", name).Msg("[rtsp] new consumer")
+			log.Debug().
+				Str("stream", name).
+				Str("remote", conn.Connection.RemoteAddr).
+				Str("user_agent", conn.UserAgent).
+				Msg("[rtsp] new consumer")
 
 			conn.SessionName = app.UserAgent
 
@@ -219,7 +223,10 @@ func tcpHandler(conn *rtsp.Conn) {
 			conn.Connection.Source = query.Get("source")
 
 			if err := stream.AddConsumer(conn); err != nil {
-				log.WithLevel(level).Err(err).Str("stream", name).Msg("[rtsp]")
+				log.WithLevel(level).Err(err).
+					Str("stream", name).
+					Str("remote", conn.Connection.RemoteAddr).
+					Msg("[rtsp]")
 				return
 			}
 
@@ -245,7 +252,11 @@ func tcpHandler(conn *rtsp.Conn) {
 				conn.Timeout = core.Atoi(s)
 			}
 
-			log.Debug().Str("stream", name).Msg("[rtsp] new producer")
+			log.Debug().
+				Str("stream", name).
+				Str("remote", conn.Connection.RemoteAddr).
+				Str("user_agent", conn.UserAgent).
+				Msg("[rtsp] new producer")
 
 			stream.AddProducer(conn)
 
@@ -276,12 +287,18 @@ func tcpHandler(conn *rtsp.Conn) {
 
 	if closer != nil {
 		if err := conn.Handle(); err != nil {
-			log.Debug().Err(err).Msg("[rtsp] handle")
+			log.Debug().Err(err).
+				Str("stream", name).
+				Str("remote", conn.Connection.RemoteAddr).
+				Msg("[rtsp] handle")
 		}
 
 		closer()
 
-		log.Debug().Str("stream", name).Msg("[rtsp] disconnect")
+		log.Debug().
+			Str("stream", name).
+			Str("remote", conn.Connection.RemoteAddr).
+			Msg("[rtsp] disconnect")
 	}
 
 	_ = conn.Close()

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -171,6 +171,16 @@ func tcpHandler(conn *rtsp.Conn) {
 
 			stream := streams.Get(name)
 			if stream == nil {
+				// Most common cause is a configuration mismatch: the client
+				// (UniFi Protect, VLC, Frigate, etc.) is configured to point
+				// at a stream name that no longer exists in go2rtc.yaml,
+				// or has a typo. Surfacing at warn so operators see it
+				// without enabling debug.
+				log.Warn().
+					Str("stream", name).
+					Str("remote", conn.Connection.RemoteAddr).
+					Str("user_agent", conn.UserAgent).
+					Msg("[rtsp] stream not found")
 				return
 			}
 
@@ -244,6 +254,11 @@ func tcpHandler(conn *rtsp.Conn) {
 
 			stream := streams.Get(name)
 			if stream == nil {
+				log.Warn().
+					Str("stream", name).
+					Str("remote", conn.Connection.RemoteAddr).
+					Str("user_agent", conn.UserAgent).
+					Msg("[rtsp] stream not found (ANNOUNCE)")
 				return
 			}
 

--- a/internal/streams/README.md
+++ b/internal/streams/README.md
@@ -84,6 +84,42 @@ streams:
     - ffmpeg:camera3#video=h264#audio=opus#hardware
 ```
 
+## Environment variables
+
+### `GO2RTC_KICK_ON_RECONNECT`
+
+After a producer reconnect (for example, a Nest WebRTC stream
+re-establishing after its lifetime cap), go2rtc can optionally
+force-disconnect downstream RTSP/WebRTC consumers so they
+re-`DESCRIBE` and pick up the new source's SDP. This used to be
+needed because some RTSP clients can't pick up in-band SPS/PPS
+changes mid-session and freeze on the new bitstream.
+
+The current default is **disabled** because modern RTSP clients
+(GStreamer 1.26+, including UniFi Protect 7.1.x) handle in-band
+parameter changes correctly via the H.264/H.265 parser, and
+UniFi Protect 7.1.69 specifically does not re-`DESCRIBE` after a
+server-initiated TCP close — making the kick actively
+counterproductive for that client.
+
+Set `GO2RTC_KICK_ON_RECONNECT=true` to re-enable the legacy
+behavior. Appropriate for older RTSP clients or for any consumer
+that genuinely cannot tolerate an in-band codec-parameter
+change.
+
+```bash
+# disable (default) — modern clients handle in-band SPS/PPS
+docker run -e GO2RTC_KICK_ON_RECONNECT=false alexxit/go2rtc
+# enable legacy kick behavior
+docker run -e GO2RTC_KICK_ON_RECONNECT=true  alexxit/go2rtc
+```
+
+The active setting is logged at startup at info level:
+
+```
+[streams] kick on producer reconnect: disabled — set GO2RTC_KICK_ON_RECONNECT=true to re-enable for legacy RTSP clients
+```
+
 ## Examples
 
 ```yaml

--- a/internal/streams/play.go
+++ b/internal/streams/play.go
@@ -109,7 +109,7 @@ func (s *Stream) Play(urlOrProd any) error {
 }
 
 func (s *Stream) AddInternalProducer(conn core.Producer) {
-	producer := &Producer{conn: conn, state: stateInternal, url: "internal"}
+	producer := &Producer{conn: conn, state: stateInternal, url: "internal", stream: s}
 	s.mu.Lock()
 	s.producers = append(s.producers, producer)
 	s.mu.Unlock()

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -3,12 +3,39 @@ package streams
 import (
 	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
+
+// kickOnReconnect controls whether downstream consumers are forcibly
+// disconnected after a Producer reconnects. Default: disabled.
+//
+// Background: the kick was added to refresh stale codec parameters
+// (SPS/PPS) on RTSP clients like UniFi Protect after a WebRTC
+// re-establishment produced new SDP. Empirically, UniFi Protect
+// versions through ≤ 7.0.x re-DESCRIBE within 1-3s of an abrupt
+// server-initiated TCP close, so the kick was a successful repair.
+//
+// UniFi Protect 7.1.69 changed behavior: after a server-initiated
+// close, the recording session does NOT re-establish (observed:
+// zero RTSP DESCRIBE attempts in the entire 2-minute grace window
+// even though the snapshot poll continued to succeed against the
+// same server). For those clients the kick is now actively
+// harmful — it permanently severs the recording session that the
+// reconnect was meant to refresh.
+//
+// Default-off because modern decoders (UniFi's GStreamer 1.26+
+// included) generally handle in-band SPS/PPS changes via RTP, so
+// the kick is unnecessary for them.
+//
+// Set GO2RTC_KICK_ON_RECONNECT=true to re-enable the legacy
+// behavior — appropriate for older UniFi versions or other RTSP
+// clients that genuinely cannot handle in-band parameter changes.
+var kickOnReconnect = os.Getenv("GO2RTC_KICK_ON_RECONNECT") == "true"
 
 // redactSourceURL returns a producer URL with the query string stripped,
 // suitable for log output. Source URLs like `nest:?client_id=…&client_secret=…`
@@ -171,7 +198,133 @@ func (p *Producer) start() {
 	p.state = stateStart
 	p.workerID++
 
+	// If the underlying producer declares a known max stream lifetime
+	// (e.g. nest WebRTC, ~60 min cap), wire up the proactive-reconnect
+	// callback so it can trigger a connection swap before the limit
+	// silently kills the stream. Logged at debug so operators can
+	// confirm the wiring is in place without waiting ~55 min for the
+	// first fire — a silent type-assertion failure would otherwise
+	// only surface as a re-emergence of the periodic gap.
+	if hook, ok := p.conn.(core.LifetimeLimited); ok {
+		hook.SetReconnectCallback(p.proactiveReconnect)
+		log.Debug().Str("source", redactSourceURL(p.url)).
+			Msg("[streams] proactive-reconnect hook registered (source declares max stream lifetime)")
+	}
+
 	go p.worker(p.conn, p.workerID)
+	go p.activityTick(p.workerID)
+}
+
+// proactiveReconnect triggers a fresh GetProducer + track swap without
+// waiting for the current connection to die. Invoked via the
+// SetReconnectCallback hook by producers that know their upstream has
+// a hard lifetime cap (currently: Nest WebRTC at ~60 min).
+//
+// The existing reconnect() flow is already overlap-friendly: it
+// allocates a new conn, moves tracks via Receiver.Replace(), then
+// stops the old conn. The only gap consumers see is the
+// GetProducer setup time (~3 s for Nest), and only on the receiver
+// tracks that haven't started flowing through the new conn yet.
+// That's small enough that UniFi's session-keepalive sees no
+// disruption.
+//
+// workerID bookkeeping: bump before reconnect so the old worker —
+// which will return shortly after reconnect calls p.conn.Stop() on
+// its conn — sees a workerID mismatch in its post-Start reconnect
+// call and no-ops. Without this, the old worker would race the new
+// one into reconnect() and produce a second fresh connection.
+func (p *Producer) proactiveReconnect() {
+	p.mu.Lock()
+	if p.state != stateStart {
+		p.mu.Unlock()
+		log.Trace().Str("source", redactSourceURL(p.url)).
+			Msg("[streams] skip proactive reconnect: producer not started")
+		return
+	}
+	p.workerID++
+	newID := p.workerID
+	p.mu.Unlock()
+
+	log.Info().Str("source", redactSourceURL(p.url)).
+		Msg("[streams] proactive reconnect (lifetime-limited source)")
+
+	// The activityTick goroutine started in start() is tied to the
+	// previous workerID and will exit on its next tick when it sees the
+	// bump. Spawn a fresh one with the new ID so heartbeats keep
+	// flowing through the new connection's lifetime — without this we
+	// lose visibility into the producer immediately after the refresh,
+	// which is the worst possible moment to go blind.
+	go p.activityTick(newID)
+
+	p.reconnect(newID, 0)
+}
+
+// activityInterval is the heartbeat cadence for the producer activity
+// log. Each tick emits one debug line per receiver with packets/bytes
+// deltas — visible only when --log.level=debug. The point is to make
+// silent-stall failure modes obvious: if the upstream connection looks
+// healthy (no EOF, no read-deadline fire) but video frames have stopped,
+// the heartbeat shows dpackets=0 on the affected track while audio
+// continues to tick over. Without this, those stalls are invisible
+// because routine RTP forwarding does not log per packet.
+//
+// Exposed as a package variable so tests can shorten it.
+var activityInterval = 60 * time.Second
+
+// activityTick periodically logs per-receiver packet and byte counts
+// for this producer. Runs in its own goroutine; exits when the
+// producer's workerID advances (start of next cycle or stop).
+//
+// Reconnect does not advance workerID, so the goroutine survives a
+// reconnect. Receivers are swapped via Receiver.Replace() in
+// p.reconnect(), which means after reconnect the slots in p.receivers
+// point at fresh *core.Receiver values whose counters start at 0. The
+// prev map is keyed by pointer, so a freshly-swapped receiver gets a
+// zero baseline on its first tick after reconnect — yielding a delta
+// equal to the new receiver's lifetime packet count. That's an
+// acceptable boundary blip; subsequent ticks are accurate deltas.
+func (p *Producer) activityTick(workerID int) {
+	ticker := time.NewTicker(activityInterval)
+	defer ticker.Stop()
+
+	type counter struct{ bytes, packets int }
+	prev := make(map[*core.Receiver]counter)
+
+	for range ticker.C {
+		p.mu.Lock()
+		if p.workerID != workerID {
+			p.mu.Unlock()
+			return
+		}
+		// Snapshot under lock — reconnect may swap p.receivers.
+		receivers := make([]*core.Receiver, len(p.receivers))
+		copy(receivers, p.receivers)
+		url := p.url
+		p.mu.Unlock()
+
+		if !log.Debug().Enabled() {
+			continue
+		}
+
+		for i, r := range receivers {
+			c := prev[r]
+			bytesNow, packetsNow := r.Bytes, r.Packets
+			prev[r] = counter{bytes: bytesNow, packets: packetsNow}
+
+			codec := "unknown"
+			if r.Codec != nil {
+				codec = r.Codec.Name
+			}
+			log.Debug().
+				Str("source", redactSourceURL(url)).
+				Int("track", i).
+				Str("codec", codec).
+				Int("dpackets", packetsNow-c.packets).
+				Int("dbytes", bytesNow-c.bytes).
+				Int("total_packets", packetsNow).
+				Msg("[streams] producer activity")
+		}
+	}
 }
 
 func (p *Producer) worker(conn core.Producer, workerID int) {
@@ -270,18 +423,27 @@ func (p *Producer) reconnect(workerID, retry int) {
 	// swap connections
 	p.conn = conn
 
+	// Re-register the proactive-reconnect callback on the new conn so
+	// the next lifetime cycle is also caught. Without this, only the
+	// first connection (from start()) benefits from proactive refresh.
+	if hook, ok := conn.(core.LifetimeLimited); ok {
+		hook.SetReconnectCallback(p.proactiveReconnect)
+		log.Debug().Str("source", redactSourceURL(p.url)).
+			Msg("[streams] proactive-reconnect hook re-registered after swap")
+	}
+
 	// Recovery signal at info level so operators at log.level=info see the
 	// outage was resolved. Pairs with the info line at retry=0.
 	log.Info().Str("source", redactSourceURL(p.url)).
 		Msg("[streams] producer reconnected")
 
 	// Disconnect downstream consumers so they re-DESCRIBE and pick up the
-	// new source's SDP (codec parameters such as SPS/PPS often differ
-	// across WebRTC re-establishments — without this, consumers like UniFi
-	// Protect remain attached to a stale RTSP session and freeze on the
-	// incompatible bitstream). Done after the swap so when consumers
-	// reconnect, the new producer is already serving.
-	if p.stream != nil {
+	// new source's SDP. Gated by kickOnReconnect because UniFi Protect
+	// 7.1.69+ does not re-DESCRIBE after a server-initiated close, so
+	// the kick now severs the recording session it was meant to repair.
+	// See the package-level comment on kickOnReconnect for the full
+	// rationale. Default behavior: no kick.
+	if p.stream != nil && kickOnReconnect {
 		// Use the URL scheme + path only (drops query string) so source
 		// URLs that carry credentials in the query (nest:?client_secret=…,
 		// etc.) don't leak them into the log line.

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -10,6 +10,17 @@ import (
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
 
+// redactSourceURL returns a producer URL with the query string stripped,
+// suitable for log output. Source URLs like `nest:?client_id=…&client_secret=…`
+// or `rtsp://user:pass@host/stream?…` would otherwise leak credentials into
+// log output that may be shared during debugging.
+func redactSourceURL(rawURL string) string {
+	if i := strings.IndexAny(rawURL, "?#"); i >= 0 {
+		return rawURL[:i]
+	}
+	return rawURL
+}
+
 type state byte
 
 const (
@@ -34,6 +45,12 @@ type Producer struct {
 	state    state
 	mu       sync.Mutex
 	workerID int
+
+	// stream is a back-reference to the parent Stream, set by NewStream /
+	// AddProducer. nil for standalone producers created via NewProducer().
+	// Used after a successful reconnect to notify the stream that downstream
+	// consumers should disconnect — see Stream.kickConsumers.
+	stream *Stream
 }
 
 const SourceTemplate = "{input}"
@@ -149,7 +166,7 @@ func (p *Producer) start() {
 		return
 	}
 
-	log.Debug().Msgf("[streams] start producer url=%s", p.url)
+	log.Debug().Msgf("[streams] start producer url=%s", redactSourceURL(p.url))
 
 	p.state = stateStart
 	p.workerID++
@@ -167,7 +184,7 @@ func (p *Producer) worker(conn core.Producer, workerID int) {
 			return
 		}
 
-		log.Warn().Err(err).Str("url", p.url).Caller().Send()
+		log.Warn().Err(err).Str("url", redactSourceURL(p.url)).Caller().Send()
 	}
 
 	p.reconnect(workerID, 0)
@@ -178,11 +195,25 @@ func (p *Producer) reconnect(workerID, retry int) {
 	defer p.mu.Unlock()
 
 	if p.workerID != workerID {
-		log.Trace().Msgf("[streams] stop reconnect url=%s", p.url)
+		log.Trace().Msgf("[streams] stop reconnect url=%s", redactSourceURL(p.url))
 		return
 	}
 
-	log.Debug().Msgf("[streams] retry=%d to url=%s", retry, p.url)
+	// First retry of a cycle is operationally interesting — surface it at
+	// info so operators running at log.level=info see source-outage events
+	// without enabling debug. Retry 5 is the threshold at which we
+	// escalate to warn: by then the backoff has stretched to 5s/retry, so
+	// the source has been down for ~10s+ and isn't coming back quickly.
+	// Per-retry detail (`retry=N to url=…`) stays at debug to avoid noise.
+	switch retry {
+	case 0:
+		log.Info().Str("source", redactSourceURL(p.url)).
+			Msg("[streams] producer reconnecting")
+	case 5:
+		log.Warn().Str("source", redactSourceURL(p.url)).Int("retry", retry).
+			Msg("[streams] producer reconnect still failing")
+	}
+	log.Debug().Msgf("[streams] retry=%d to url=%s", retry, redactSourceURL(p.url))
 
 	conn, err := GetProducer(p.url)
 	if err != nil {
@@ -239,6 +270,24 @@ func (p *Producer) reconnect(workerID, retry int) {
 	// swap connections
 	p.conn = conn
 
+	// Recovery signal at info level so operators at log.level=info see the
+	// outage was resolved. Pairs with the info line at retry=0.
+	log.Info().Str("source", redactSourceURL(p.url)).
+		Msg("[streams] producer reconnected")
+
+	// Disconnect downstream consumers so they re-DESCRIBE and pick up the
+	// new source's SDP (codec parameters such as SPS/PPS often differ
+	// across WebRTC re-establishments — without this, consumers like UniFi
+	// Protect remain attached to a stale RTSP session and freeze on the
+	// incompatible bitstream). Done after the swap so when consumers
+	// reconnect, the new producer is already serving.
+	if p.stream != nil {
+		// Use the URL scheme + path only (drops query string) so source
+		// URLs that carry credentials in the query (nest:?client_secret=…,
+		// etc.) don't leak them into the log line.
+		go p.stream.kickConsumers("producer reconnect: " + redactSourceURL(p.url))
+	}
+
 	go p.worker(conn, workerID)
 }
 
@@ -257,7 +306,7 @@ func (p *Producer) stop() {
 		p.workerID++
 	}
 
-	log.Debug().Msgf("[streams] stop producer url=%s", p.url)
+	log.Debug().Msgf("[streams] stop producer url=%s", redactSourceURL(p.url))
 
 	if p.conn != nil {
 		_ = p.conn.Stop()

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -175,6 +175,22 @@ func (p *Producer) AddTrack(media *core.Media, codec *core.Codec, track *core.Re
 	return nil
 }
 
+func (p *Producer) Move(pan, tilt float64) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.state == stateNone {
+		return errors.New("move from none state")
+	}
+
+	ptz, ok := p.conn.(core.PTZ)
+	if !ok {
+		return errors.New("PTZ not supported")
+	}
+
+	return ptz.Move(pan, tilt)
+}
+
 func (p *Producer) MarshalJSON() ([]byte, error) {
 	if conn := p.conn; conn != nil {
 		return json.Marshal(conn)

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -18,14 +18,15 @@ type Stream struct {
 func NewStream(source any) *Stream {
 	switch source := source.(type) {
 	case string:
-		return &Stream{
-			producers: []*Producer{NewProducer(source)},
-		}
+		s := &Stream{producers: []*Producer{NewProducer(source)}}
+		s.linkProducers()
+		return s
 	case []string:
 		s := new(Stream)
 		for _, str := range source {
 			s.producers = append(s.producers, NewProducer(str))
 		}
+		s.linkProducers()
 		return s
 	case []any:
 		s := new(Stream)
@@ -37,6 +38,7 @@ func NewStream(source any) *Stream {
 			}
 			s.producers = append(s.producers, NewProducer(str))
 		}
+		s.linkProducers()
 		return s
 	case map[string]any:
 		return NewStream(source["url"])
@@ -44,6 +46,15 @@ func NewStream(source any) *Stream {
 		return new(Stream)
 	default:
 		panic(core.Caller())
+	}
+}
+
+// linkProducers sets each Producer's stream back-reference. Required for
+// Producer.reconnect to be able to notify the parent Stream
+// (kickConsumers) after a successful reconnect.
+func (s *Stream) linkProducers() {
+	for _, p := range s.producers {
+		p.stream = s
 	}
 }
 
@@ -76,8 +87,62 @@ func (s *Stream) RemoveConsumer(cons core.Consumer) {
 	s.stopProducers()
 }
 
+// remoteAddrer is the interface implemented by consumers whose underlying
+// transport has a known remote address. Most go2rtc consumer types embed
+// *core.Connection, which provides GetRemoteAddr() via promoted method —
+// so this assertion succeeds for RTSP, WebRTC, etc.
+type remoteAddrer interface {
+	GetRemoteAddr() string
+}
+
+// kickConsumers disconnects all consumers attached to this stream.
+// Called after a Producer reconnect when downstream consumers may be
+// holding stale codec parameters (SPS/PPS) from the previous source
+// session. By calling Stop() on each consumer, their underlying
+// transports (e.g. RTSP TCP connections) close, prompting them to
+// reconnect and re-DESCRIBE with the new producer's SDP.
+//
+// Consumers are not removed from s.consumers here — the natural
+// close-path in each transport (e.g. tcpHandler in internal/rtsp)
+// calls RemoveConsumer when its handler loop exits, keeping the list
+// in sync.
+//
+// reason is logged for observability; pass something specific like
+// "producer reconnect: <scheme>".
+func (s *Stream) kickConsumers(reason string) {
+	s.mu.Lock()
+	consumers := make([]core.Consumer, len(s.consumers))
+	copy(consumers, s.consumers)
+	s.mu.Unlock()
+
+	if len(consumers) == 0 {
+		return
+	}
+
+	// Collect remote addresses for the log line so a single grep on the
+	// kick event tells you exactly which clients were notified.
+	remotes := make([]string, 0, len(consumers))
+	for _, cons := range consumers {
+		if r, ok := cons.(remoteAddrer); ok {
+			if addr := r.GetRemoteAddr(); addr != "" {
+				remotes = append(remotes, addr)
+			}
+		}
+	}
+
+	log.Debug().
+		Int("count", len(consumers)).
+		Strs("remotes", remotes).
+		Str("reason", reason).
+		Msg("[streams] kicking consumers")
+
+	for _, cons := range consumers {
+		_ = cons.Stop()
+	}
+}
+
 func (s *Stream) AddProducer(prod core.Producer) {
-	producer := &Producer{conn: prod, state: stateExternal, url: "external"}
+	producer := &Producer{conn: prod, state: stateExternal, url: "external", stream: s}
 	s.mu.Lock()
 	s.producers = append(s.producers, producer)
 	s.mu.Unlock()

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -83,7 +83,16 @@ func (s *Stream) RemoveConsumer(cons core.Consumer) {
 			break
 		}
 	}
+	remaining := len(s.consumers)
 	s.mu.Unlock()
+
+	// Trace-only: the per-transport disconnect log (e.g. `[rtsp] disconnect`)
+	// already records who left, but it doesn't show the stream's resulting
+	// consumer count. Surfacing that here closes a gap during incident
+	// reconstruction — without it, you cannot tell from logs alone whether
+	// a producer.stop() that follows is the last-consumer teardown or one
+	// of many simultaneous removals.
+	log.Trace().Int("remaining", remaining).Msg("[streams] consumer removed")
 
 	s.stopProducers()
 }
@@ -97,12 +106,22 @@ type remoteAddrer interface {
 }
 
 // kickGracePeriod is how long producers are held alive after kickConsumers
-// fires so kicked clients (e.g. UniFi Protect) can reconnect without
-// hitting a cold producer that has to spin back up. 30s easily covers
-// UniFi's normal 1–3s reconnect window and tolerates cloud-API throttles
-// (Google's Nest API briefly rate-limits successive WebRTC re-establishes).
+// fires so kicked clients can reconnect without hitting a cold producer
+// that has to spin back up.
+//
+// 2 minutes — long enough to cover the worst case observed in practice:
+// UniFi Protect's RTSP retry back-off after a session that closed shortly
+// after opening (which it interprets as a server-instability signal).
+// Empirically UniFi waits ~60-90s in that mode before retrying. We add
+// margin on top of the advertised `Session:timeout=60` for safety.
+//
+// Trade-off: a producer with no consumers for the full grace window keeps
+// streaming from upstream (small ongoing bandwidth cost — ~50-200 kbps
+// for a typical Nest stream). Worth it to avoid recording gaps that
+// require manual intervention to clear.
+//
 // Exposed as a package variable so tests can shorten it.
-var kickGracePeriod = 30 * time.Second
+var kickGracePeriod = 2 * time.Minute
 
 // kickConsumers disconnects all consumers attached to this stream.
 // Called after a Producer reconnect when downstream consumers may be
@@ -129,30 +148,103 @@ var kickGracePeriod = 30 * time.Second
 // "producer reconnect: <scheme>".
 func (s *Stream) kickConsumers(reason string) {
 	s.mu.Lock()
+	// Snapshot consumers and producer URLs in one critical section so the
+	// internal-consumer skip below is consistent with the current set of
+	// producers.
 	consumers := make([]core.Consumer, len(s.consumers))
 	copy(consumers, s.consumers)
+	producerURLs := make(map[string]struct{}, len(s.producers))
+	for _, p := range s.producers {
+		if p.url != "" {
+			producerURLs[p.url] = struct{}{}
+		}
+	}
 	s.mu.Unlock()
 
 	if len(consumers) == 0 {
 		return
 	}
 
-	// Collect remote addresses for the log line so a single grep on the
-	// kick event tells you exactly which clients were notified.
+	// Trace dump of the comparison inputs (producer URLs the skip-logic
+	// is matching against). Combined with the per-consumer "kick filter"
+	// trace below, this gives a full picture of why each consumer was or
+	// wasn't kicked. URLs are redacted (query string stripped) to avoid
+	// leaking credentials in shared trace dumps.
+	if log.Trace().Enabled() {
+		urls := make([]string, 0, len(producerURLs))
+		for u := range producerURLs {
+			urls = append(urls, redactSourceURL(u))
+		}
+		log.Trace().Strs("producer_urls", urls).Msg("[streams] kick start")
+	}
+
+	// Filter out internal-loop consumers — i.e. consumers whose source URL
+	// matches one of this stream's producers. These are the inner ends of
+	// recursive ffmpeg-style pipelines (e.g. `ffmpeg:driveway` is a
+	// producer whose subprocess reads `rtsp://localhost/driveway` and
+	// registers as a consumer). Kicking such a consumer kills the very
+	// producer that just reconnected, triggering an instant reconnect loop.
+	// Matches the loop-protection check in AddConsumer.
+	toKick := make([]core.Consumer, 0, len(consumers))
 	remotes := make([]string, 0, len(consumers))
+	skipped := make([]string, 0)
 	for _, cons := range consumers {
+		// Diagnostic: trace-level per-consumer match attempt. Helps verify
+		// the skip-logic is correctly engaging (or diagnose why it's not)
+		// without enabling per-line debug log dumps. Visible at
+		// streams=trace.
+		var consSource, consRemote string
+		if info, ok := cons.(core.Info); ok {
+			consSource = info.GetSource()
+		}
 		if r, ok := cons.(remoteAddrer); ok {
-			if addr := r.GetRemoteAddr(); addr != "" {
-				remotes = append(remotes, addr)
-			}
+			consRemote = r.GetRemoteAddr()
+		}
+
+		_, isInternal := producerURLs[consSource]
+		log.Trace().
+			Str("remote", consRemote).
+			Str("source", redactSourceURL(consSource)).
+			Bool("is_internal", isInternal && consSource != "").
+			Msg("[streams] kick filter")
+
+		if isInternal && consSource != "" {
+			skipped = append(skipped, consSource)
+			continue
+		}
+
+		toKick = append(toKick, cons)
+		if consRemote != "" {
+			remotes = append(remotes, consRemote)
 		}
 	}
 
-	log.Debug().
-		Int("count", len(consumers)).
+	if len(toKick) == 0 {
+		// Every consumer was an internal-loop. Surface this at debug so
+		// the no-op kick is visible during diagnosis — otherwise a
+		// reconnect cycle dominated by internal consumers would show
+		// repeated "producer reconnected" lines with no kick output and
+		// look mysteriously inert.
+		if len(skipped) > 0 {
+			log.Debug().
+				Int("consumers", len(consumers)).
+				Strs("skipped_internal", skipped).
+				Str("reason", reason).
+				Msg("[streams] kick skipped: all consumers are internal-loop")
+		}
+		return
+	}
+
+	ev := log.Debug().
+		Int("count", len(toKick)).
 		Strs("remotes", remotes).
-		Str("reason", reason).
-		Msg("[streams] kicking consumers")
+		Str("reason", reason)
+	if len(skipped) > 0 {
+		// Tells operators which producers' inner consumers were exempted,
+		// which both explains lower kick counts and surfaces topology.
+		ev = ev.Strs("skipped_internal", skipped)
+	}
+	ev.Msg("[streams] kicking consumers")
 
 	// Hold producers alive during the grace window. See kickGracePeriod.
 	s.pending.Add(1)
@@ -162,7 +254,7 @@ func (s *Stream) kickConsumers(reason string) {
 		}
 	})
 
-	for _, cons := range consumers {
+	for _, cons := range toKick {
 		_ = cons.Stop()
 	}
 }
@@ -192,21 +284,36 @@ func (s *Stream) stopProducers() {
 	}
 
 	s.mu.Lock()
+	var stopped, kept int
 producers:
 	for _, producer := range s.producers {
 		for _, track := range producer.receivers {
 			if len(track.Senders()) > 0 {
+				kept++
 				continue producers
 			}
 		}
 		for _, track := range producer.senders {
 			if len(track.Senders()) > 0 {
+				kept++
 				continue producers
 			}
 		}
 		producer.stop()
+		stopped++
 	}
 	s.mu.Unlock()
+
+	// Per-call summary: which branch did the decision take? Until now,
+	// stopProducers either logged "skip stop pending producer" or was
+	// silent — so a stopProducers that kept all producers (senders still
+	// attached) looked identical in logs to one that wasn't called at
+	// all. With this line we can tell when producers WERE kept alive
+	// because senders held them up vs. when no consumer left in the
+	// first place.
+	if stopped > 0 || kept > 0 {
+		log.Trace().Int("stopped", stopped).Int("kept", kept).Msg("[streams] stopProducers")
+	}
 }
 
 func (s *Stream) MarshalJSON() ([]byte, error) {

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
 )
@@ -95,6 +96,14 @@ type remoteAddrer interface {
 	GetRemoteAddr() string
 }
 
+// kickGracePeriod is how long producers are held alive after kickConsumers
+// fires so kicked clients (e.g. UniFi Protect) can reconnect without
+// hitting a cold producer that has to spin back up. 30s easily covers
+// UniFi's normal 1–3s reconnect window and tolerates cloud-API throttles
+// (Google's Nest API briefly rate-limits successive WebRTC re-establishes).
+// Exposed as a package variable so tests can shorten it.
+var kickGracePeriod = 30 * time.Second
+
 // kickConsumers disconnects all consumers attached to this stream.
 // Called after a Producer reconnect when downstream consumers may be
 // holding stale codec parameters (SPS/PPS) from the previous source
@@ -106,6 +115,15 @@ type remoteAddrer interface {
 // close-path in each transport (e.g. tcpHandler in internal/rtsp)
 // calls RemoveConsumer when its handler loop exits, keeping the list
 // in sync.
+//
+// To keep producers alive during the reconnect window, this method
+// bumps s.pending for kickGracePeriod. While pending is non-zero,
+// stopProducers() short-circuits — so the producers we just
+// reconnected stay attached and ready for the kicked consumers'
+// near-immediate re-DESCRIBE. Without this, the cascade is
+// kick → consumers gone → producers stop (no senders) → consumer
+// reconnects to a cold producer → cold-start latency → consumer
+// timeout, back-off cycle.
 //
 // reason is logged for observability; pass something specific like
 // "producer reconnect: <scheme>".
@@ -135,6 +153,14 @@ func (s *Stream) kickConsumers(reason string) {
 		Strs("remotes", remotes).
 		Str("reason", reason).
 		Msg("[streams] kicking consumers")
+
+	// Hold producers alive during the grace window. See kickGracePeriod.
+	s.pending.Add(1)
+	time.AfterFunc(kickGracePeriod, func() {
+		if s.pending.Add(-1) == 0 {
+			s.stopProducers()
+		}
+	})
 
 	for _, cons := range consumers {
 		_ = cons.Stop()

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -13,6 +13,7 @@ import (
 type Stream struct {
 	producers []*Producer
 	consumers []core.Consumer
+	control   string
 	mu        sync.Mutex
 	pending   atomic.Int32
 }
@@ -43,7 +44,11 @@ func NewStream(source any) *Stream {
 		s.linkProducers()
 		return s
 	case map[string]any:
-		return NewStream(source["url"])
+		stream := NewStream(source["url"])
+		if control, ok := source["control"].(string); ok {
+			stream.control = control
+		}
+		return stream
 	case nil:
 		return new(Stream)
 	default:
@@ -75,13 +80,28 @@ func (s *Stream) SetSource(source string) {
 }
 
 func (s *Stream) Move(pan, tilt float64) error {
+	if s.control != "" {
+		control := Get(s.control)
+		if control == nil {
+			return errors.New("streams: control stream not found")
+		}
+		return control.Move(pan, tilt)
+	}
+
+	var lastErr error
 	for _, prod := range s.producers {
 		if err := prod.Dial(); err != nil {
+			lastErr = err
 			continue
 		}
 		if err := prod.Move(pan, tilt); err == nil {
 			return nil
+		} else {
+			lastErr = err
 		}
+	}
+	if lastErr != nil {
+		return lastErr
 	}
 	return errors.New("streams: PTZ not supported")
 }

--- a/internal/streams/stream.go
+++ b/internal/streams/stream.go
@@ -2,6 +2,7 @@ package streams
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -71,6 +72,18 @@ func (s *Stream) SetSource(source string) {
 	for _, prod := range s.producers {
 		prod.SetSource(source)
 	}
+}
+
+func (s *Stream) Move(pan, tilt float64) error {
+	for _, prod := range s.producers {
+		if err := prod.Dial(); err != nil {
+			continue
+		}
+		if err := prod.Move(pan, tilt); err == nil {
+			return nil
+		}
+	}
+	return errors.New("streams: PTZ not supported")
 }
 
 func (s *Stream) RemoveConsumer(cons core.Consumer) {

--- a/internal/streams/stream_test.go
+++ b/internal/streams/stream_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,36 @@ func TestKickConsumers(t *testing.T) {
 
 		require.Len(t, s.consumers, 2,
 			"kickConsumers should not modify s.consumers directly")
+	})
+
+	t.Run("grace period holds producers alive then releases", func(t *testing.T) {
+		// Shorten the grace period so the test runs fast. The contract
+		// being verified: pending counter is bumped synchronously by
+		// kickConsumers, then decremented after the grace window.
+		// stopProducers checks pending and short-circuits while it's
+		// non-zero, so producers stay alive during the window.
+		original := kickGracePeriod
+		kickGracePeriod = 50 * time.Millisecond
+		defer func() { kickGracePeriod = original }()
+
+		s := &Stream{}
+		s.consumers = append(s.consumers, &mockConsumer{})
+
+		require.Equal(t, int32(0), s.pending.Load(),
+			"pending should start at 0")
+
+		s.kickConsumers("test")
+
+		// Immediately after the kick, pending should be 1 — producers
+		// are protected from premature stopProducers.
+		require.Equal(t, int32(1), s.pending.Load(),
+			"pending should be 1 during grace period")
+
+		// After the grace window expires, pending returns to 0.
+		require.Eventually(t,
+			func() bool { return s.pending.Load() == 0 },
+			500*time.Millisecond, 10*time.Millisecond,
+			"pending should return to 0 after grace period")
 	})
 }
 

--- a/internal/streams/stream_test.go
+++ b/internal/streams/stream_test.go
@@ -1,6 +1,7 @@
 package streams
 
 import (
+	"net/http"
 	"net/url"
 	"sync/atomic"
 	"testing"
@@ -22,6 +23,23 @@ func (m *mockConsumer) Stop() error {
 	m.stops.Add(1)
 	return nil
 }
+
+// mockInternalConsumer is a mockConsumer that reports a source URL.
+// Models the inner ffmpeg subprocess of a recursive pipeline like
+// `ffmpeg:driveway` (subprocess reads rtsp://localhost/driveway and
+// is registered as a consumer of the same stream).
+type mockInternalConsumer struct {
+	mockConsumer
+	source string
+}
+
+// Satisfy core.Info — we only need GetSource for the kick-skip check.
+func (m *mockInternalConsumer) SetProtocol(string)             {}
+func (m *mockInternalConsumer) SetRemoteAddr(string)           {}
+func (m *mockInternalConsumer) SetSource(string)               {}
+func (m *mockInternalConsumer) SetURL(string)                  {}
+func (m *mockInternalConsumer) WithRequest(*http.Request)      {}
+func (m *mockInternalConsumer) GetSource() string              { return m.source }
 
 func TestRecursion(t *testing.T) {
 	// create stream with some source
@@ -92,6 +110,50 @@ func TestKickConsumers(t *testing.T) {
 
 		require.Len(t, s.consumers, 2,
 			"kickConsumers should not modify s.consumers directly")
+	})
+
+	t.Run("internal-loop consumer is skipped (no infinite reconnect)", func(t *testing.T) {
+		// Regression test for the recursive-pipeline reconnect loop:
+		//
+		//   ffmpeg:driveway producer
+		//     -> ffmpeg subprocess (registers as consumer of driveway)
+		//     -> kick called on producer reconnect
+		//     -> kicks the inner ffmpeg subprocess (its own source)
+		//     -> subprocess exits -> producer EOFs -> reconnect cycle
+		//
+		// Fix: consumers whose GetSource() matches one of this stream's
+		// producer URLs are exempt from the kick.
+		s := &Stream{
+			producers: []*Producer{
+				{url: "nest:?client_id=…"},
+				{url: "ffmpeg:driveway"},
+			},
+		}
+		external := &mockConsumer{} // UniFi-style consumer
+		internal := &mockInternalConsumer{source: "ffmpeg:driveway"}
+		s.consumers = append(s.consumers, external, internal)
+
+		s.kickConsumers("test")
+
+		require.Equal(t, int32(1), external.stops.Load(),
+			"external consumer should be kicked")
+		require.Equal(t, int32(0), internal.mockConsumer.stops.Load(),
+			"internal-loop consumer must NOT be kicked")
+	})
+
+	t.Run("grace period not held when only internal consumers", func(t *testing.T) {
+		// If every consumer is filtered out as internal, no kick happens
+		// and we should not bump pending unnecessarily.
+		s := &Stream{
+			producers: []*Producer{{url: "ffmpeg:driveway"}},
+		}
+		internal := &mockInternalConsumer{source: "ffmpeg:driveway"}
+		s.consumers = append(s.consumers, internal)
+
+		s.kickConsumers("test")
+
+		require.Equal(t, int32(0), s.pending.Load(),
+			"pending should not be bumped when no consumers are kicked")
 	})
 
 	t.Run("grace period holds producers alive then releases", func(t *testing.T) {

--- a/internal/streams/stream_test.go
+++ b/internal/streams/stream_test.go
@@ -2,11 +2,25 @@ package streams
 
 import (
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/stretchr/testify/require"
 )
+
+// mockConsumer is a minimal core.Consumer for testing kickConsumers.
+// It records how many times Stop() was called.
+type mockConsumer struct {
+	stops atomic.Int32
+}
+
+func (m *mockConsumer) GetMedias() []*core.Media                                { return nil }
+func (m *mockConsumer) AddTrack(*core.Media, *core.Codec, *core.Receiver) error { return nil }
+func (m *mockConsumer) Stop() error {
+	m.stops.Add(1)
+	return nil
+}
 
 func TestRecursion(t *testing.T) {
 	// create stream with some source
@@ -39,4 +53,95 @@ func TestTempate(t *testing.T) {
 
 	require.Equal(t, stream1, stream2)
 	require.Equal(t, "ffmpeg:rtsp://example.com#video=copy", stream1.producers[0].url)
+}
+
+// TestKickConsumers verifies that Stream.kickConsumers calls Stop()
+// exactly once on every attached consumer. This is the disconnect path
+// used after a Producer reconnects so downstream RTSP clients re-DESCRIBE
+// and pick up fresh codec parameters (SPS/PPS).
+func TestKickConsumers(t *testing.T) {
+	t.Run("no consumers - no-op, doesn't panic", func(t *testing.T) {
+		s := &Stream{}
+		s.kickConsumers("test")
+	})
+
+	t.Run("multiple consumers - all get Stop()", func(t *testing.T) {
+		s := &Stream{}
+		consumers := []*mockConsumer{{}, {}, {}}
+		for _, c := range consumers {
+			s.consumers = append(s.consumers, c)
+		}
+
+		s.kickConsumers("test reason")
+
+		for i, c := range consumers {
+			require.Equal(t, int32(1), c.stops.Load(),
+				"consumer %d should have Stop() called exactly once", i)
+		}
+	})
+
+	t.Run("kick doesn't remove consumers from list", func(t *testing.T) {
+		// kickConsumers only triggers Stop(); the actual list cleanup
+		// happens in RemoveConsumer when each consumer's transport
+		// handler exits naturally.
+		s := &Stream{}
+		s.consumers = append(s.consumers, &mockConsumer{}, &mockConsumer{})
+
+		s.kickConsumers("test")
+
+		require.Len(t, s.consumers, 2,
+			"kickConsumers should not modify s.consumers directly")
+	})
+}
+
+// TestRedactSourceURL verifies the helper used to scrub query strings
+// from source URLs before they appear in log lines. Producer URLs like
+// `nest:?client_id=…&client_secret=…` carry credentials that must not
+// leak when debugging output is shared.
+func TestRedactSourceURL(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"nest:?client_id=abc&client_secret=xyz&refresh_token=tok", "nest:"},
+		{"rtsp://user:pass@host/stream?audio=copy", "rtsp://user:pass@host/stream"},
+		{"rtsp://192.168.1.10/stream", "rtsp://192.168.1.10/stream"},
+		{"ffmpeg:driveway#audio=aac", "ffmpeg:driveway"},
+		{"ffmpeg:driveway?something#audio=aac", "ffmpeg:driveway"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			require.Equal(t, tt.want, redactSourceURL(tt.in))
+		})
+	}
+}
+
+// TestNewStreamLinksProducers verifies that NewStream sets the
+// Producer.stream back-reference, which is required for the
+// reconnect → kickConsumers wiring to work.
+func TestNewStreamLinksProducers(t *testing.T) {
+	t.Run("single string source", func(t *testing.T) {
+		s := NewStream("rtsp://example.com")
+		require.Len(t, s.producers, 1)
+		require.Same(t, s, s.producers[0].stream,
+			"producer.stream should point back to its parent Stream")
+	})
+
+	t.Run("multiple string sources", func(t *testing.T) {
+		s := NewStream([]string{"rtsp://a", "rtsp://b", "rtsp://c"})
+		require.Len(t, s.producers, 3)
+		for i, p := range s.producers {
+			require.Same(t, s, p.stream,
+				"producer %d stream back-ref not set", i)
+		}
+	})
+
+	t.Run("[]any sources", func(t *testing.T) {
+		s := NewStream([]any{"rtsp://a", "rtsp://b"})
+		require.Len(t, s.producers, 2)
+		for i, p := range s.producers {
+			require.Same(t, s, p.stream,
+				"producer %d stream back-ref not set", i)
+		}
+	})
 }

--- a/internal/streams/stream_test.go
+++ b/internal/streams/stream_test.go
@@ -34,12 +34,12 @@ type mockInternalConsumer struct {
 }
 
 // Satisfy core.Info — we only need GetSource for the kick-skip check.
-func (m *mockInternalConsumer) SetProtocol(string)             {}
-func (m *mockInternalConsumer) SetRemoteAddr(string)           {}
-func (m *mockInternalConsumer) SetSource(string)               {}
-func (m *mockInternalConsumer) SetURL(string)                  {}
-func (m *mockInternalConsumer) WithRequest(*http.Request)      {}
-func (m *mockInternalConsumer) GetSource() string              { return m.source }
+func (m *mockInternalConsumer) SetProtocol(string)        {}
+func (m *mockInternalConsumer) SetRemoteAddr(string)      {}
+func (m *mockInternalConsumer) SetSource(string)          {}
+func (m *mockInternalConsumer) SetURL(string)             {}
+func (m *mockInternalConsumer) WithRequest(*http.Request) {}
+func (m *mockInternalConsumer) GetSource() string         { return m.source }
 
 func TestRecursion(t *testing.T) {
 	// create stream with some source
@@ -236,5 +236,15 @@ func TestNewStreamLinksProducers(t *testing.T) {
 			require.Same(t, s, p.stream,
 				"producer %d stream back-ref not set", i)
 		}
+	})
+
+	t.Run("presentation stream control source", func(t *testing.T) {
+		s := NewStream(map[string]any{
+			"url":     "ffmpeg:rtsp://127.0.0.1:8554/porton#video=copy#audio=aac",
+			"control": "porton",
+		})
+		require.Equal(t, "porton", s.control)
+		require.Len(t, s.producers, 1)
+		require.Equal(t, "ffmpeg:rtsp://127.0.0.1:8554/porton#video=copy#audio=aac", s.producers[0].url)
 	})
 }

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -22,6 +22,15 @@ func Init() {
 
 	log = app.GetLogger("streams")
 
+	// Surface the kick-on-reconnect mode at startup. Without this the
+	// only signal of the active setting is its absence from reconnect
+	// logs, which is easy to miss during incident triage.
+	if kickOnReconnect {
+		log.Info().Msg("[streams] kick on producer reconnect: enabled (GO2RTC_KICK_ON_RECONNECT=true)")
+	} else {
+		log.Info().Msg("[streams] kick on producer reconnect: disabled — set GO2RTC_KICK_ON_RECONNECT=true to re-enable for legacy RTSP clients")
+	}
+
 	for name, item := range cfg.Streams {
 		streams[name] = NewStream(item)
 	}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ import (
 
 func main() {
 	// version will be set later from -buildvcs info, this used only as fallback
-	app.Version = "1.9.14"
+	app.Version = "1.9.15"
 
 	type module struct {
 		name string

--- a/pkg/core/connection.go
+++ b/pkg/core/connection.go
@@ -56,6 +56,13 @@ func (c *Connection) GetMedias() []*Media {
 	return c.Medias
 }
 
+// GetRemoteAddr exposes RemoteAddr through a method so consumer types
+// embedding *Connection can be discovered via a small interface in the
+// streams package without an import cycle.
+func (c *Connection) GetRemoteAddr() string {
+	return c.RemoteAddr
+}
+
 func (c *Connection) GetTrack(media *Media, codec *Codec) (*Receiver, error) {
 	for _, receiver := range c.Receivers {
 		if receiver.Codec == codec {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -69,6 +69,25 @@ type Consumer interface {
 	Stop() error
 }
 
+// LifetimeLimited is an optional interface for Producers whose upstream
+// has a known maximum stream lifetime (e.g. Google Nest WebRTC enforces
+// a ~60 min cap per session, after which a fresh offer/answer is
+// required). When implemented, the wrapping streams.Producer registers
+// a reconnect callback during start, and the underlying producer can
+// invoke it ahead of the lifetime limit to trigger a proactive
+// connection swap. This avoids the data gap that comes from waiting
+// for the upstream to silently stop delivering frames.
+//
+// The callback is goroutine-safe; the producer may invoke it from any
+// goroutine. It is idempotent — repeated calls during a single
+// reconnect cycle no-op via the streams.Producer workerID guard. The
+// implementation is expected to swap the callback under its own lock
+// (the wrapping Producer may call SetReconnectCallback again after a
+// reconnect creates a new underlying connection).
+type LifetimeLimited interface {
+	SetReconnectCallback(cb func())
+}
+
 type Mode byte
 
 const (

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -69,6 +69,10 @@ type Consumer interface {
 	Stop() error
 }
 
+type PTZ interface {
+	Move(pan, tilt float64) error
+}
+
 // LifetimeLimited is an optional interface for Producers whose upstream
 // has a known maximum stream lifetime (e.g. Google Nest WebRTC enforces
 // a ~60 min cap per session, after which a fresh offer/answer is

--- a/pkg/core/helpers.go
+++ b/pkg/core/helpers.go
@@ -92,3 +92,40 @@ func Caller() string {
 	_, file, line, _ := runtime.Caller(1)
 	return file + ":" + strconv.Itoa(line)
 }
+
+// StripUserinfo redacts the userinfo (username:password) portion of any
+// rtsp:// or http:// URL embedded in the given string. The URL host,
+// path, and query are preserved unchanged. Intended for sanitising
+// streams.yaml content before it appears in logs or shared bug reports.
+//
+// Only the userinfo immediately preceding a scheme://host boundary is
+// replaced, so a literal "@" inside a path or query (e.g.
+// "rtsp://10.1.2.3:554/stream1@#video=copy") is left intact.
+func StripUserinfo(s string) string {
+	const placeholder = "***"
+	var b strings.Builder
+	b.Grow(len(s))
+	for {
+		i := strings.Index(s, "://")
+		if i < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		b.WriteString(s[:i+3])
+		s = s[i+3:]
+		// Find the next userinfo terminator before the host ends. The
+		// host ends at '/', '?', '#', whitespace, or end-of-string.
+		end := len(s)
+		for j, ch := range s {
+			if ch == '/' || ch == '?' || ch == '#' || ch == ' ' || ch == '\n' || ch == '\r' || ch == '\t' {
+				end = j
+				break
+			}
+		}
+		if at := strings.LastIndex(s[:end], "@"); at >= 0 {
+			b.WriteString(placeholder)
+			b.WriteByte('@')
+			s = s[at+1:]
+		}
+	}
+}

--- a/pkg/core/track.go
+++ b/pkg/core/track.go
@@ -3,6 +3,8 @@ package core
 import (
 	"encoding/json"
 	"errors"
+	"math/rand/v2"
+	"time"
 
 	"github.com/pion/rtp"
 )
@@ -19,6 +21,20 @@ type Receiver struct {
 
 	Bytes   int `json:"bytes,omitempty"`
 	Packets int `json:"packets,omitempty"`
+
+	// RTP continuity rewriting state. See NewReceiver for the rationale
+	// and Replace for the swap-time transfer logic. Package-private so
+	// the rewrite contract is fully owned by this package; callers see
+	// only continuous RTP downstream.
+	outgoingSSRC    uint32
+	lastOutgoingSeq uint16
+	lastOutgoingTS  uint32
+	lastPacketTime  time.Time
+	upstreamSSRC    uint32
+	seqOffset       int32
+	tsOffset        int64
+	initialized     bool
+	rewriteRTP      bool
 }
 
 func NewReceiver(media *Media, codec *Codec) *Receiver {
@@ -26,7 +42,84 @@ func NewReceiver(media *Media, codec *Codec) *Receiver {
 		Node:  Node{id: NewID(), Codec: codec},
 		Media: media,
 	}
+
+	// For RTP-based codecs, normalize outgoing RTP so downstream sees
+	// one continuous stream across upstream session swaps
+	// (Receiver.Replace, triggered by Producer.reconnect — including the
+	// proactive reconnect on lifetime-limited sources like Nest WebRTC's
+	// ~60 min cap).
+	//
+	// Without this, every reconnect produces a fresh upstream session
+	// with a new SSRC, fresh sequence numbers, and a new RTP timestamp
+	// clock. Strict consumers (UniFi Protect 7.1.69 confirmed) interpret
+	// the SSRC change as "the stream I was recording has ended" and stop
+	// writing to disk — even though the RTSP/TCP session is still alive
+	// and packets keep arriving. With rewriting:
+	//   - outgoingSSRC stays constant for the life of this Receiver and
+	//     propagates through Replace to its successors
+	//   - sequence numbers continue monotonically from where we left off
+	//   - timestamps advance by an amount roughly matching the wall-clock
+	//     time elapsed during the reconnect (clock-rate × elapsed)
+	// so the swap is invisible to RTP-layer logic in consumers.
+	if codec != nil && codec.IsRTP() {
+		r.rewriteRTP = true
+		// Random 32-bit SSRC. Collision probability across a single
+		// stream's consumers is negligible (~1 in 4 billion).
+		r.outgoingSSRC = rand.Uint32()
+	}
+
 	r.Input = func(packet *Packet) {
+		if r.rewriteRTP {
+			now := time.Now()
+			// SSRC change signals either the cold start of this receiver
+			// (Packets == 0) or an upstream session swap mid-stream
+			// (initialized && new SSRC). The cold-start case adopts the
+			// upstream SSRC silently; the mid-stream case computes
+			// continuity offsets so downstream sequence/timestamp stay
+			// monotonic from where we left off.
+			if packet.SSRC != r.upstreamSSRC {
+				if r.initialized {
+					// Estimate how much RTP clock time should appear to
+					// have elapsed across the swap. Use wall-clock
+					// elapsed × codec ClockRate, clamped to a sane
+					// range so a long pause or a clock skew doesn't
+					// produce an enormous timestamp jump. For typical
+					// proactive reconnects this is ~2 s × 90 kHz =
+					// 180 000 samples (video) or ~2 s × 48 kHz =
+					// 96 000 (Opus audio).
+					elapsed := now.Sub(r.lastPacketTime)
+					if elapsed < time.Millisecond || elapsed > 30*time.Second {
+						elapsed = 100 * time.Millisecond
+					}
+					clockRate := uint32(90000)
+					if r.Codec != nil && r.Codec.ClockRate > 0 {
+						clockRate = r.Codec.ClockRate
+					}
+					clockAdvance := int64(elapsed.Seconds() * float64(clockRate))
+					if clockAdvance < 1 {
+						clockAdvance = 1
+					}
+
+					r.seqOffset = int32(r.lastOutgoingSeq+1) - int32(packet.SequenceNumber)
+					r.tsOffset = int64(r.lastOutgoingTS) + clockAdvance - int64(packet.Timestamp)
+				}
+				r.upstreamSSRC = packet.SSRC
+				r.initialized = true
+			}
+
+			if r.seqOffset != 0 {
+				packet.SequenceNumber = uint16(int32(packet.SequenceNumber) + r.seqOffset)
+			}
+			if r.tsOffset != 0 {
+				packet.Timestamp = uint32(int64(packet.Timestamp) + r.tsOffset)
+			}
+			packet.SSRC = r.outgoingSSRC
+
+			r.lastOutgoingSeq = packet.SequenceNumber
+			r.lastOutgoingTS = packet.Timestamp
+			r.lastPacketTime = now
+		}
+
 		r.Bytes += len(packet.Payload)
 		r.Packets++
 		for _, child := range r.childs {
@@ -52,6 +145,33 @@ func (r *Receiver) Senders() []*Sender {
 
 // Deprecated: should be removed
 func (r *Receiver) Replace(target *Receiver) {
+	// Transfer outgoing RTP continuity state to the successor receiver so
+	// downstream consumers see one uninterrupted stream across the swap.
+	// target.Input's closure captures target by pointer, so updating these
+	// fields here is visible to the next Input call without any further
+	// wiring. Only applies when both ends are RTP — for raw-codec
+	// receivers (PayloadTypeRAW) we leave packets untouched.
+	if r.rewriteRTP && target.rewriteRTP {
+		target.outgoingSSRC = r.outgoingSSRC
+		target.lastOutgoingSeq = r.lastOutgoingSeq
+		target.lastOutgoingTS = r.lastOutgoingTS
+		target.lastPacketTime = r.lastPacketTime
+		// initialized = true (so the new-SSRC branch in Input recognises
+		// this as a session change, not a cold start) but upstreamSSRC =
+		// 0 (so any real upstream SSRC triggers the change branch). On
+		// the next packet, Input computes seq/ts offsets anchored on the
+		// inherited lastOutgoingSeq / lastOutgoingTS.
+		//
+		// Cold-start case (first packet through a brand-new receiver
+		// that was never Replaced) still works: initialized is the
+		// zero-value false there, so the offset-compute branch is
+		// skipped and packets pass through with only SSRC rewriting.
+		target.initialized = true
+		target.upstreamSSRC = 0
+		target.seqOffset = 0
+		target.tsOffset = 0
+	}
+
 	MoveNode(&target.Node, &r.Node)
 }
 

--- a/pkg/core/track_test.go
+++ b/pkg/core/track_test.go
@@ -2,7 +2,9 @@ package core
 
 import (
 	"testing"
+	"time"
 
+	"github.com/pion/rtp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,4 +52,195 @@ func TestSenser(t *testing.T) {
 		ok = false
 	}
 	require.False(t, ok)
+}
+
+// rtpPkt is a test helper for constructing a minimal rtp.Packet with the
+// fields used by the continuity-rewrite logic. Other fields are zeroed.
+func rtpPkt(ssrc uint32, seq uint16, ts uint32) *Packet {
+	return &Packet{
+		Header: rtp.Header{
+			Version:        2,
+			SSRC:           ssrc,
+			SequenceNumber: seq,
+			Timestamp:      ts,
+		},
+		Payload: []byte{0xFF},
+	}
+}
+
+// captureChild is a child Node whose Input copies the packet header into
+// a slice so tests can assert what downstream sees after Receiver
+// rewriting.
+func captureChild(out *[]rtp.Header) *Node {
+	n := &Node{id: NewID()}
+	n.Input = func(p *Packet) { *out = append(*out, p.Header) }
+	return n
+}
+
+// TestReceiverRTPContinuity verifies the SSRC / seq / timestamp rewriting
+// that keeps downstream RTP continuous across an upstream session swap
+// (i.e. Receiver.Replace from Producer.reconnect). Without this, strict
+// consumers like UniFi Protect treat the SSRC change as "stream ended"
+// and stop recording even though the RTSP/TCP session is still alive.
+func TestReceiverRTPContinuity(t *testing.T) {
+	t.Run("non-RTP codec leaves packets untouched", func(t *testing.T) {
+		// PayloadTypeRAW means the codec doesn't use RTP packets; the
+		// rewrite path must be a no-op so raw-payload pipelines work
+		// unchanged.
+		var out []rtp.Header
+		r := NewReceiver(nil, &Codec{Name: "RAW", PayloadType: PayloadTypeRAW})
+		r.Node.AppendChild(captureChild(&out))
+
+		p := rtpPkt(0x11111111, 1000, 50000)
+		r.Input(p)
+
+		require.Equal(t, uint32(0x11111111), out[0].SSRC, "SSRC must pass through unchanged for non-RTP codecs")
+		require.Equal(t, uint16(1000), out[0].SequenceNumber)
+		require.Equal(t, uint32(50000), out[0].Timestamp)
+		require.False(t, r.rewriteRTP)
+	})
+
+	t.Run("stable SSRC + passthrough seq/ts for a single-session stream", func(t *testing.T) {
+		var out []rtp.Header
+		r := NewReceiver(nil, &Codec{Name: CodecH264, ClockRate: 90000, PayloadType: 96})
+		r.Node.AppendChild(captureChild(&out))
+
+		require.True(t, r.rewriteRTP)
+		require.NotZero(t, r.outgoingSSRC)
+		stableSSRC := r.outgoingSSRC
+
+		// Three packets from the same upstream SSRC: outgoing SSRC must
+		// be our chosen stable value; seq/ts pass through (offsets are
+		// zero on the first session, so no recomputation occurs).
+		r.Input(rtpPkt(0xAAAAAAAA, 100, 1000))
+		r.Input(rtpPkt(0xAAAAAAAA, 101, 4000))
+		r.Input(rtpPkt(0xAAAAAAAA, 102, 7000))
+
+		require.Len(t, out, 3)
+		for i, h := range out {
+			require.Equal(t, stableSSRC, h.SSRC, "packet %d: outgoing SSRC must equal r.outgoingSSRC", i)
+		}
+		require.Equal(t, uint16(100), out[0].SequenceNumber)
+		require.Equal(t, uint16(101), out[1].SequenceNumber)
+		require.Equal(t, uint16(102), out[2].SequenceNumber)
+		require.Equal(t, uint32(1000), out[0].Timestamp)
+		require.Equal(t, uint32(4000), out[1].Timestamp)
+		require.Equal(t, uint32(7000), out[2].Timestamp)
+	})
+
+	t.Run("upstream SSRC change anchors continuity (seq+1, ts forward)", func(t *testing.T) {
+		var out []rtp.Header
+		r := NewReceiver(nil, &Codec{Name: CodecH264, ClockRate: 90000, PayloadType: 96})
+		r.Node.AppendChild(captureChild(&out))
+
+		// Establish session 1: last outgoing seq=500, ts=90000.
+		r.Input(rtpPkt(0xAAAAAAAA, 500, 90000))
+		require.Equal(t, uint16(500), out[0].SequenceNumber)
+		require.Equal(t, uint32(90000), out[0].Timestamp)
+
+		// Force "elapsed time" to a known value by backdating
+		// lastPacketTime. Without this the elapsed-clamp branch picks
+		// 100 ms (1 ms..30 s sanity range), which is fine but harder
+		// to assert against. 1 s at 90 kHz = 90 000 samples.
+		r.lastPacketTime = time.Now().Add(-1 * time.Second)
+
+		// Session 2: brand-new upstream SSRC, fresh seq/ts. The first
+		// packet through must trigger the continuity recomputation.
+		r.Input(rtpPkt(0xBBBBBBBB, 7000, 5000000))
+
+		require.Len(t, out, 2)
+		require.Equal(t, out[0].SSRC, out[1].SSRC, "outgoing SSRC must stay constant across upstream session change")
+		// First packet of session 2 must be seq=lastOutgoingSeq+1=501.
+		require.Equal(t, uint16(501), out[1].SequenceNumber,
+			"sequence number must continue monotonically from the previous session")
+		// Timestamp must advance by ~clockRate*elapsed (~90 000)
+		// from the previous outgoing timestamp (90 000), so ~180 000.
+		// Allow a small fudge for elapsed-time measurement jitter.
+		require.InDelta(t, 180000, out[1].Timestamp, 5000,
+			"timestamp must advance by ~clockRate × elapsed seconds")
+	})
+
+	t.Run("subsequent packets after session change preserve relative spacing", func(t *testing.T) {
+		var out []rtp.Header
+		r := NewReceiver(nil, &Codec{Name: CodecH264, ClockRate: 90000, PayloadType: 96})
+		r.Node.AppendChild(captureChild(&out))
+
+		r.Input(rtpPkt(0xAAAAAAAA, 500, 90000))
+		r.lastPacketTime = time.Now().Add(-1 * time.Second)
+
+		// New session: three packets with normal 30 fps spacing
+		// (3 000 samples between frames at 90 kHz, seq +1 per packet).
+		r.Input(rtpPkt(0xBBBBBBBB, 7000, 5000000))
+		r.Input(rtpPkt(0xBBBBBBBB, 7001, 5003000))
+		r.Input(rtpPkt(0xBBBBBBBB, 7002, 5006000))
+
+		require.Len(t, out, 4)
+		// Sequence must be 500, 501, 502, 503.
+		require.Equal(t, uint16(501), out[1].SequenceNumber)
+		require.Equal(t, uint16(502), out[2].SequenceNumber)
+		require.Equal(t, uint16(503), out[3].SequenceNumber)
+		// Timestamps must advance by exactly 3 000 between each of the
+		// new-session frames (relative spacing of the upstream stream
+		// is preserved).
+		require.Equal(t, uint32(3000), out[2].Timestamp-out[1].Timestamp)
+		require.Equal(t, uint32(3000), out[3].Timestamp-out[2].Timestamp)
+	})
+
+	t.Run("Replace transfers continuity state to successor", func(t *testing.T) {
+		// downstream captures what the consumer ends up receiving. There's
+		// only one consumer here — `old` has it attached as a child, and
+		// after Replace that child is moved to `successor`, so packets
+		// fed to either receiver land in the same slice.
+		var downstream []rtp.Header
+		old := NewReceiver(nil, &Codec{Name: CodecH264, ClockRate: 90000, PayloadType: 96})
+		old.Node.AppendChild(captureChild(&downstream))
+
+		old.Input(rtpPkt(0xAAAAAAAA, 1000, 100000))
+		stableSSRC := old.outgoingSSRC
+		require.Len(t, downstream, 1)
+		require.Equal(t, stableSSRC, downstream[0].SSRC)
+		require.Equal(t, uint16(1000), downstream[0].SequenceNumber)
+
+		// Build the successor receiver as Producer.reconnect would: a
+		// fresh Receiver from the new upstream connection. Its own
+		// outgoingSSRC is random and different from old's — Replace must
+		// overwrite it so downstream continuity holds.
+		successor := NewReceiver(nil, &Codec{Name: CodecH264, ClockRate: 90000, PayloadType: 96})
+		require.NotEqual(t, stableSSRC, successor.outgoingSSRC,
+			"successor's pre-Replace SSRC must differ so we know the transfer happened")
+
+		old.lastPacketTime = time.Now().Add(-2 * time.Second)
+		old.Replace(successor)
+
+		// After Replace, successor inherits old's outgoing-state.
+		require.Equal(t, stableSSRC, successor.outgoingSSRC)
+		require.Equal(t, uint16(1000), successor.lastOutgoingSeq)
+		require.Equal(t, uint32(100000), successor.lastOutgoingTS)
+		require.True(t, successor.initialized,
+			"initialized must stay true so the first packet's SSRC mismatch is treated as a session change, not a cold start")
+		require.Equal(t, uint32(0), successor.upstreamSSRC,
+			"upstreamSSRC must be reset to 0 so any real new-session SSRC triggers the change branch")
+
+		// MoveNode contract: old's children move to successor. old now
+		// has no children of its own, so future packets fed to old go
+		// nowhere — which is what Producer.reconnect relies on to make
+		// the swap clean.
+		require.Empty(t, old.childs, "old's children must have moved to successor")
+
+		// First packet on successor from the new upstream session.
+		// Continuity rewrite must produce: outgoing SSRC = stable
+		// (unchanged), seq = lastOutgoingSeq + 1 = 1001, timestamp
+		// forward (>= old's last + clockAdvance).
+		successor.Input(rtpPkt(0xBBBBBBBB, 9000, 9000000))
+		require.Len(t, downstream, 2)
+		require.Equal(t, stableSSRC, downstream[1].SSRC,
+			"outgoing SSRC must remain stable across the producer-reconnect swap")
+		require.Equal(t, uint16(1001), downstream[1].SequenceNumber,
+			"sequence number must continue from where old left off")
+		require.Greater(t, downstream[1].Timestamp, uint32(100000),
+			"timestamp must advance past where old left off")
+		// Specifically: ~2 s × 90 000 Hz ≈ 180 000 advance from 100 000
+		// → expect roughly 280 000. Allow some elapsed-time jitter.
+		require.InDelta(t, 280000, downstream[1].Timestamp, 20000)
+	})
 }

--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -144,7 +144,10 @@ func (a *API) GetDevices(projectID string) ([]DeviceInfo, error) {
 
 	req.Header.Set("Authorization", "Bearer "+a.Token)
 
-	client := &http.Client{Timeout: time.Second * 5000}
+	// 10 s timeout (was time.Second * 5000 ≈ 83 minutes — almost certainly
+	// an upstream typo for 5s; left as 10s so flaky Google API calls fail
+	// fast instead of blocking a goroutine for over an hour).
+	client := &http.Client{Timeout: 10 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -221,7 +224,9 @@ func (a *API) ExchangeSDP(projectID, deviceID, offer string) (string, error) {
 
 		req.Header.Set("Authorization", "Bearer "+a.Token)
 
-		client := &http.Client{Timeout: time.Second * 5000}
+		// 10 s timeout — see GetDevices for context on why we dropped from
+		// the upstream 5000s value.
+		client := &http.Client{Timeout: 10 * time.Second}
 		res, err := client.Do(req)
 		if err != nil {
 			return "", err
@@ -364,6 +369,19 @@ func (a *API) refreshToken() error {
 	return nil
 }
 
+// extendBackoffInitial is the initial back-off delay for transient
+// 409/429 responses in ExtendStream. Doubles after each failed retry up
+// to maxRetries. Exposed as a package variable so tests can shorten it.
+var extendBackoffInitial = 30 * time.Second
+
+// extendURI builds the Google SDM API URI for a stream-extend command.
+// Hookable for tests so they can point requests at an httptest server
+// without needing a live Google endpoint or network access.
+var extendURI = func(projectID, deviceID string) string {
+	return "https://smartdevicemanagement.googleapis.com/v1/enterprises/" +
+		projectID + "/devices/" + deviceID + ":executeCommand"
+}
+
 func (a *API) ExtendStream() error {
 	var reqv struct {
 		Command string `json:"command"`
@@ -388,77 +406,100 @@ func (a *API) ExtendStream() error {
 		return err
 	}
 
-	uri := "https://smartdevicemanagement.googleapis.com/v1/enterprises/" +
-		a.StreamProjectID + "/devices/" + a.StreamDeviceID + ":executeCommand"
+	uri := extendURI(a.StreamProjectID, a.StreamDeviceID)
 
-	// Helper because the request must be replayed verbatim after a 401
-	// refresh (a single *http.Request can't be Do'd twice — the body
-	// reader would be drained).
+	// Helper because the request must be replayed verbatim after a retry
+	// (a single *http.Request can't be Do'd twice — the body reader
+	// would be drained).
 	doRequest := func() (*http.Response, error) {
 		req, err := http.NewRequest("POST", uri, bytes.NewReader(b))
 		if err != nil {
 			return nil, err
 		}
 		req.Header.Set("Authorization", "Bearer "+a.Token)
-		client := &http.Client{Timeout: time.Second * 10}
+		client := &http.Client{Timeout: 10 * time.Second}
 		return client.Do(req)
 	}
 
-	res, err := doRequest()
-	if err != nil {
-		return err
-	}
+	// Retry loop handles three classes of response status:
+	//   - 401 Unauthorized: OAuth tokens expire after ~60 minutes and a
+	//     mid-session extend will land on a freshly-expired token. Refresh
+	//     and retry immediately (counts as one attempt, no backoff).
+	//   - 409 Conflict / 429 Too Many Requests: transient server-side
+	//     condition. Back off exponentially and retry.
+	//   - 200 OK: parse the new session expiry/token and return.
+	//   - anything else: surface as error immediately.
+	const maxRetries = 3
+	backoff := extendBackoffInitial
 
-	// OAuth tokens expire after ~60 minutes. Each Nest stream session
-	// runs up to ~60 minutes too, so it's normal for an extend mid-way
-	// through a session to land on a freshly-expired token. Refresh
-	// the token and retry once.
-	if res.StatusCode == 401 {
-		res.Body.Close()
-		// until_predicted_expiry sign distinguishes two cases:
-		//   positive: token rejected *before* our predicted expiry —
-		//     Google rotated early, or our cached ExpiresAt was wrong
-		//   negative: token was rejected *after* our predicted expiry —
-		//     we should have refreshed proactively (current code is
-		//     lazy 401-driven, so this is normal)
-		Log("info", "[nest] extend got 401, refreshing OAuth token",
-			"session", a.StreamSessionID,
-			"predicted_expires_at", a.ExpiresAt,
-			"until_predicted_expiry", time.Until(a.ExpiresAt).String())
-		if err := a.refreshToken(); err != nil {
-			return errors.New("nest: token refresh failed during extend: " + err.Error())
-		}
-		res, err = doRequest()
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		res, err := doRequest()
 		if err != nil {
 			return err
 		}
+
+		if res.StatusCode == 401 && attempt < maxRetries-1 {
+			res.Body.Close()
+			// until_predicted_expiry sign distinguishes two cases:
+			//   positive: token rejected *before* our predicted expiry —
+			//     Google rotated early, or our cached ExpiresAt was wrong
+			//   negative: token was rejected *after* our predicted expiry —
+			//     we should have refreshed proactively (current code is
+			//     lazy 401-driven, so this is normal)
+			Log("info", "[nest] extend got 401, refreshing OAuth token",
+				"session", a.StreamSessionID,
+				"predicted_expires_at", a.ExpiresAt,
+				"until_predicted_expiry", time.Until(a.ExpiresAt).String(),
+				"attempt", attempt+1,
+				"max_attempts", maxRetries)
+			if err := a.refreshToken(); err != nil {
+				return errors.New("nest: token refresh failed during extend: " + err.Error())
+			}
+			continue
+		}
+
+		if (res.StatusCode == 409 || res.StatusCode == 429) && attempt < maxRetries-1 {
+			res.Body.Close()
+			Log("warn", "[nest] extend got transient status, backing off and retrying",
+				"session", a.StreamSessionID,
+				"status", res.Status,
+				"attempt", attempt+1,
+				"max_attempts", maxRetries,
+				"backoff", backoff.String())
+			time.Sleep(backoff)
+			backoff *= 2
+			continue
+		}
+
+		if res.StatusCode != 200 {
+			res.Body.Close()
+			return errors.New("nest: wrong status: " + res.Status)
+		}
+
+		var resv struct {
+			Results struct {
+				ExpiresAt            time.Time `json:"expiresAt"`
+				MediaSessionID       string    `json:"mediaSessionId"`
+				StreamExtensionToken string    `json:"streamExtensionToken"`
+				StreamToken          string    `json:"streamToken"`
+			} `json:"results"`
+		}
+
+		err = json.NewDecoder(res.Body).Decode(&resv)
+		res.Body.Close()
+		if err != nil {
+			return err
+		}
+
+		a.StreamSessionID = resv.Results.MediaSessionID
+		a.StreamExpiresAt = resv.Results.ExpiresAt
+		a.StreamExtensionToken = resv.Results.StreamExtensionToken
+		a.StreamToken = resv.Results.StreamToken
+
+		return nil
 	}
 
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return errors.New("nest: wrong status: " + res.Status)
-	}
-
-	var resv struct {
-		Results struct {
-			ExpiresAt            time.Time `json:"expiresAt"`
-			MediaSessionID       string    `json:"mediaSessionId"`
-			StreamExtensionToken string    `json:"streamExtensionToken"`
-			StreamToken          string    `json:"streamToken"`
-		} `json:"results"`
-	}
-
-	if err = json.NewDecoder(res.Body).Decode(&resv); err != nil {
-		return err
-	}
-
-	a.StreamSessionID = resv.Results.MediaSessionID
-	a.StreamExpiresAt = resv.Results.ExpiresAt
-	a.StreamExtensionToken = resv.Results.StreamExtensionToken
-	a.StreamToken = resv.Results.StreamToken
-
-	return nil
+	return errors.New("nest: extend max retries exceeded")
 }
 
 func (a *API) GenerateRtspStream(projectID, deviceID string) (string, error) {
@@ -482,11 +523,16 @@ func (a *API) GenerateRtspStream(projectID, deviceID string) (string, error) {
 
 	req.Header.Set("Authorization", "Bearer "+a.Token)
 
-	client := &http.Client{Timeout: time.Second * 5000}
+	// 10 s timeout — see GetDevices for context.
+	client := &http.Client{Timeout: 10 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
+	// defer Close() to cover the non-200 / decode-error early returns; the
+	// original code only closed the body via the implicit decoder path on
+	// the success branch, leaking connections under sustained errors.
+	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
 		return "", errors.New("nest: wrong status: " + res.Status)
@@ -546,11 +592,14 @@ func (a *API) StopRTSPStream() error {
 
 	req.Header.Set("Authorization", "Bearer "+a.Token)
 
-	client := &http.Client{Timeout: time.Second * 5000}
+	// 10 s timeout — see GetDevices for context.
+	client := &http.Client{Timeout: 10 * time.Second}
 	res, err := client.Do(req)
 	if err != nil {
 		return err
 	}
+	// defer Close() so the non-200 early return doesn't leak the connection.
+	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
 		return errors.New("nest: wrong status: " + res.Status)

--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -11,6 +11,23 @@ import (
 	"time"
 )
 
+// Log is the pkg/nest logging hook. Default is no-op so this package
+// can be imported without bringing in a logging dependency. The
+// wrapping go2rtc layer (internal/nest) replaces it during Init with a
+// function that routes structured records into the application
+// logger.
+//
+// Signature: level is one of "debug", "info", "warn", "error"; msg is
+// a short message; kv is alternating key/value pairs in the
+// zerolog-style (string key, any value, repeated).
+//
+// Used here to surface the stream-extend lifecycle (timer arming,
+// extend success/failure, terminal abandonment). Without it the
+// extend path is completely silent on success and almost-silent on
+// failure — which made the "new session never extended" diagnosis
+// from the 09:36 outage impossible to confirm from logs.
+var Log = func(level, msg string, kv ...any) {}
+
 type API struct {
 	Token     string
 	ExpiresAt time.Time
@@ -28,6 +45,12 @@ type API struct {
 
 	extendTimer *time.Timer
 	extendStop  chan struct{}
+
+	// refreshMu serializes OAuth token refreshes against this API so
+	// concurrent 401 retries (e.g. several near-simultaneous extend
+	// failures, or extend + a producer reconnect) do not each fire a
+	// separate refresh-token request to Google.
+	refreshMu sync.Mutex
 }
 
 type Auth struct {
@@ -51,8 +74,13 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 	now := time.Now()
 
 	if api := cache[key]; api != nil && now.Before(api.ExpiresAt) {
+		Log("debug", "[nest] OAuth cache hit (token still valid)",
+			"expires_at", api.ExpiresAt,
+			"ttl", time.Until(api.ExpiresAt).String())
 		return api, nil
 	}
+
+	Log("debug", "[nest] OAuth acquiring new token (cache miss or expired)")
 
 	data := url.Values{
 		"grant_type":    []string{"refresh_token"},
@@ -61,14 +89,22 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 		"refresh_token": []string{refreshToken},
 	}
 
-	client := &http.Client{Timeout: time.Second * 5000}
+	client := &http.Client{Timeout: time.Second * 10}
 	res, err := client.PostForm("https://www.googleapis.com/oauth2/v4/token", data)
 	if err != nil {
+		Log("error", "[nest] OAuth token request transport error",
+			"err", err.Error())
 		return nil, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
+		// Most useful failure modes: 400 (invalid_grant — refresh token
+		// revoked or wrong client_id/secret), 401 (bad credentials), 429
+		// (rate limit), 5xx (Google outage). Surface the status so the
+		// distinction is obvious in logs.
+		Log("error", "[nest] OAuth token request rejected",
+			"status", res.Status)
 		return nil, errors.New("nest: wrong status: " + res.Status)
 	}
 
@@ -80,6 +116,8 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 	}
 
 	if err = json.NewDecoder(res.Body).Decode(&resv); err != nil {
+		Log("error", "[nest] OAuth response decode failed",
+			"err", err.Error())
 		return nil, err
 	}
 
@@ -89,6 +127,10 @@ func NewAPI(clientID, clientSecret, refreshToken string) (*API, error) {
 	}
 
 	cache[key] = api
+
+	Log("info", "[nest] OAuth token acquired",
+		"expires_at", api.ExpiresAt,
+		"ttl", (resv.ExpiresIn * time.Second).String())
 
 	return api, nil
 }
@@ -188,6 +230,16 @@ func (a *API) ExchangeSDP(projectID, deviceID, offer string) (string, error) {
 		// Handle 409 (Conflict), 429 (Too Many Requests), and 401 (Unauthorized)
 		if res.StatusCode == 409 || res.StatusCode == 429 || res.StatusCode == 401 {
 			res.Body.Close()
+			// Surface the retry path so OAuth flakiness is visible
+			// (previously this branch was completely silent — making
+			// "ExchangeSDP eventually failed" indistinguishable from
+			// "ExchangeSDP failed once and then transient-retry-loop
+			// finally gave up").
+			Log("warn", "[nest] ExchangeSDP retryable status, refreshing token + retrying",
+				"status", res.Status,
+				"attempt", attempt+1,
+				"max_attempts", maxRetries,
+				"retry_delay", retryDelay.String())
 			if attempt < maxRetries-1 {
 				// Get new token from Google
 				if err := a.refreshToken(); err != nil {
@@ -228,12 +280,27 @@ func (a *API) ExchangeSDP(projectID, deviceID, offer string) (string, error) {
 	return "", errors.New("nest: max retries exceeded")
 }
 
+// refreshToken obtains a fresh OAuth access token from Google and
+// mutates this API instance's Token + ExpiresAt in place. Bypasses
+// NewAPI's cache check intentionally — callers reach this path
+// because the existing token was rejected (401), which means the
+// cache's recorded ExpiresAt is wrong (server-side expiry was earlier
+// than we thought) and a cache hit would just return the same stale
+// token.
+//
+// Serialized via refreshMu so concurrent 401 retries fold into one
+// refresh request; second caller through the lock benefits from the
+// first's freshly written Token without re-fetching.
 func (a *API) refreshToken() error {
-	// Get the cached API with matching token to get credentials
+	a.refreshMu.Lock()
+	defer a.refreshMu.Unlock()
+
+	// Look up our credentials from the cache (the cache stores APIs
+	// keyed by credential triple; the key was set in NewAPI).
 	var refreshKey string
 	cacheMu.Lock()
 	for key, api := range cache {
-		if api.Token == a.Token {
+		if api == a {
 			refreshKey = key
 			break
 		}
@@ -244,22 +311,56 @@ func (a *API) refreshToken() error {
 		return errors.New("nest: unable to find cached credentials")
 	}
 
-	// Parse credentials from cache key
 	parts := strings.Split(refreshKey, ":")
 	if len(parts) != 3 {
 		return errors.New("nest: invalid cache key format")
 	}
 	clientID, clientSecret, refreshToken := parts[0], parts[1], parts[2]
 
-	// Get new API instance which will refresh the token
-	newAPI, err := NewAPI(clientID, clientSecret, refreshToken)
+	previousExpiresAt := a.ExpiresAt
+	Log("debug", "[nest] OAuth token refresh starting",
+		"previous_expires_at", previousExpiresAt,
+		"since_predicted_expiry", time.Since(previousExpiresAt).String())
+
+	data := url.Values{
+		"grant_type":    []string{"refresh_token"},
+		"client_id":     []string{clientID},
+		"client_secret": []string{clientSecret},
+		"refresh_token": []string{refreshToken},
+	}
+
+	client := &http.Client{Timeout: time.Second * 10}
+	res, err := client.PostForm("https://www.googleapis.com/oauth2/v4/token", data)
 	if err != nil {
+		Log("error", "[nest] OAuth refresh transport error",
+			"err", err.Error())
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		Log("error", "[nest] OAuth refresh rejected",
+			"status", res.Status)
+		return errors.New("nest: token refresh failed: " + res.Status)
+	}
+
+	var resv struct {
+		AccessToken string        `json:"access_token"`
+		ExpiresIn   time.Duration `json:"expires_in"`
+	}
+	if err = json.NewDecoder(res.Body).Decode(&resv); err != nil {
+		Log("error", "[nest] OAuth refresh response decode failed",
+			"err", err.Error())
 		return err
 	}
 
-	// Update current API with new token
-	a.Token = newAPI.Token
-	a.ExpiresAt = newAPI.ExpiresAt
+	a.Token = resv.AccessToken
+	a.ExpiresAt = time.Now().Add(resv.ExpiresIn * time.Second)
+
+	Log("info", "[nest] OAuth token refreshed",
+		"new_expires_at", a.ExpiresAt,
+		"new_ttl", (resv.ExpiresIn * time.Second).String())
+
 	return nil
 }
 
@@ -289,18 +390,50 @@ func (a *API) ExtendStream() error {
 
 	uri := "https://smartdevicemanagement.googleapis.com/v1/enterprises/" +
 		a.StreamProjectID + "/devices/" + a.StreamDeviceID + ":executeCommand"
-	req, err := http.NewRequest("POST", uri, bytes.NewReader(b))
+
+	// Helper because the request must be replayed verbatim after a 401
+	// refresh (a single *http.Request can't be Do'd twice — the body
+	// reader would be drained).
+	doRequest := func() (*http.Response, error) {
+		req, err := http.NewRequest("POST", uri, bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+a.Token)
+		client := &http.Client{Timeout: time.Second * 10}
+		return client.Do(req)
+	}
+
+	res, err := doRequest()
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+a.Token)
-
-	client := &http.Client{Timeout: time.Second * 5000}
-	res, err := client.Do(req)
-	if err != nil {
-		return err
+	// OAuth tokens expire after ~60 minutes. Each Nest stream session
+	// runs up to ~60 minutes too, so it's normal for an extend mid-way
+	// through a session to land on a freshly-expired token. Refresh
+	// the token and retry once.
+	if res.StatusCode == 401 {
+		res.Body.Close()
+		// until_predicted_expiry sign distinguishes two cases:
+		//   positive: token rejected *before* our predicted expiry —
+		//     Google rotated early, or our cached ExpiresAt was wrong
+		//   negative: token was rejected *after* our predicted expiry —
+		//     we should have refreshed proactively (current code is
+		//     lazy 401-driven, so this is normal)
+		Log("info", "[nest] extend got 401, refreshing OAuth token",
+			"session", a.StreamSessionID,
+			"predicted_expires_at", a.ExpiresAt,
+			"until_predicted_expiry", time.Until(a.ExpiresAt).String())
+		if err := a.refreshToken(); err != nil {
+			return errors.New("nest: token refresh failed during extend: " + err.Error())
+		}
+		res, err = doRequest()
+		if err != nil {
+			return err
+		}
 	}
+
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
@@ -467,42 +600,69 @@ type Device struct {
 
 func (a *API) StartExtendStreamTimer() {
 	if a.extendTimer != nil {
+		Log("debug", "[nest] extend timer already armed, skipping",
+			"session", a.StreamSessionID)
 		return
 	}
 
 	// Nest streams expire ~5 minutes after the last extension. Re-arm after
 	// each successful ExtendStream so the loop keeps running; without the loop
 	// the stream silently dies at the second expiry (~10 min after connect).
-	a.extendTimer = time.NewTimer(extendDelay(a.StreamExpiresAt))
+	delay := extendDelay(a.StreamExpiresAt)
+	a.extendTimer = time.NewTimer(delay)
 	a.extendStop = make(chan struct{})
 	timer, stop := a.extendTimer, a.extendStop
+
+	Log("debug", "[nest] extend timer armed",
+		"session", a.StreamSessionID,
+		"expires_at", a.StreamExpiresAt,
+		"next_fire_in", delay.String())
+
 	go func() {
 		for {
 			select {
 			case <-stop:
+				Log("debug", "[nest] extend goroutine stopped (stop signal)",
+					"session", a.StreamSessionID)
 				return
 			case <-timer.C:
 			}
 
 			if err := a.ExtendStream(); err != nil {
+				Log("warn", "[nest] extend failed, retrying in 10s",
+					"session", a.StreamSessionID,
+					"err", err.Error())
 				// Retry once after a short delay to ride out transient errors.
 				select {
 				case <-stop:
+					Log("debug", "[nest] extend goroutine stopped during retry wait",
+						"session", a.StreamSessionID)
 					return
 				case <-time.After(10 * time.Second):
 				}
 				if err := a.ExtendStream(); err != nil {
+					Log("error", "[nest] extend giving up — stream will die at expires_at",
+						"session", a.StreamSessionID,
+						"expires_at", a.StreamExpiresAt,
+						"err", err.Error())
 					return
 				}
 			}
 
-			timer.Reset(extendDelay(a.StreamExpiresAt))
+			next := extendDelay(a.StreamExpiresAt)
+			Log("debug", "[nest] extend ok",
+				"session", a.StreamSessionID,
+				"expires_at", a.StreamExpiresAt,
+				"next_fire_in", next.String())
+			timer.Reset(next)
 		}
 	}()
 }
 
 func (a *API) StopExtendStreamTimer() {
 	if a.extendTimer != nil {
+		Log("debug", "[nest] extend timer cancelled",
+			"session", a.StreamSessionID)
 		close(a.extendStop)
 		a.extendTimer.Stop()
 		a.extendTimer = nil

--- a/pkg/nest/api.go
+++ b/pkg/nest/api.go
@@ -27,6 +27,7 @@ type API struct {
 	StreamExtensionToken string
 
 	extendTimer *time.Timer
+	extendStop  chan struct{}
 }
 
 type Auth struct {
@@ -469,18 +470,53 @@ func (a *API) StartExtendStreamTimer() {
 		return
 	}
 
-	a.extendTimer = time.NewTimer(time.Until(a.StreamExpiresAt) - time.Minute)
+	// Nest streams expire ~5 minutes after the last extension. Re-arm after
+	// each successful ExtendStream so the loop keeps running; without the loop
+	// the stream silently dies at the second expiry (~10 min after connect).
+	a.extendTimer = time.NewTimer(extendDelay(a.StreamExpiresAt))
+	a.extendStop = make(chan struct{})
+	timer, stop := a.extendTimer, a.extendStop
 	go func() {
-		<-a.extendTimer.C
-		if err := a.ExtendStream(); err != nil {
-			return
+		for {
+			select {
+			case <-stop:
+				return
+			case <-timer.C:
+			}
+
+			if err := a.ExtendStream(); err != nil {
+				// Retry once after a short delay to ride out transient errors.
+				select {
+				case <-stop:
+					return
+				case <-time.After(10 * time.Second):
+				}
+				if err := a.ExtendStream(); err != nil {
+					return
+				}
+			}
+
+			timer.Reset(extendDelay(a.StreamExpiresAt))
 		}
 	}()
 }
 
 func (a *API) StopExtendStreamTimer() {
 	if a.extendTimer != nil {
+		close(a.extendStop)
 		a.extendTimer.Stop()
 		a.extendTimer = nil
+		a.extendStop = nil
 	}
+}
+
+// extendDelay returns the wait time before the next stream extension call.
+// Clamped to a 1-second minimum so a stale or already-past expiry doesn't
+// cause a busy-loop of ExtendStream() calls.
+func extendDelay(expiresAt time.Time) time.Duration {
+	d := time.Until(expiresAt) - time.Minute
+	if d < time.Second {
+		return time.Second
+	}
+	return d
 }

--- a/pkg/nest/api_test.go
+++ b/pkg/nest/api_test.go
@@ -1,0 +1,239 @@
+package nest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureLogs replaces the package-level Log hook with one that records
+// every event into a slice. The slice is returned by-pointer so callers
+// can assert against it after the unit-under-test runs; the previous Log
+// implementation is restored on test cleanup.
+//
+// Recorded entries are "<level>|<msg>" — kv pairs are not captured here
+// because the existing tests only assert on level/msg.
+func captureLogs(t *testing.T) *[]string {
+	t.Helper()
+	var captured []string
+	prev := Log
+	Log = func(level, msg string, kv ...any) {
+		captured = append(captured, level+"|"+msg)
+	}
+	t.Cleanup(func() { Log = prev })
+	return &captured
+}
+
+// shortenExtendBackoff swaps the production 30s initial backoff for 1ms
+// so tests don't wait minutes between retries. Reverted on cleanup.
+func shortenExtendBackoff(t *testing.T) {
+	t.Helper()
+	prev := extendBackoffInitial
+	extendBackoffInitial = time.Millisecond
+	t.Cleanup(func() { extendBackoffInitial = prev })
+}
+
+// pointExtendURI redirects ExtendStream's outgoing requests to the given
+// httptest server URL instead of Google's real SDM API. Reverted on
+// cleanup. Tests that need to assert on the original URL behaviour should
+// not call this.
+func pointExtendURI(t *testing.T, serverURL string) {
+	t.Helper()
+	prev := extendURI
+	extendURI = func(_, _ string) string { return serverURL }
+	t.Cleanup(func() { extendURI = prev })
+}
+
+// newExtendAPI builds an API in a minimal state sufficient for
+// ExtendStream — a token (any string, the test server ignores it),
+// project/device IDs (only used for URI building, which the test
+// hook overrides), and a session ID so the WebRTC branch is taken.
+func newExtendAPI() *API {
+	return &API{
+		Token:           "test-token",
+		StreamProjectID: "test-project",
+		StreamDeviceID:  "test-device",
+		StreamSessionID: "session-before-extend",
+	}
+}
+
+// validExtendResponse is the minimal JSON body ExtendStream needs to
+// parse a 200 response without erroring. The expires-at is intentionally
+// far in the future so test runs aren't affected by clock skew.
+const validExtendResponse = `{
+  "results": {
+    "expiresAt": "2099-12-31T23:59:59Z",
+    "mediaSessionId": "session-after-extend",
+    "streamExtensionToken": "ext-token-after",
+    "streamToken": "stream-token-after"
+  }
+}`
+
+// TestExtendStreamRetry covers the retry/back-off behaviour added in
+// the 409/429-handling change. The 401-refresh path is covered
+// indirectly by the existing refresh-token logic and not re-tested
+// here because driving the refreshToken() path requires either a
+// second mock OAuth endpoint or a cache pre-seed — out of scope for
+// the retry-loop change being landed.
+func TestExtendStreamRetry(t *testing.T) {
+	shortenExtendBackoff(t)
+
+	t.Run("200 on first attempt — no retry, session updated", func(t *testing.T) {
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(validExtendResponse))
+		}))
+		defer server.Close()
+		pointExtendURI(t, server.URL)
+
+		api := newExtendAPI()
+		err := api.ExtendStream()
+		require.NoError(t, err)
+		require.Equal(t, int32(1), atomic.LoadInt32(&hits), "happy path must hit the endpoint exactly once")
+		require.Equal(t, "session-after-extend", api.StreamSessionID,
+			"successful extend must overwrite session ID with the new value from the response")
+		require.Equal(t, "ext-token-after", api.StreamExtensionToken)
+		require.Equal(t, "stream-token-after", api.StreamToken)
+	})
+
+	t.Run("429 then 200 — retries once after backoff, succeeds", func(t *testing.T) {
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&hits, 1)
+			if n == 1 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(validExtendResponse))
+		}))
+		defer server.Close()
+		pointExtendURI(t, server.URL)
+		logs := captureLogs(t)
+
+		api := newExtendAPI()
+		start := time.Now()
+		err := api.ExtendStream()
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.Equal(t, int32(2), atomic.LoadInt32(&hits), "must call server twice: one 429 then one 200")
+		require.Equal(t, "session-after-extend", api.StreamSessionID, "successful retry must still update session state")
+		// At least one backoff interval must have elapsed (extendBackoffInitial = 1ms).
+		require.GreaterOrEqual(t, elapsed, time.Millisecond, "must observe at least the configured backoff between attempts")
+		// Confirm the retry was logged at warn level (the only event the loop emits for 429/409).
+		var foundRetryLog bool
+		for _, l := range *logs {
+			if strings.HasPrefix(l, "warn|[nest] extend got transient status") {
+				foundRetryLog = true
+				break
+			}
+		}
+		require.True(t, foundRetryLog, "expected a warn-level log for the 429 retry; got %v", *logs)
+	})
+
+	t.Run("409 then 200 — same retry path as 429", func(t *testing.T) {
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&hits, 1)
+			if n == 1 {
+				w.WriteHeader(http.StatusConflict)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(validExtendResponse))
+		}))
+		defer server.Close()
+		pointExtendURI(t, server.URL)
+
+		api := newExtendAPI()
+		err := api.ExtendStream()
+		require.NoError(t, err)
+		require.Equal(t, int32(2), atomic.LoadInt32(&hits))
+		require.Equal(t, "session-after-extend", api.StreamSessionID)
+	})
+
+	t.Run("three consecutive 429s exhaust max retries and return error", func(t *testing.T) {
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+		defer server.Close()
+		pointExtendURI(t, server.URL)
+
+		api := newExtendAPI()
+		preSessionID := api.StreamSessionID
+		err := api.ExtendStream()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wrong status: 429",
+			"after retries are exhausted, the loop should surface the last status as an error")
+		require.Equal(t, int32(3), atomic.LoadInt32(&hits),
+			"maxRetries is 3; should attempt exactly that many times before giving up")
+		require.Equal(t, preSessionID, api.StreamSessionID,
+			"failed extend must leave session state untouched")
+	})
+
+	t.Run("500 server error returns immediately — only 409/429/401 are retried", func(t *testing.T) {
+		// 5xx is intentionally not in the retry list. The Google API returns
+		// 5xx for genuine server problems where retrying without delay is
+		// counterproductive; the producer-level reconnect machinery is the
+		// right place to handle those, not this inner loop.
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+		pointExtendURI(t, server.URL)
+
+		api := newExtendAPI()
+		err := api.ExtendStream()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wrong status: 500")
+		require.Equal(t, int32(1), atomic.LoadInt32(&hits),
+			"5xx must fail fast without consuming the retry budget")
+	})
+
+	t.Run("backoff doubles between retries", func(t *testing.T) {
+		// Two consecutive 429s followed by a 200. With initial backoff =
+		// 1ms (test override), the loop sleeps 1ms before retry 2 and 2ms
+		// before retry 3. Asserting precise timing would be flaky on
+		// shared CI; instead assert that elapsed time is at least the sum
+		// of expected backoffs (1ms + 2ms = 3ms).
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&hits, 1)
+			if n <= 2 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(validExtendResponse))
+		}))
+		defer server.Close()
+		pointExtendURI(t, server.URL)
+
+		api := newExtendAPI()
+		start := time.Now()
+		err := api.ExtendStream()
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.Equal(t, int32(3), atomic.LoadInt32(&hits))
+		// Lower bound: 1ms (first backoff) + 2ms (doubled) = 3ms. Practical
+		// time.Sleep often rounds up by a few ms on Windows so this is a
+		// safe floor without being flaky.
+		require.GreaterOrEqual(t, elapsed, 3*time.Millisecond,
+			"backoff doubling should produce at least 1ms + 2ms of cumulative sleep")
+	})
+}

--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -12,14 +13,41 @@ import (
 	pion "github.com/pion/webrtc/v4"
 )
 
+// refreshBeforeCap is how long before Nest's max-stream-lifetime cap to
+// trigger a proactive reconnect. Google's WebRTC stream lifetime is
+// documented as up to 1 hour; empirically the cap hits between 60 and
+// 67 minutes. Triggering refresh at +55 minutes from initial Exchange
+// gives a 5+ minute buffer for the swap to complete (GetProducer for
+// nest takes a few seconds — ExchangeSDP RPC + ICE setup) before the
+// old session goes silent.
+//
+// Exposed as a package variable so tests can shorten it.
+var refreshBeforeCap = 55 * time.Minute
+
 type WebRTCClient struct {
 	conn *webrtc.Conn
 	api  *API
+
+	// proactiveReconnect callback wired up by the wrapping
+	// streams.Producer via SetReconnectCallback. Invoked once by the
+	// refresh timer ahead of Nest's lifetime cap. Guarded by mu so the
+	// timer goroutine and the producer reconnect path (which calls
+	// SetReconnectCallback again on the new conn after a swap) can't
+	// race.
+	mu              sync.Mutex
+	reconnectCB     func()
+	refreshTimer    *time.Timer
+	refreshFired    bool
 }
 
 type RTSPClient struct {
 	conn *rtsp.Conn
 	api  *API
+
+	mu              sync.Mutex
+	reconnectCB     func()
+	refreshTimer    *time.Timer
+	refreshFired    bool
 }
 
 func Dial(rawURL string) (core.Producer, error) {
@@ -83,13 +111,76 @@ func (c *WebRTCClient) AddTrack(media *core.Media, codec *core.Codec, track *cor
 }
 
 func (c *WebRTCClient) Start() error {
+	c.scheduleRefresh()
 	c.api.StartExtendStreamTimer()
 	return c.conn.Start()
 }
 
 func (c *WebRTCClient) Stop() error {
+	c.cancelRefresh()
 	c.api.StopExtendStreamTimer()
 	return c.conn.Stop()
+}
+
+// SetReconnectCallback implements core.LifetimeLimited. Called by the
+// streams.Producer wrapping this client during start (and again after
+// each reconnect-swap onto a new client instance).
+func (c *WebRTCClient) SetReconnectCallback(cb func()) {
+	c.mu.Lock()
+	c.reconnectCB = cb
+	c.mu.Unlock()
+}
+
+// scheduleRefresh arms a one-shot timer to invoke the producer's
+// proactive-reconnect callback ahead of Nest's lifetime cap. Safe to
+// call multiple times — only the first arm takes effect.
+func (c *WebRTCClient) scheduleRefresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.refreshTimer != nil {
+		return
+	}
+	c.refreshTimer = time.AfterFunc(refreshBeforeCap, c.fireRefresh)
+}
+
+func (c *WebRTCClient) cancelRefresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Mark as fired so any in-flight fireRefresh that races us (timer
+	// already entered the AfterFunc goroutine before we Stop'd it)
+	// no-ops. Without this, a near-simultaneous Stop + timer-fire can
+	// trigger a proactive reconnect on a client that's being torn
+	// down — and the late callback could fire long after the new
+	// client took over, mistargeting the producer.
+	c.refreshFired = true
+	if c.refreshTimer != nil {
+		c.refreshTimer.Stop()
+		c.refreshTimer = nil
+	}
+}
+
+// fireRefresh runs in the timer goroutine. Invokes the producer's
+// proactive-reconnect callback in a fresh goroutine so the timer
+// runner isn't blocked by the reconnect — GetProducer for Nest can
+// take several seconds (ExchangeSDP + ICE).
+func (c *WebRTCClient) fireRefresh() {
+	c.mu.Lock()
+	if c.refreshFired {
+		c.mu.Unlock()
+		return
+	}
+	c.refreshFired = true
+	cb := c.reconnectCB
+	c.mu.Unlock()
+	if cb == nil {
+		Log("warn", "[nest] refresh timer fired but no reconnect callback registered",
+			"session", c.api.StreamSessionID)
+		return
+	}
+	Log("info", "[nest] refresh timer fired — triggering proactive reconnect",
+		"session", c.api.StreamSessionID,
+		"age", refreshBeforeCap.String())
+	go cb()
 }
 
 func (c *WebRTCClient) MarshalJSON() ([]byte, error) {
@@ -182,14 +273,61 @@ func (c *RTSPClient) GetTrack(media *core.Media, codec *core.Codec) (*core.Recei
 }
 
 func (c *RTSPClient) Start() error {
+	c.scheduleRefresh()
 	c.api.StartExtendStreamTimer()
 	return c.conn.Start()
 }
 
 func (c *RTSPClient) Stop() error {
+	c.cancelRefresh()
 	c.api.StopRTSPStream()
 	c.api.StopExtendStreamTimer()
 	return c.conn.Stop()
+}
+
+func (c *RTSPClient) SetReconnectCallback(cb func()) {
+	c.mu.Lock()
+	c.reconnectCB = cb
+	c.mu.Unlock()
+}
+
+func (c *RTSPClient) scheduleRefresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.refreshTimer != nil {
+		return
+	}
+	c.refreshTimer = time.AfterFunc(refreshBeforeCap, c.fireRefresh)
+}
+
+func (c *RTSPClient) cancelRefresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refreshFired = true
+	if c.refreshTimer != nil {
+		c.refreshTimer.Stop()
+		c.refreshTimer = nil
+	}
+}
+
+func (c *RTSPClient) fireRefresh() {
+	c.mu.Lock()
+	if c.refreshFired {
+		c.mu.Unlock()
+		return
+	}
+	c.refreshFired = true
+	cb := c.reconnectCB
+	c.mu.Unlock()
+	if cb == nil {
+		Log("warn", "[nest] refresh timer fired but no reconnect callback registered",
+			"session", c.api.StreamSessionID)
+		return
+	}
+	Log("info", "[nest] refresh timer fired — triggering proactive reconnect (rtsp)",
+		"session", c.api.StreamSessionID,
+		"age", refreshBeforeCap.String())
+	go cb()
 }
 
 func (c *RTSPClient) MarshalJSON() ([]byte, error) {

--- a/pkg/nest/client.go
+++ b/pkg/nest/client.go
@@ -57,13 +57,13 @@ func Dial(rawURL string) (core.Producer, error) {
 	}
 
 	query := u.Query()
-	cliendID := query.Get("client_id")
-	cliendSecret := query.Get("client_secret")
+	clientID := query.Get("client_id")
+	clientSecret := query.Get("client_secret")
 	refreshToken := query.Get("refresh_token")
 	projectID := query.Get("project_id")
 	deviceID := query.Get("device_id")
 
-	if cliendID == "" || cliendSecret == "" || refreshToken == "" || projectID == "" || deviceID == "" {
+	if clientID == "" || clientSecret == "" || refreshToken == "" || projectID == "" || deviceID == "" {
 		return nil, errors.New("nest: wrong query")
 	}
 
@@ -74,7 +74,7 @@ func Dial(rawURL string) (core.Producer, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		nestAPI, err = NewAPI(cliendID, cliendSecret, refreshToken)
+		nestAPI, err = NewAPI(clientID, clientSecret, refreshToken)
 		if err == nil {
 			break
 		}
@@ -94,7 +94,7 @@ func Dial(rawURL string) (core.Producer, error) {
 		return rtspConn(nestAPI, rawURL, projectID, deviceID)
 	}
 
-	// Default to WEB_RTC for backwards compataiility
+	// Default to WEB_RTC for backwards compatibility
 	return rtcConn(nestAPI, rawURL, projectID, deviceID)
 }
 
@@ -220,12 +220,26 @@ func rtcConn(nestAPI *API, rawURL, projectID, deviceID string) (*WebRTCClient, e
 		// 3. Create offer with candidates
 		offer, err := conn.CreateCompleteOffer(medias)
 		if err != nil {
+			// Close the PeerConnection on every error return so its UDP
+			// sockets, ICE state, and DTLS context are released. Without
+			// this, repeated dial failures (which happen during Google
+			// API throttling or transient network issues) would leak a
+			// PeerConnection per failed attempt and slowly exhaust the
+			// process's UDP-port and goroutine budget.
+			_ = pc.Close()
+			Log("debug", "[nest] closed PeerConnection after CreateCompleteOffer error",
+				"err", err.Error())
 			return nil, err
 		}
 
-		// 4. Exchange SDP via Hass
+		// 4. Exchange SDP via Google SDM API
 		answer, err := nestAPI.ExchangeSDP(projectID, deviceID, offer)
 		if err != nil {
+			_ = pc.Close()
+			Log("debug", "[nest] closed PeerConnection after ExchangeSDP error",
+				"err", err.Error(),
+				"attempt", attempt+1,
+				"max_attempts", maxRetries)
 			lastErr = err
 			if attempt < maxRetries-1 {
 				time.Sleep(retryDelay)
@@ -237,6 +251,9 @@ func rtcConn(nestAPI *API, rawURL, projectID, deviceID string) (*WebRTCClient, e
 
 		// 5. Set answer with remote medias
 		if err = conn.SetAnswer(answer); err != nil {
+			_ = pc.Close()
+			Log("debug", "[nest] closed PeerConnection after SetAnswer error",
+				"err", err.Error())
 			return nil, err
 		}
 

--- a/pkg/onvif/envelope.go
+++ b/pkg/onvif/envelope.go
@@ -15,7 +15,7 @@ type Envelope struct {
 }
 
 const (
-	prefix1 = `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl">`
+	prefix1 = `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl">`
 	prefix2 = `<s:Body>`
 	suffix  = `</s:Body></s:Envelope>`
 )

--- a/pkg/onvif/envelope.go
+++ b/pkg/onvif/envelope.go
@@ -17,7 +17,7 @@ type Envelope struct {
 }
 
 const (
-	prefix1 = `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl">`
+	prefix1 = `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl">`
 	prefix2 = `<s:Body>`
 	suffix  = `</s:Body></s:Envelope>`
 )

--- a/pkg/onvif/envelope.go
+++ b/pkg/onvif/envelope.go
@@ -2,9 +2,11 @@ package onvif
 
 import (
 	"crypto/sha1"
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -58,6 +60,21 @@ func NewEnvelopeWithUser(user *url.Userinfo) *Envelope {
 	return e
 }
 
+// nonceTTL bounds both how stale a Created timestamp may be and how long a
+// (username, nonce) pair is remembered for replay rejection.
+const nonceTTL = 5 * time.Minute
+
+// futureSkew is the only leeway given to a Created timestamp that's ahead of
+// our clock (normal clock drift); tokens claiming to be further in the
+// future than this are rejected outright rather than accepted into the
+// full nonceTTL window.
+const futureSkew = 30 * time.Second
+
+var (
+	seenNoncesMu sync.Mutex
+	seenNonces   = map[string]time.Time{}
+)
+
 func VerifyUsernameToken(b []byte, username, password string) bool {
 	if FindTagValue(b, "Username") != username {
 		return false
@@ -65,11 +82,20 @@ func VerifyUsernameToken(b []byte, username, password string) bool {
 
 	created := FindTagValue(b, "Created")
 	t, err := time.Parse(time.RFC3339Nano, created)
-	if err != nil || time.Since(t).Abs() > 5*time.Minute {
+	if err != nil {
+		return false
+	}
+	if age := time.Since(t); age < -futureSkew || age > nonceTTL {
 		return false
 	}
 
-	nonce, err := base64.StdEncoding.DecodeString(FindTagValue(b, "Nonce"))
+	nonceB64 := FindTagValue(b, "Nonce")
+	nonce, err := base64.StdEncoding.DecodeString(nonceB64)
+	if err != nil {
+		return false
+	}
+
+	provided, err := base64.StdEncoding.DecodeString(FindTagValue(b, "Password"))
 	if err != nil {
 		return false
 	}
@@ -78,9 +104,33 @@ func VerifyUsernameToken(b []byte, username, password string) bool {
 	h.Write(nonce)
 	h.Write([]byte(created))
 	h.Write([]byte(password))
-	digest := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	digest := h.Sum(nil)
 
-	return FindTagValue(b, "Password") == digest
+	if subtle.ConstantTimeCompare(digest, provided) != 1 {
+		return false
+	}
+
+	// Reject replays of a previously-seen (username, nonce, created) triple.
+	// ponytail: in-memory map, so restarting the process resets it; fine for
+	// a single-instance server, add a shared store if you ever run more than one.
+	key := username + "\x00" + nonceB64 + "\x00" + created
+
+	seenNoncesMu.Lock()
+	defer seenNoncesMu.Unlock()
+
+	if _, dup := seenNonces[key]; dup {
+		return false
+	}
+
+	now := time.Now()
+	for k, exp := range seenNonces {
+		if now.After(exp) {
+			delete(seenNonces, k)
+		}
+	}
+	seenNonces[key] = now.Add(nonceTTL)
+
+	return true
 }
 
 func (e *Envelope) Append(args ...string) {

--- a/pkg/onvif/envelope.go
+++ b/pkg/onvif/envelope.go
@@ -58,6 +58,31 @@ func NewEnvelopeWithUser(user *url.Userinfo) *Envelope {
 	return e
 }
 
+func VerifyUsernameToken(b []byte, username, password string) bool {
+	if FindTagValue(b, "Username") != username {
+		return false
+	}
+
+	created := FindTagValue(b, "Created")
+	t, err := time.Parse(time.RFC3339Nano, created)
+	if err != nil || time.Since(t).Abs() > 5*time.Minute {
+		return false
+	}
+
+	nonce, err := base64.StdEncoding.DecodeString(FindTagValue(b, "Nonce"))
+	if err != nil {
+		return false
+	}
+
+	h := sha1.New()
+	h.Write(nonce)
+	h.Write([]byte(created))
+	h.Write([]byte(password))
+	digest := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	return FindTagValue(b, "Password") == digest
+}
+
 func (e *Envelope) Append(args ...string) {
 	for _, s := range args {
 		e.buf = append(e.buf, s...)

--- a/pkg/onvif/helpers.go
+++ b/pkg/onvif/helpers.go
@@ -128,26 +128,50 @@ func atoi(s string) int {
 	return i
 }
 
+// GetPosixTZ returns a POSIX-style TZ string suitable for ONVIF
+// GetSystemDateAndTime responses. ONVIF (per IEEE 1003.1 POSIX) expects
+// strings of the form `std[offset[dst[offset][,start,end]]]`, e.g.
+// "UTC0", "EST5EDT,M3.2.0,M11.1.0".
+//
+// POSIX uses the *reverse* sign convention from ISO 8601: UTC-5 (EST) is
+// written "EST5", UTC+9 (JST) is written "JST-9".
+//
+// We don't try to emit DST rules (Go's tzdata doesn't expose them in an
+// easily-renderable form). Clients that need DST awareness should fall
+// back to UTCDateTime, which we also include in the response.
 func GetPosixTZ(current time.Time) string {
-	// Thanks to https://github.com/Path-Variable/go-posix-time
-	_, offset := current.Zone()
-
+	// In DST, advance past the next transition so we report the standard
+	// offset rather than the DST offset — POSIX's std field is the
+	// non-DST baseline.
+	name, offset := current.Zone()
 	if current.IsDST() {
 		_, end := current.ZoneBounds()
-		endPlus1 := end.Add(time.Hour * 25)
-		_, offset = endPlus1.Zone()
+		stdName, stdOffset := end.Add(time.Hour * 25).Zone()
+		name, offset = stdName, stdOffset
 	}
 
-	var prefix string
-	if offset < 0 {
-		prefix = "GMT+"
-		offset = -offset / 60
-	} else {
-		prefix = "GMT-"
-		offset = offset / 60
+	if name == "" {
+		name = "GMT"
 	}
 
-	return prefix + fmt.Sprintf("%02d:%02d", offset/60, offset%60)
+	// POSIX offset is the negation of the ISO offset (in seconds).
+	posixSec := -offset
+	if posixSec == 0 {
+		return name + "0"
+	}
+
+	sign := ""
+	if posixSec < 0 {
+		sign = "-"
+		posixSec = -posixSec
+	}
+
+	hours := posixSec / 3600
+	mins := (posixSec % 3600) / 60
+	if mins == 0 {
+		return fmt.Sprintf("%s%s%d", name, sign, hours)
+	}
+	return fmt.Sprintf("%s%s%d:%02d", name, sign, hours, mins)
 }
 
 func GetPath(urlOrPath, defPath string) string {

--- a/pkg/onvif/helpers.go
+++ b/pkg/onvif/helpers.go
@@ -27,6 +27,15 @@ func FindTagValue(b []byte, tag string) string {
 	return string(m[1])
 }
 
+func FindTagAttribute(b []byte, tag, attribute string) string {
+	re := regexp.MustCompile(`(?s)<(?:\w+:)?` + tag + `\b[^>]*\b` + attribute + `="([^"]+)"`)
+	m := re.FindSubmatch(b)
+	if len(m) != 2 {
+		return ""
+	}
+	return string(m[1])
+}
+
 // UUID - generate something like 44302cbf-0d18-4feb-79b3-33b575263da3
 func UUID() string {
 	s := core.RandString(32, 16)

--- a/pkg/onvif/onvif_test.go
+++ b/pkg/onvif/onvif_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -222,6 +223,123 @@ func TestGetCapabilities(t *testing.T) {
 
 			rawURL = FindTagValue([]byte(test.xml), "Imaging.+?XAddr")
 			require.Equal(t, "http://192.168.1.123/onvif/imaging_service", rawURL)
+		})
+	}
+}
+
+// TestGetPosixTZ verifies the POSIX TZ string format that ONVIF
+// GetSystemDateAndTime responses use. POSIX TZ uses reversed sign
+// convention vs. ISO 8601: UTC-5 (EST) is written "EST5", UTC+9 (JST)
+// is written "JST-9". No colons in standard form; we permit a colon
+// for half-hour offsets only.
+func TestGetPosixTZ(t *testing.T) {
+	tests := []struct {
+		name string
+		zone *time.Location
+		want string
+	}{
+		{"UTC", time.UTC, "UTC0"},
+		{"EST west of UTC", time.FixedZone("EST", -5*3600), "EST5"},
+		{"JST east of UTC", time.FixedZone("JST", 9*3600), "JST-9"},
+		{"NST half-hour west", time.FixedZone("NST", -3*3600-1800), "NST3:30"},
+		{"IST half-hour east", time.FixedZone("IST", 5*3600+1800), "IST-5:30"},
+		{"empty zone name falls back to GMT", time.FixedZone("", -5*3600), "GMT5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now().In(tt.zone)
+			require.Equal(t, tt.want, GetPosixTZ(now))
+		})
+	}
+}
+
+// TestGetCapabilitiesResponse verifies all three ONVIF services
+// (Device, Media, Imaging) are advertised in the response.
+func TestGetCapabilitiesResponse(t *testing.T) {
+	out := string(GetCapabilitiesResponse("192.168.1.123:1984"))
+
+	require.Contains(t, out, "<tt:Device>")
+	require.Contains(t, out, "<tt:Media>")
+	require.Contains(t, out, "<tt:Imaging>")
+	require.Contains(t, out, "http://192.168.1.123:1984/onvif/device_service")
+	require.Contains(t, out, "http://192.168.1.123:1984/onvif/media_service")
+	require.Contains(t, out, "http://192.168.1.123:1984/onvif/imaging_service")
+	require.Contains(t, out, "<tt:RTP_RTSP_TCP>true</tt:RTP_RTSP_TCP>")
+}
+
+// TestGetServicesResponse verifies all three WSDL namespaces are
+// advertised in the response (Device, Media, Imaging).
+func TestGetServicesResponse(t *testing.T) {
+	out := string(GetServicesResponse("192.168.1.123:1984"))
+
+	require.Contains(t, out, "http://www.onvif.org/ver10/device/wsdl")
+	require.Contains(t, out, "http://www.onvif.org/ver10/media/wsdl")
+	require.Contains(t, out, "http://www.onvif.org/ver20/imaging/wsdl")
+	require.Contains(t, out, "http://192.168.1.123:1984/onvif/device_service")
+	require.Contains(t, out, "http://192.168.1.123:1984/onvif/media_service")
+	require.Contains(t, out, "http://192.168.1.123:1984/onvif/imaging_service")
+}
+
+// TestGetProfilesResponseIncludesAudio verifies appendProfile emits both
+// audio and video Source/Encoder Configuration blocks. The audio blocks
+// are essential for UniFi Protect 3rd-party adoption: without
+// AudioEncoderConfiguration in the profile, UniFi won't negotiate the
+// audio track during RTSP SETUP even if SDP advertises it.
+func TestGetProfilesResponseIncludesAudio(t *testing.T) {
+	out := string(GetProfilesResponse([]string{"driveway"}))
+
+	require.Contains(t, out, `token="driveway"`)
+	require.Contains(t, out, "<tt:VideoSourceConfiguration")
+	require.Contains(t, out, "<tt:VideoEncoderConfiguration")
+	require.Contains(t, out, "<tt:AudioSourceConfiguration")
+	require.Contains(t, out, "<tt:AudioEncoderConfiguration")
+	require.Contains(t, out, "<tt:Encoding>H264</tt:Encoding>")
+	require.Contains(t, out, "<tt:Encoding>AAC</tt:Encoding>")
+}
+
+// TestImagingResponses verifies the imaging service stub responses use
+// the timg: namespace and produce well-formed (if empty) configurations.
+// The namespace prefix must be declared on the envelope for clients to
+// parse them; the regression check is "do these strings appear together
+// in the same response".
+func TestImagingResponses(t *testing.T) {
+	tests := []struct {
+		name  string
+		body  []byte
+		inner string
+	}{
+		{"GetServiceCapabilities", GetImagingServiceCapabilitiesResponse(), "<timg:GetServiceCapabilitiesResponse>"},
+		{"GetImagingSettings", GetImagingSettingsResponse(), "<timg:GetImagingSettingsResponse>"},
+		{"GetOptions", GetImagingOptionsResponse(), "<timg:GetOptionsResponse>"},
+		{"GetMoveOptions", GetImagingMoveOptionsResponse(), "<timg:GetMoveOptionsResponse>"},
+		{"GetStatus", GetImagingStatusResponse(), "<timg:GetStatusResponse>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := string(tt.body)
+			require.Contains(t, out, tt.inner)
+			require.Contains(t, out, `xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl"`)
+		})
+	}
+}
+
+// TestStaticResponseRoutesImagingOps verifies the operation-name
+// dispatcher in StaticResponse routes imaging operations to the
+// timg-namespaced response builders rather than falling through to
+// the empty-string default.
+func TestStaticResponseRoutesImagingOps(t *testing.T) {
+	for _, op := range []string{
+		ImagingGetImagingSettings,
+		ImagingGetOptions,
+		ImagingGetMoveOptions,
+		ImagingGetStatus,
+	} {
+		t.Run(op, func(t *testing.T) {
+			out := string(StaticResponse(op))
+			require.Contains(t, out, "<timg:")
+			require.Contains(t, out, op+"Response>")
 		})
 	}
 }

--- a/pkg/onvif/onvif_test.go
+++ b/pkg/onvif/onvif_test.go
@@ -363,3 +363,30 @@ func TestStaticResponseRoutesImagingOps(t *testing.T) {
 		})
 	}
 }
+
+func TestPTZResponses(t *testing.T) {
+	capabilities := string(GetCapabilitiesResponse("192.168.1.123:1984"))
+	require.Contains(t, capabilities, "http://192.168.1.123:1984/onvif/ptz_service")
+
+	services := string(GetServicesResponse("192.168.1.123:1984"))
+	require.Contains(t, services, "http://www.onvif.org/ver20/ptz/wsdl")
+
+	profile := string(GetProfilesResponse([]string{"porton"}))
+	require.Contains(t, profile, "<tt:PTZConfiguration")
+
+	for _, response := range []string{
+		string(GetPTZConfigurationsResponse()),
+		string(GetPTZNodesResponse()),
+		string(GetPTZStatusResponse()),
+		string(GetPTZContinuousMoveResponse()),
+		string(GetPTZStopResponse()),
+	} {
+		require.Contains(t, response, `xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl"`)
+	}
+}
+
+func TestFindTagAttribute(t *testing.T) {
+	request := []byte(`<tptz:ContinuousMove><tptz:Velocity><tt:PanTilt x="-0.5" y="1" /></tptz:Velocity></tptz:ContinuousMove>`)
+	require.Equal(t, "-0.5", FindTagAttribute(request, "PanTilt", "x"))
+	require.Equal(t, "1", FindTagAttribute(request, "PanTilt", "y"))
+}

--- a/pkg/onvif/onvif_test.go
+++ b/pkg/onvif/onvif_test.go
@@ -22,6 +22,14 @@ func TestVerifyUsernameToken(t *testing.T) {
 	require.False(t, VerifyUsernameToken([]byte(stale), "admin", "secret"))
 }
 
+func TestVerifyUsernameTokenReplay(t *testing.T) {
+	e := NewEnvelopeWithUser(url.UserPassword("admin", "secret"))
+	b := e.Bytes()
+
+	require.True(t, VerifyUsernameToken(b, "admin", "secret"))
+	require.False(t, VerifyUsernameToken(b, "admin", "secret"))
+}
+
 func TestGetStreamUri(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/onvif/onvif_test.go
+++ b/pkg/onvif/onvif_test.go
@@ -378,6 +378,7 @@ func TestPTZResponses(t *testing.T) {
 		string(GetPTZConfigurationsResponse()),
 		string(GetPTZNodesResponse()),
 		string(GetPTZStatusResponse()),
+		string(GetPTZAbsoluteMoveResponse()),
 		string(GetPTZContinuousMoveResponse()),
 		string(GetPTZStopResponse()),
 	} {

--- a/pkg/onvif/onvif_test.go
+++ b/pkg/onvif/onvif_test.go
@@ -10,6 +10,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVerifyUsernameToken(t *testing.T) {
+	u := url.UserPassword("admin", "secret")
+	e := NewEnvelopeWithUser(u)
+
+	require.True(t, VerifyUsernameToken(e.Bytes(), "admin", "secret"))
+	require.False(t, VerifyUsernameToken(e.Bytes(), "admin", "wrong"))
+	require.False(t, VerifyUsernameToken(e.Bytes(), "other", "secret"))
+
+	stale := `<wsse:Security><wsse:UsernameToken><wsse:Username>admin</wsse:Username><wsse:Password>x</wsse:Password><wsse:Nonce>eA==</wsse:Nonce><wsu:Created>2000-01-01T00:00:00Z</wsu:Created></wsse:UsernameToken></wsse:Security>`
+	require.False(t, VerifyUsernameToken([]byte(stale), "admin", "secret"))
+}
+
 func TestGetStreamUri(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -26,8 +26,10 @@ const (
 )
 
 const (
+	MediaGetAudioEncoderConfiguration        = "GetAudioEncoderConfiguration"
 	MediaGetAudioEncoderConfigurations       = "GetAudioEncoderConfigurations"
 	MediaGetAudioSources                     = "GetAudioSources"
+	MediaGetAudioSourceConfiguration         = "GetAudioSourceConfiguration"
 	MediaGetAudioSourceConfigurations        = "GetAudioSourceConfigurations"
 	MediaGetProfile                          = "GetProfile"
 	MediaGetProfiles                         = "GetProfiles"
@@ -39,6 +41,16 @@ const (
 	MediaGetVideoSources                     = "GetVideoSources"
 	MediaGetVideoSourceConfiguration         = "GetVideoSourceConfiguration"
 	MediaGetVideoSourceConfigurations        = "GetVideoSourceConfigurations"
+)
+
+// Imaging service operations. Note: GetServiceCapabilities is shared with
+// the Media service (same operation name); the dispatcher must differentiate
+// by URL path (/onvif/imaging_service vs /onvif/media_service) when routing.
+const (
+	ImagingGetImagingSettings = "GetImagingSettings"
+	ImagingGetOptions         = "GetOptions"
+	ImagingGetMoveOptions     = "GetMoveOptions"
+	ImagingGetStatus          = "GetStatus"
 )
 
 func GetRequestAction(b []byte) string {
@@ -70,8 +82,11 @@ func GetCapabilitiesResponse(host string) []byte {
 				<tt:RTP_RTSP_TCP>true</tt:RTP_RTSP_TCP>
 			</tt:StreamingCapabilities>
 		</tt:Media>
+		<tt:Imaging>
+			<tt:XAddr>http://%s/onvif/imaging_service</tt:XAddr>
+		</tt:Imaging>
 	</tds:Capabilities>
-</tds:GetCapabilitiesResponse>`, host, host)
+</tds:GetCapabilitiesResponse>`, host, host, host)
 	return e.Bytes()
 }
 
@@ -88,7 +103,12 @@ func GetServicesResponse(host string) []byte {
 		<tds:XAddr>http://%s/onvif/media_service</tds:XAddr>
 		<tds:Version><tt:Major>2</tt:Major><tt:Minor>5</tt:Minor></tds:Version>
 	</tds:Service>
-</tds:GetServicesResponse>`, host, host)
+	<tds:Service>
+		<tds:Namespace>http://www.onvif.org/ver20/imaging/wsdl</tds:Namespace>
+		<tds:XAddr>http://%s/onvif/imaging_service</tds:XAddr>
+		<tds:Version><tt:Major>2</tt:Major><tt:Minor>5</tt:Minor></tds:Version>
+	</tds:Service>
+</tds:GetServicesResponse>`, host, host, host)
 	return e.Bytes()
 }
 
@@ -157,6 +177,8 @@ func appendProfile(e *Envelope, tag, name string) {
 	e.Appendf(`<tt:Name>%s</tt:Name>`, name)
 	appendVideoSourceConfiguration(e, "VideoSourceConfiguration", name)
 	appendVideoEncoderConfiguration(e, "VideoEncoderConfiguration")
+	appendAudioSourceConfiguration(e, "AudioSourceConfiguration")
+	appendAudioEncoderConfiguration(e, "AudioEncoderConfiguration")
 	e.Appendf(`</trt:%s>`, tag)
 }
 
@@ -231,6 +253,130 @@ func appendVideoEncoderConfiguration(e *Envelope, tag string) {
 	</tt:%s>`, tag, tag)
 }
 
+func appendAudioSourceConfiguration(e *Envelope, tag string) {
+	e.Appendf(`<tt:%s token="asc">
+		<tt:Name>ASC</tt:Name>
+		<tt:UseCount>1</tt:UseCount>
+		<tt:SourceToken>audio_source</tt:SourceToken>
+	</tt:%s>`, tag, tag)
+}
+
+func appendAudioEncoderConfiguration(e *Envelope, tag string) {
+	// Encoding=AAC (ONVIF allows G711/G726/AAC). go2rtc transcodes to AAC when
+	// requested via `audio=aac`, so always advertise AAC capability for clients
+	// like UniFi Protect that only set up audio if the profile declares it.
+	e.Appendf(`<tt:%s token="aec">
+		<tt:Name>AEC</tt:Name>
+		<tt:UseCount>1</tt:UseCount>
+		<tt:Encoding>AAC</tt:Encoding>
+		<tt:Bitrate>64</tt:Bitrate>
+		<tt:SampleRate>48</tt:SampleRate>
+		<tt:Multicast>
+			<tt:Address><tt:Type>IPv4</tt:Type><tt:IPv4Address>0.0.0.0</tt:IPv4Address></tt:Address>
+			<tt:Port>0</tt:Port>
+			<tt:TTL>1</tt:TTL>
+			<tt:AutoStart>false</tt:AutoStart>
+		</tt:Multicast>
+		<tt:SessionTimeout>PT60S</tt:SessionTimeout>
+	</tt:%s>`, tag, tag)
+}
+
+func GetAudioSourcesResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<trt:GetAudioSourcesResponse>
+		<trt:AudioSources token="audio_source">
+			<tt:Channels>1</tt:Channels>
+		</trt:AudioSources>
+	</trt:GetAudioSourcesResponse>`)
+	return e.Bytes()
+}
+
+func GetAudioSourceConfigurationsResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<trt:GetAudioSourceConfigurationsResponse>`)
+	appendAudioSourceConfiguration(e, "Configurations")
+	e.Append(`</trt:GetAudioSourceConfigurationsResponse>`)
+	return e.Bytes()
+}
+
+func GetAudioEncoderConfigurationsResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<trt:GetAudioEncoderConfigurationsResponse>`)
+	appendAudioEncoderConfiguration(e, "Configurations")
+	e.Append(`</trt:GetAudioEncoderConfigurationsResponse>`)
+	return e.Bytes()
+}
+
+// GetAudioSourceConfigurationResponse — singular variant. ONVIF spec says
+// implementations SHOULD provide both singular and plural Get variants for
+// every Configuration type; we previously only provided the plural.
+func GetAudioSourceConfigurationResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<trt:GetAudioSourceConfigurationResponse>`)
+	appendAudioSourceConfiguration(e, "Configuration")
+	e.Append(`</trt:GetAudioSourceConfigurationResponse>`)
+	return e.Bytes()
+}
+
+// GetAudioEncoderConfigurationResponse — singular variant. See note above.
+func GetAudioEncoderConfigurationResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<trt:GetAudioEncoderConfigurationResponse>`)
+	appendAudioEncoderConfiguration(e, "Configuration")
+	e.Append(`</trt:GetAudioEncoderConfigurationResponse>`)
+	return e.Bytes()
+}
+
+// GetImagingServiceCapabilitiesResponse advertises a minimal imaging service
+// with no features enabled. UniFi, Frigate, and a few NVRs probe imaging
+// even on cameras that don't support it; returning a well-formed empty
+// capabilities document is friendlier than 4xx-ing the request.
+func GetImagingServiceCapabilitiesResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<timg:GetServiceCapabilitiesResponse>
+		<timg:Capabilities ImageStabilization="false" Presets="false" />
+	</timg:GetServiceCapabilitiesResponse>`)
+	return e.Bytes()
+}
+
+// GetImagingSettingsResponse returns an empty imaging settings document.
+// No image adjustments are supported.
+func GetImagingSettingsResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<timg:GetImagingSettingsResponse>
+		<timg:ImagingSettings />
+	</timg:GetImagingSettingsResponse>`)
+	return e.Bytes()
+}
+
+// GetImagingOptionsResponse returns an empty options set — no adjustable
+// imaging parameters offered.
+func GetImagingOptionsResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<timg:GetOptionsResponse>
+		<timg:ImagingOptions />
+	</timg:GetOptionsResponse>`)
+	return e.Bytes()
+}
+
+// GetImagingMoveOptionsResponse returns empty move options — no focus motor.
+func GetImagingMoveOptionsResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<timg:GetMoveOptionsResponse>
+		<timg:MoveOptions />
+	</timg:GetMoveOptionsResponse>`)
+	return e.Bytes()
+}
+
+// GetImagingStatusResponse returns a neutral status.
+func GetImagingStatusResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<timg:GetStatusResponse>
+		<timg:Status />
+	</timg:GetStatusResponse>`)
+	return e.Bytes()
+}
+
 func GetStreamUriResponse(uri string) []byte {
 	e := NewEnvelope()
 	e.Appendf(`<trt:GetStreamUriResponse><trt:MediaUri><tt:Uri>%s</tt:Uri></trt:MediaUri></trt:GetStreamUriResponse>`, uri)
@@ -251,6 +397,24 @@ func StaticResponse(operation string) []byte {
 		return GetVideoEncoderConfigurationResponse()
 	case MediaGetVideoEncoderConfigurations:
 		return GetVideoEncoderConfigurationsResponse()
+	case MediaGetAudioSources:
+		return GetAudioSourcesResponse()
+	case MediaGetAudioSourceConfiguration:
+		return GetAudioSourceConfigurationResponse()
+	case MediaGetAudioSourceConfigurations:
+		return GetAudioSourceConfigurationsResponse()
+	case MediaGetAudioEncoderConfiguration:
+		return GetAudioEncoderConfigurationResponse()
+	case MediaGetAudioEncoderConfigurations:
+		return GetAudioEncoderConfigurationsResponse()
+	case ImagingGetImagingSettings:
+		return GetImagingSettingsResponse()
+	case ImagingGetOptions:
+		return GetImagingOptionsResponse()
+	case ImagingGetMoveOptions:
+		return GetImagingMoveOptionsResponse()
+	case ImagingGetStatus:
+		return GetImagingStatusResponse()
 	}
 
 	e := NewEnvelope()
@@ -281,10 +445,6 @@ var responses = map[string]string{
 	<tds:Scopes><tt:ScopeDef>Fixed</tt:ScopeDef><tt:ScopeItem>onvif://www.onvif.org/Profile/Streaming</tt:ScopeItem></tds:Scopes>
 	<tds:Scopes><tt:ScopeDef>Fixed</tt:ScopeDef><tt:ScopeItem>onvif://www.onvif.org/type/Network_Video_Transmitter</tt:ScopeItem></tds:Scopes>
 </tds:GetScopesResponse>`,
-
-	MediaGetAudioEncoderConfigurations: `<trt:GetAudioEncoderConfigurationsResponse />`,
-	MediaGetAudioSources:               `<trt:GetAudioSourcesResponse />`,
-	MediaGetAudioSourceConfigurations:  `<trt:GetAudioSourceConfigurationsResponse />`,
 
 	MediaGetVideoEncoderConfigurationOptions: `<trt:GetVideoEncoderConfigurationOptionsResponse>
    <trt:Options>

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -29,6 +29,7 @@ const (
 	PTZGetConfigurations = "GetConfigurations"
 	PTZGetNodes          = "GetNodes"
 	PTZGetStatus         = "GetStatus"
+	PTZAbsoluteMove      = "AbsoluteMove"
 	PTZContinuousMove    = "ContinuousMove"
 	PTZStop              = "Stop"
 )
@@ -425,6 +426,12 @@ func GetPTZNodesResponse() []byte {
 func GetPTZStatusResponse() []byte {
 	e := NewEnvelope()
 	e.Append(`<tptz:GetStatusResponse><tptz:PTZStatus><tt:Position><tt:PanTilt x="0" y="0" /></tt:Position><tt:MoveStatus><tt:PanTilt>IDLE</tt:PanTilt></tt:MoveStatus></tptz:PTZStatus></tptz:GetStatusResponse>`)
+	return e.Bytes()
+}
+
+func GetPTZAbsoluteMoveResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<tptz:AbsoluteMoveResponse />`)
 	return e.Bytes()
 }
 

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -389,6 +389,10 @@ func GetSnapshotUriResponse(uri string) []byte {
 	return e.Bytes()
 }
 
+func NotAuthorizedResponse() []byte {
+	return []byte(`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope"><s:Body><s:Fault><s:Code><s:Value>s:Sender</s:Value><s:Subcode><s:Value xmlns:ter="http://www.onvif.org/ver10/error">ter:NotAuthorized</s:Value></s:Subcode></s:Code><s:Reason><s:Text xml:lang="en">Sender not Authorized</s:Text></s:Reason></s:Fault></s:Body></s:Envelope>`)
+}
+
 func StaticResponse(operation string) []byte {
 	switch operation {
 	case DeviceGetSystemDateAndTime:

--- a/pkg/onvif/server.go
+++ b/pkg/onvif/server.go
@@ -26,6 +26,14 @@ const (
 )
 
 const (
+	PTZGetConfigurations = "GetConfigurations"
+	PTZGetNodes          = "GetNodes"
+	PTZGetStatus         = "GetStatus"
+	PTZContinuousMove    = "ContinuousMove"
+	PTZStop              = "Stop"
+)
+
+const (
 	MediaGetAudioEncoderConfiguration        = "GetAudioEncoderConfiguration"
 	MediaGetAudioEncoderConfigurations       = "GetAudioEncoderConfigurations"
 	MediaGetAudioSources                     = "GetAudioSources"
@@ -85,8 +93,11 @@ func GetCapabilitiesResponse(host string) []byte {
 		<tt:Imaging>
 			<tt:XAddr>http://%s/onvif/imaging_service</tt:XAddr>
 		</tt:Imaging>
+		<tt:PTZ>
+			<tt:XAddr>http://%s/onvif/ptz_service</tt:XAddr>
+		</tt:PTZ>
 	</tds:Capabilities>
-</tds:GetCapabilitiesResponse>`, host, host, host)
+</tds:GetCapabilitiesResponse>`, host, host, host, host)
 	return e.Bytes()
 }
 
@@ -108,7 +119,12 @@ func GetServicesResponse(host string) []byte {
 		<tds:XAddr>http://%s/onvif/imaging_service</tds:XAddr>
 		<tds:Version><tt:Major>2</tt:Major><tt:Minor>5</tt:Minor></tds:Version>
 	</tds:Service>
-</tds:GetServicesResponse>`, host, host, host)
+	<tds:Service>
+		<tds:Namespace>http://www.onvif.org/ver20/ptz/wsdl</tds:Namespace>
+		<tds:XAddr>http://%s/onvif/ptz_service</tds:XAddr>
+		<tds:Version><tt:Major>2</tt:Major><tt:Minor>5</tt:Minor></tds:Version>
+	</tds:Service>
+</tds:GetServicesResponse>`, host, host, host, host)
 	return e.Bytes()
 }
 
@@ -177,6 +193,7 @@ func appendProfile(e *Envelope, tag, name string) {
 	e.Appendf(`<tt:Name>%s</tt:Name>`, name)
 	appendVideoSourceConfiguration(e, "VideoSourceConfiguration", name)
 	appendVideoEncoderConfiguration(e, "VideoEncoderConfiguration")
+	appendPTZConfiguration(e)
 	appendAudioSourceConfiguration(e, "AudioSourceConfiguration")
 	appendAudioEncoderConfiguration(e, "AudioEncoderConfiguration")
 	e.Appendf(`</trt:%s>`, tag)
@@ -237,6 +254,10 @@ func GetVideoEncoderConfigurationResponse() []byte {
 	appendVideoEncoderConfiguration(e, "VideoEncoderConfiguration")
 	e.Append(`</trt:GetVideoEncoderConfigurationResponse>`)
 	return e.Bytes()
+}
+
+func appendPTZConfiguration(e *Envelope) {
+	e.Append(`<tt:PTZConfiguration token="ptz"><tt:Name>PTZ</tt:Name><tt:UseCount>1</tt:UseCount><tt:NodeToken>ptz</tt:NodeToken><tt:DefaultPTZTimeout>PT1S</tt:DefaultPTZTimeout></tt:PTZConfiguration>`)
 }
 
 func appendVideoEncoderConfiguration(e *Envelope, tag string) {
@@ -386,6 +407,36 @@ func GetStreamUriResponse(uri string) []byte {
 func GetSnapshotUriResponse(uri string) []byte {
 	e := NewEnvelope()
 	e.Appendf(`<trt:GetSnapshotUriResponse><trt:MediaUri><tt:Uri>%s</tt:Uri></trt:MediaUri></trt:GetSnapshotUriResponse>`, uri)
+	return e.Bytes()
+}
+
+func GetPTZConfigurationsResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<tptz:GetConfigurationsResponse><tptz:PTZConfiguration token="ptz"><tt:Name>PTZ</tt:Name><tt:UseCount>1</tt:UseCount><tt:NodeToken>ptz</tt:NodeToken><tt:DefaultPTZTimeout>PT1S</tt:DefaultPTZTimeout><tt:PanTiltLimits><tt:Range><tt:URI>http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace</tt:URI><tt:XRange><tt:Min>-1</tt:Min><tt:Max>1</tt:Max></tt:XRange><tt:YRange><tt:Min>-1</tt:Min><tt:Max>1</tt:Max></tt:YRange></tt:Range></tt:PanTiltLimits></tptz:PTZConfiguration></tptz:GetConfigurationsResponse>`)
+	return e.Bytes()
+}
+
+func GetPTZNodesResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<tptz:GetNodesResponse><tptz:PTZNode token="ptz" fixedHomePosition="false"><tt:Name>PTZ</tt:Name><tt:SupportedPTZSpaces><tt:ContinuousPanTiltVelocitySpace><tt:URI>http://www.onvif.org/ver10/tptz/PanTiltSpaces/VelocityGenericSpace</tt:URI><tt:XRange><tt:Min>-1</tt:Min><tt:Max>1</tt:Max></tt:XRange><tt:YRange><tt:Min>-1</tt:Min><tt:Max>1</tt:Max></tt:YRange></tt:ContinuousPanTiltVelocitySpace></tt:SupportedPTZSpaces></tptz:PTZNode></tptz:GetNodesResponse>`)
+	return e.Bytes()
+}
+
+func GetPTZStatusResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<tptz:GetStatusResponse><tptz:PTZStatus><tt:Position><tt:PanTilt x="0" y="0" /></tt:Position><tt:MoveStatus><tt:PanTilt>IDLE</tt:PanTilt></tt:MoveStatus></tptz:PTZStatus></tptz:GetStatusResponse>`)
+	return e.Bytes()
+}
+
+func GetPTZContinuousMoveResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<tptz:ContinuousMoveResponse />`)
+	return e.Bytes()
+}
+
+func GetPTZStopResponse() []byte {
+	e := NewEnvelope()
+	e.Append(`<tptz:StopResponse />`)
 	return e.Bytes()
 }
 

--- a/pkg/rtsp/conn.go
+++ b/pkg/rtsp/conn.go
@@ -54,15 +54,17 @@ type Conn struct {
 }
 
 const (
-	ProtoRTSP      = "RTSP/1.0"
-	MethodOptions  = "OPTIONS"
-	MethodSetup    = "SETUP"
-	MethodTeardown = "TEARDOWN"
-	MethodDescribe = "DESCRIBE"
-	MethodPlay     = "PLAY"
-	MethodPause    = "PAUSE"
-	MethodAnnounce = "ANNOUNCE"
-	MethodRecord   = "RECORD"
+	ProtoRTSP           = "RTSP/1.0"
+	MethodOptions       = "OPTIONS"
+	MethodSetup         = "SETUP"
+	MethodTeardown      = "TEARDOWN"
+	MethodDescribe      = "DESCRIBE"
+	MethodPlay          = "PLAY"
+	MethodPause         = "PAUSE"
+	MethodAnnounce      = "ANNOUNCE"
+	MethodRecord        = "RECORD"
+	MethodGetParameter  = "GET_PARAMETER"
+	MethodSetParameter  = "SET_PARAMETER"
 )
 
 type State byte
@@ -219,8 +221,29 @@ func (c *Conn) handleTCPData() error {
 				return err
 			}
 			c.Fire(req)
-			if req.Method == MethodOptions {
+			// Reply to in-stream RTSP requests that may arrive after PLAY.
+			// OPTIONS, GET_PARAMETER, SET_PARAMETER are commonly used as
+			// keepalives (UniFi Protect uses SET_PARAMETER every ~30s);
+			// TEARDOWN must be ACKed and the connection closed; PAUSE is
+			// acknowledged but we don't actually halt media flow (clients
+			// almost always TEARDOWN+SETUP instead). Other methods get
+			// 455 Method Not Valid In This State per RFC 2326 §11.4.
+			switch req.Method {
+			case MethodOptions, MethodGetParameter, MethodSetParameter, MethodPause:
 				res := &tcp.Response{Request: req}
+				if err = c.WriteResponse(res); err != nil {
+					return err
+				}
+			case MethodTeardown:
+				res := &tcp.Response{Request: req}
+				_ = c.WriteResponse(res)
+				c.state = StateNone
+				return c.conn.Close()
+			default:
+				res := &tcp.Response{
+					Status:  "455 Method Not Valid In This State",
+					Request: req,
+				}
 				if err = c.WriteResponse(res); err != nil {
 					return err
 				}

--- a/pkg/rtsp/server.go
+++ b/pkg/rtsp/server.go
@@ -70,10 +70,21 @@ func (c *Conn) Accept() error {
 		case MethodOptions:
 			res := &tcp.Response{
 				Header: map[string][]string{
-					"Public": {"OPTIONS, SETUP, TEARDOWN, DESCRIBE, PLAY, PAUSE, ANNOUNCE, RECORD"},
+					"Public": {"OPTIONS, SETUP, TEARDOWN, DESCRIBE, PLAY, PAUSE, ANNOUNCE, RECORD, GET_PARAMETER, SET_PARAMETER"},
 				},
 				Request: req,
 			}
+			if err = c.WriteResponse(res); err != nil {
+				return err
+			}
+
+		case MethodGetParameter, MethodSetParameter:
+			// RFC 2326 §10.8/§10.9 — commonly used by clients (UniFi Protect,
+			// Axis, others) as a keepalive. Without a 200 OK response the
+			// client treats the session as dead and tears down the TCP
+			// connection, which manifests as periodic "lost connection"
+			// errors and visible decode artefacts on reconnect.
+			res := &tcp.Response{Request: req}
 			if err = c.WriteResponse(res); err != nil {
 				return err
 			}
@@ -166,7 +177,12 @@ func (c *Conn) Accept() error {
 			// Test if client requests TCP transport, otherwise return 461 Transport not supported
 			// This allows smart clients who initially requested UDP to fall back on TCP transport
 			if tr := req.Header.Get("Transport"); strings.HasPrefix(tr, "RTP/AVP/TCP") {
-				c.session = core.RandString(8, 10)
+				// RFC 2326 §10.4 — the session ID is generated on the FIRST
+				// SETUP and must remain the same across subsequent SETUPs
+				// for additional media tracks in the same client session.
+				if c.session == "" {
+					c.session = core.RandString(8, 10)
+				}
 				c.state = StateSetup
 
 				if c.mode == core.ModePassiveConsumer {
@@ -213,8 +229,32 @@ func (c *Conn) Accept() error {
 			c.state = StateNone
 			return c.conn.Close()
 
+		case MethodPause:
+			// RFC 2326 §10.6 — PAUSE is RECOMMENDED. We don't actually
+			// pause the underlying media flow (clients almost always use
+			// TEARDOWN+SETUP instead), but acknowledging avoids dropping
+			// the connection on clients that probe PAUSE during adoption.
+			res := &tcp.Response{Request: req}
+			if err = c.WriteResponse(res); err != nil {
+				return err
+			}
+
 		default:
-			return fmt.Errorf("unsupported method: %s", req.Method)
+			// RFC 2326 §11.4 — respond 501 Not Implemented for unrecognised
+			// methods rather than closing the TCP connection. Per §1.4 the
+			// RTSP control connection is persistent; closing it on every
+			// unknown method (vendor extensions, PAUSE, REDIRECT, etc.)
+			// triggers reconnect loops in spec-strict clients.
+			res := &tcp.Response{
+				Status: "501 Not Implemented",
+				Header: map[string][]string{
+					"Allow": {"OPTIONS, SETUP, TEARDOWN, DESCRIBE, PLAY, PAUSE, ANNOUNCE, RECORD, GET_PARAMETER, SET_PARAMETER"},
+				},
+				Request: req,
+			}
+			if err = c.WriteResponse(res); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/pkg/tapo/client.go
+++ b/pkg/tapo/client.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -179,6 +180,26 @@ func (c *Client) SetupStream() (err error) {
 	// audio: default, disable, enable
 	c.session1, err = c.Request(c.conn1, []byte(c.request))
 	return
+}
+
+func (c *Client) Move(pan, tilt float64) error {
+	if pan == 0 && tilt == 0 {
+		return nil
+	}
+
+	conn, err := c.newConn()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	direction := int(90 - 180*math.Atan2(tilt, pan)/math.Pi)
+	if direction < 0 {
+		direction += 360
+	}
+
+	_, err = c.Request(conn, []byte(fmt.Sprintf(`{"method":"do","motor":{"movestep":{"direction":"%03d"}}}`, direction)))
+	return err
 }
 
 // Handle - first run will be in probe state

--- a/pkg/tapo/client.go
+++ b/pkg/tapo/client.go
@@ -187,19 +187,20 @@ func (c *Client) Move(pan, tilt float64) error {
 		return nil
 	}
 
-	conn, err := c.newConn()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	direction := int(90 - 180*math.Atan2(tilt, pan)/math.Pi)
 	if direction < 0 {
 		direction += 360
 	}
 
-	_, err = c.Request(conn, []byte(fmt.Sprintf(`{"method":"do","motor":{"movestep":{"direction":"%03d"}}}`, direction)))
-	return err
+	host := c.url.Hostname()
+	username := c.url.User.Username()
+	password, _ := c.url.User.Password()
+	if c.url.Scheme == "tapo" && password == "" {
+		password = username
+		username = "admin"
+	}
+
+	return newControlClient(host, username, password).Move(direction)
 }
 
 // Handle - first run will be in probe state

--- a/pkg/tapo/control.go
+++ b/pkg/tapo/control.go
@@ -1,0 +1,181 @@
+package tapo
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AlexxIT/go2rtc/pkg/core"
+)
+
+type controlClient struct {
+	host     string
+	username string
+	password string
+	client   *http.Client
+}
+
+type controlLogin struct {
+	ErrorCode int `json:"error_code"`
+	Result    struct {
+		Stok     string `json:"stok"`
+		StartSeq int    `json:"start_seq"`
+		Data     struct {
+			Nonce         string `json:"nonce"`
+			DeviceConfirm string `json:"device_confirm"`
+		} `json:"data"`
+	} `json:"result"`
+}
+
+func newControlClient(host, username, password string) *controlClient {
+	return &controlClient{
+		host:     host,
+		username: username,
+		password: password,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		},
+	}
+}
+
+func (c *controlClient) Move(direction int) error {
+	stok, seq, key, iv, hash, cnonce, err := c.login()
+	if err != nil {
+		return err
+	}
+
+	request := []byte(fmt.Sprintf(`{"method":"multipleRequest","params":{"requests":[{"method":"relativeMove","params":{"motor":{"movestep":{"direction":"%03d"}}}}]}}`, direction))
+	return c.request(stok, seq, key, iv, hash, cnonce, request)
+}
+
+func (c *controlClient) login() (string, int, []byte, []byte, string, string, error) {
+	cnonce := strings.ToUpper(core.RandString(16, 16))
+
+	initial := fmt.Sprintf(`{"method":"login","params":{"cnonce":"%s","encrypt_type":"3","username":"%s"}}`, cnonce, c.username)
+	var first controlLogin
+	if err := c.post("/", initial, nil, &first); err != nil {
+		return "", 0, nil, nil, "", "", err
+	}
+	if first.Result.Data.Nonce == "" || first.Result.Data.DeviceConfirm == "" {
+		return "", 0, nil, nil, "", "", errors.New("tapo: control authentication challenge rejected")
+	}
+
+	passwordHash := sha256Hex(c.password)
+	keyHash := sha256Hex(cnonce + passwordHash + first.Result.Data.Nonce)
+	if first.Result.Data.DeviceConfirm != keyHash+first.Result.Data.Nonce+cnonce {
+		passwordHash = md5Hex(c.password)
+		keyHash = sha256Hex(cnonce + passwordHash + first.Result.Data.Nonce)
+		if first.Result.Data.DeviceConfirm != keyHash+first.Result.Data.Nonce+cnonce {
+			return "", 0, nil, nil, "", "", errors.New("tapo: control authentication failed")
+		}
+	}
+
+	digest := sha256Hex(passwordHash + cnonce + first.Result.Data.Nonce)
+	login := fmt.Sprintf(`{"method":"login","params":{"cnonce":"%s","digest_passwd":"%s%s%s","encrypt_type":"3","username":"%s"}}`, cnonce, digest, cnonce, first.Result.Data.Nonce, c.username)
+	var second controlLogin
+	if err := c.post("/", login, nil, &second); err != nil {
+		return "", 0, nil, nil, "", "", err
+	}
+	if second.ErrorCode != 0 || second.Result.Stok == "" {
+		return "", 0, nil, nil, "", "", errors.New("tapo: control login failed")
+	}
+
+	key := sha256Bytes("lsk" + cnonce + first.Result.Data.Nonce + keyHash)
+	iv := sha256Bytes("ivb" + cnonce + first.Result.Data.Nonce + keyHash)
+	return second.Result.Stok, second.Result.StartSeq, key[:aes.BlockSize], iv[:aes.BlockSize], passwordHash, cnonce, nil
+}
+
+func (c *controlClient) request(stok string, seq int, key, iv []byte, passwordHash, cnonce string, request []byte) error {
+	payload, err := encrypt(request, key, iv)
+	if err != nil {
+		return err
+	}
+	body := fmt.Sprintf(`{"method":"securePassthrough","params":{"request":"%s"}}`, base64.StdEncoding.EncodeToString(payload))
+	tag := sha256Hex(sha256Hex(passwordHash+cnonce) + body + fmt.Sprint(seq))
+
+	var response struct {
+		ErrorCode int `json:"error_code"`
+		Result    struct {
+			Response string `json:"response"`
+		} `json:"result"`
+	}
+	if err = c.post("/stok="+stok+"/ds", body, map[string]string{"Seq": fmt.Sprint(seq), "Tapo_tag": tag}, &response); err != nil {
+		return err
+	}
+	if response.ErrorCode != 0 {
+		return fmt.Errorf("tapo: control request failed: %d", response.ErrorCode)
+	}
+	if response.Result.Response == "" {
+		return errors.New("tapo: control response missing")
+	}
+	return nil
+}
+
+func (c *controlClient) post(path, body string, headers map[string]string, value any) error {
+	req, err := http.NewRequest(http.MethodPost, "https://"+c.host+path, strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Set("requestByApp", "true")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusUnauthorized {
+		return fmt.Errorf("tapo: control request: %s", res.Status)
+	}
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	if err = json.NewDecoder(bytes.NewReader(b)).Decode(value); err != nil {
+		return err
+	}
+	return nil
+}
+
+func encrypt(plaintext, key, iv []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
+	plaintext = append(plaintext, bytes.Repeat([]byte{byte(padding)}, padding)...)
+	ciphertext := make([]byte, len(plaintext))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, plaintext)
+	return ciphertext, nil
+}
+
+func sha256Bytes(value string) []byte {
+	sum := sha256.Sum256([]byte(value))
+	return sum[:]
+}
+
+func sha256Hex(value string) string {
+	return strings.ToUpper(hex.EncodeToString(sha256Bytes(value)))
+}
+
+func md5Hex(value string) string {
+	sum := md5.Sum([]byte(value))
+	return strings.ToUpper(hex.EncodeToString(sum[:]))
+}

--- a/pkg/tapo/control_test.go
+++ b/pkg/tapo/control_test.go
@@ -1,0 +1,24 @@
+package tapo
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncrypt(t *testing.T) {
+	key, err := hex.DecodeString("2b7e151628aed2a6abf7158809cf4f3c")
+	require.NoError(t, err)
+	iv, err := hex.DecodeString("000102030405060708090a0b0c0d0e0f")
+	require.NoError(t, err)
+
+	ciphertext, err := encrypt([]byte("hello"), key, iv)
+	require.NoError(t, err)
+	require.Equal(t, "d8666ea8aad65cc08354b4bc43d4ff56", hex.EncodeToString(ciphertext))
+}
+
+func TestControlHashes(t *testing.T) {
+	require.Equal(t, "2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824", sha256Hex("hello"))
+	require.Equal(t, "5D41402ABC4B2A76B9719D911017C592", md5Hex("hello"))
+}

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -122,42 +122,10 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 			}()
 		}
 
-		// For ActiveProducer sources (e.g. Nest, where go2rtc dials out to
-		// a cloud SFU), set a read deadline on the VIDEO track so a silent
-		// upstream — SFU drops media but keeps the WebRTC peer connection
-		// technically open — is detected and surfaces as a connection
-		// error. Without this, pion's TrackRemote.Read() blocks indefinitely
-		// on silence and the producer never restarts.
-		//
-		// Audio tracks are deliberately exempt: WebRTC Opus encoders
-		// commonly use DTX (discontinuous transmission), so legitimate
-		// silence in the room produces no audio packets at all. Applying a
-		// deadline to audio tracks would tear down the peer connection
-		// every time the scene went acoustically quiet, killing the video
-		// stream that was working fine.
-		//
-		// Skipped entirely for PassiveProducer (browser → go2rtc) because
-		// inbound silence (user mute, paused webcam) is also common there.
-		//
-		// 20s gives enough margin for PLI/IDR roundtrips (PLI ticker is
-		// 10s) while still catching terminal silences within ~25s
-		// end-to-end recovery.
-		useReadDeadline := c.Mode == core.ModeActiveProducer &&
-			remote.Kind() == webrtc.RTPCodecTypeVideo
-		const readDeadline = 20 * time.Second
-
 		for {
 			b := make([]byte, ReceiveMTU)
-			if useReadDeadline {
-				_ = remote.SetReadDeadline(time.Now().Add(readDeadline))
-			}
 			n, _, err := remote.Read(b)
 			if err != nil {
-				if useReadDeadline {
-					// Tear down the peer connection so OnConnectionStateChange
-					// fires and the producer enters its reconnect path.
-					_ = pc.Close()
-				}
 				return
 			}
 

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -122,10 +122,31 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 			}()
 		}
 
+		// For ActiveProducer sources (e.g. Nest, where go2rtc dials out to
+		// a cloud SFU), set a read deadline so a silent upstream — SFU
+		// drops media but keeps the WebRTC peer connection technically open
+		// — is detected and surfaces as a connection error. Without this,
+		// pion's TrackRemote.Read() blocks indefinitely on silence and the
+		// producer never restarts, producing minutes-long recording gaps.
+		//
+		// Skipped for PassiveProducer (browser → go2rtc) because legitimate
+		// silence (user mute, paused webcam) is common and shouldn't force
+		// a disconnect.
+		useReadDeadline := c.Mode == core.ModeActiveProducer
+		const readDeadline = 10 * time.Second
+
 		for {
 			b := make([]byte, ReceiveMTU)
+			if useReadDeadline {
+				_ = remote.SetReadDeadline(time.Now().Add(readDeadline))
+			}
 			n, _, err := remote.Read(b)
 			if err != nil {
+				if useReadDeadline {
+					// Tear down the peer connection so OnConnectionStateChange
+					// fires and the producer enters its reconnect path.
+					_ = pc.Close()
+				}
 				return
 			}
 

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -123,17 +123,28 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 		}
 
 		// For ActiveProducer sources (e.g. Nest, where go2rtc dials out to
-		// a cloud SFU), set a read deadline so a silent upstream — SFU
-		// drops media but keeps the WebRTC peer connection technically open
-		// — is detected and surfaces as a connection error. Without this,
-		// pion's TrackRemote.Read() blocks indefinitely on silence and the
-		// producer never restarts, producing minutes-long recording gaps.
+		// a cloud SFU), set a read deadline on the VIDEO track so a silent
+		// upstream — SFU drops media but keeps the WebRTC peer connection
+		// technically open — is detected and surfaces as a connection
+		// error. Without this, pion's TrackRemote.Read() blocks indefinitely
+		// on silence and the producer never restarts.
 		//
-		// Skipped for PassiveProducer (browser → go2rtc) because legitimate
-		// silence (user mute, paused webcam) is common and shouldn't force
-		// a disconnect.
-		useReadDeadline := c.Mode == core.ModeActiveProducer
-		const readDeadline = 10 * time.Second
+		// Audio tracks are deliberately exempt: WebRTC Opus encoders
+		// commonly use DTX (discontinuous transmission), so legitimate
+		// silence in the room produces no audio packets at all. Applying a
+		// deadline to audio tracks would tear down the peer connection
+		// every time the scene went acoustically quiet, killing the video
+		// stream that was working fine.
+		//
+		// Skipped entirely for PassiveProducer (browser → go2rtc) because
+		// inbound silence (user mute, paused webcam) is also common there.
+		//
+		// 20s gives enough margin for PLI/IDR roundtrips (PLI ticker is
+		// 10s) while still catching terminal silences within ~25s
+		// end-to-end recovery.
+		useReadDeadline := c.Mode == core.ModeActiveProducer &&
+			remote.Kind() == webrtc.RTPCodecTypeVideo
+		const readDeadline = 20 * time.Second
 
 		for {
 			b := make([]byte, ReceiveMTU)

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -87,10 +87,34 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 			}
 		}
 
-		if c.Mode == core.ModePassiveProducer && remote.Kind() == webrtc.RTPCodecTypeVideo {
+		// Send PLI (Picture Loss Indication) to request keyframes from the
+		// upstream WebRTC source. WebRTC SDP doesn't usually include
+		// sprop-parameter-sets, so downstream RTSP consumers can't decode
+		// anything until an IDR (carrying SPS/PPS inline) arrives. Without
+		// PLI requests, the upstream cadence is on the sender's schedule —
+		// typically 30-60s for live streams — which means new consumers see
+		// extended pixelation after a connection or restart.
+		//
+		// PassiveProducer (e.g. a browser broadcasting in): 2s — low cost,
+		// keeps tune-in latency tight for viewers.
+		// ActiveProducer (e.g. Nest, where go2rtc dials out to a cloud SFU):
+		// 10s — slower because keyframes cost WiFi airtime on the camera and
+		// upstream bandwidth on the SFU. Still fast enough that any consumer
+		// recovers from a restart within ~10s.
+		if remote.Kind() == webrtc.RTPCodecTypeVideo &&
+			(c.Mode == core.ModePassiveProducer || c.Mode == core.ModeActiveProducer) {
+			interval := time.Second * 2
+			if c.Mode == core.ModeActiveProducer {
+				interval = time.Second * 10
+			}
 			go func() {
 				pkts := []rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(remote.SSRC())}}
-				for range time.NewTicker(time.Second * 2).C {
+				// Immediate PLI so cold-start tune-in doesn't have to wait
+				// for the first ticker fire.
+				if err := pc.WriteRTCP(pkts); err != nil {
+					return
+				}
+				for range time.NewTicker(interval).C {
 					if err := pc.WriteRTCP(pkts); err != nil {
 						return
 					}


### PR DESCRIPTION
Reworked Tapo PTZ to authenticate against its HTTPS control API and send an encrypted `relativeMove` request, replacing the invalid streaming-protocol request.

Added encryption/hash tests. Focused tests and CGO-free build pass. Changes are local on `onvif-camera-controls`; build and deploy this revision to test it against the camera.