### PR TITLE
webrtc: read RTCP feedback to enable NACK retransmissions

### DIFF
--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/AlexxIT/go2rtc/pkg/core"
@@ -20,8 +21,9 @@ type Conn struct {
 
 	pc *webrtc.PeerConnection
 
-	offer  string
-	closed core.Waiter
+	offer    string
+	closed   core.Waiter
+	rtcpOnce sync.Once
 }
 
 func NewConn(pc *webrtc.PeerConnection) *Conn {
@@ -134,6 +136,21 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 
 		switch state {
 		case webrtc.PeerConnectionStateConnected:
+			// Pion's NACK responder runs while RTCP is read. Without this,
+			// receivers request missing RTP packets but never receive repairs.
+			// Start only once; an ICE transition must not add competing readers.
+			c.rtcpOnce.Do(func() {
+				for _, sender := range pc.GetSenders() {
+					go func(sender *webrtc.RTPSender) {
+						buf := make([]byte, 1500)
+						for {
+							if _, _, err := sender.Read(buf); err != nil {
+								return
+							}
+						}
+					}(sender)
+				}
+			})
 			for _, sender := range c.Senders {
 				sender.Start()
 			}

--- a/pkg/webrtc/nack_test.go
+++ b/pkg/webrtc/nack_test.go
@@ -1,0 +1,95 @@
+package webrtc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+	pion "github.com/pion/webrtc/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise the actual connection lifecycle and Pion NACK responder over local ICE.
+// The test receiver accepts a duplicate only so we can verify a requested repair
+// without relying on random packet loss. Production replay protection is unchanged.
+func TestConnectionRetransmitsNack(t *testing.T) {
+	api, err := NewServerAPI("", "", &Filters{Loopback: true, Networks: []string{"udp4"}})
+	require.NoError(t, err)
+	pc, err := api.NewPeerConnection(pion.Configuration{})
+	require.NoError(t, err)
+	conn := NewConn(pc)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	settings := pion.SettingEngine{}
+	settings.SetIncludeLoopbackCandidate(true)
+	settings.SetNetworkTypes([]pion.NetworkType{pion.NetworkTypeUDP4})
+	settings.DisableSRTPReplayProtection(true)
+	remoteAPI := pion.NewAPI(pion.WithSettingEngine(settings))
+	remote, err := remoteAPI.NewPeerConnection(pion.Configuration{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = remote.Close() })
+
+	packets := make(chan *rtp.Packet, 8)
+	remote.OnTrack(func(track *pion.TrackRemote, _ *pion.RTPReceiver) {
+		for {
+			packet, _, readErr := track.ReadRTP()
+			if readErr != nil {
+				return
+			}
+			select {
+			case packets <- packet:
+			default:
+			}
+		}
+	})
+	track := NewTrack("video")
+	_, err = pc.AddTrack(track)
+	require.NoError(t, err)
+	_, err = pc.CreateDataChannel("test", nil)
+	require.NoError(t, err)
+
+	offer, err := pc.CreateOffer(nil)
+	require.NoError(t, err)
+	gathered := pion.GatheringCompletePromise(pc)
+	require.NoError(t, pc.SetLocalDescription(offer))
+	select {
+	case <-gathered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("offer ICE timeout")
+	}
+	require.NoError(t, remote.SetRemoteDescription(*pc.LocalDescription()))
+	answer, err := remote.CreateAnswer(nil)
+	require.NoError(t, err)
+	gathered = pion.GatheringCompletePromise(remote)
+	require.NoError(t, remote.SetLocalDescription(answer))
+	select {
+	case <-gathered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("answer ICE timeout")
+	}
+	require.NoError(t, pc.SetRemoteDescription(*remote.LocalDescription()))
+	require.Eventually(t, func() bool { return pc.ConnectionState() == pion.PeerConnectionStateConnected }, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, track.WriteRTP(96, &rtp.Packet{
+		Header: rtp.Header{Version: 2, Marker: true, Timestamp: 90000}, Payload: []byte{0x65, 0x88, 0x84},
+	}))
+	var original *rtp.Packet
+	select {
+	case original = <-packets:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial RTP missing")
+	}
+	require.NoError(t, remote.WriteRTCP([]rtcp.Packet{&rtcp.TransportLayerNack{
+		SenderSSRC: 1, MediaSSRC: original.SSRC,
+		Nacks: []rtcp.NackPair{{PacketID: original.SequenceNumber}},
+	}}))
+	select {
+	case repaired := <-packets:
+		require.Equal(t, original.SequenceNumber, repaired.SequenceNumber)
+		require.Equal(t, original.Timestamp, repaired.Timestamp)
+		require.Equal(t, original.Payload, repaired.Payload)
+	case <-time.After(2 * time.Second):
+		t.Fatal("go2rtc did not retransmit the packet requested by NACK")
+	}
+}


### PR DESCRIPTION
When a WebRTC receiver loses an RTP packet, go2rtc advertises NACK feedback but does not read incoming RTCP from its `RTPSender`s. Pion's NACK responder processes that feedback through the RTCP reader, so the requested packet is never retransmitted. With H.264 this can leave playback frozen until the next keyframe.

Read RTCP from each sender when the peer connects. `sync.Once` prevents competing readers on repeated connection events, and the reader exits when the sender closes. This uses the existing Pion interceptors without changing codec, bitrate, playback buffering, or retransmission cache settings. Pion documents the required read in its [reflect example](https://github.com/pion/webrtc/blob/v4.2.3/examples/reflect/main.go).

The regression test establishes two local WebRTC peers, sends an RTP packet, explicitly requests it with NACK, and checks the retransmitted sequence number, timestamp, and payload. Only the test receiver accepts duplicate SRTP packets to make this deterministic; production replay protection is unchanged.

Validation on Windows amd64 with Go 1.27.1:

- On current master (`c245815e75e2a5fd60b4290f12bfc04e55a984d3`), the new test fails with `go2rtc did not retransmit the packet requested by NACK`.
- With this change, `go test ./pkg/webrtc -count=1 -v` passes all four tests, including the regression test.
- `go build -trimpath .` succeeds.
- A local Android H.264/WHEP → go2rtc → Firefox 155 test at 1920×1080 and about 30 FPS previously showed freezes after packet loss. After applying the fix, playback was confirmed smooth while NACK requests continued, with the same resolution and bitrate limit.

This addresses NACK retransmission on the WebRTC output; forwarding PLI/FIR to upstream producers is outside this change.
