### PR TITLE
Fix CS2 command channel buffer overflow causing stream disconnects

### DIFF
--- a/pkg/xiaomi/miss/client.go
+++ b/pkg/xiaomi/miss/client.go
@@ -72,7 +72,19 @@ func NewClient(rawURL string) (*Client, error) {
 		return nil, err
 	}
 
-	return &Client{Conn: conn, key: key, model: model}, nil
+	client := &Client{Conn: conn, key: key, model: model}
+	client.startCommandLoop()
+	return client, nil
+}
+
+func (c *Client) startCommandLoop() {
+	go func() {
+		for {
+			if _, _, err := c.Conn.ReadCommand(); err != nil {
+				return
+			}
+		}
+	}()
 }
 
 type Client struct {


### PR DESCRIPTION
### Problem
In Xiaomi cameras communicating over CS2 P2P protocol (e.g. Mi 360° 2K, CW501D, CW700S, C301, C700, etc.), cameras continuously transmit control/heartbeat messages on channel 0 during active streaming.

Because `ReadCommand()` was only called once during initial `login()`, no goroutine ever consumed incoming packets from channel 0. The internal channel pop buffer has a capacity of 10 (`newDataChannel(0, 10)`). Once 10 command packets accumulate (typically within ~60–120s of streaming), `c.channels[0].Push()` returns `fmt.Errorf("pop buffer is full")`. This causes `c.worker()` to fail and close the connection, resulting in periodic stream freezes and disconnects.

### Solution
Launch a lightweight background goroutine (`startCommandLoop`) upon `Client` instantiation to continuously drain `c.Conn.ReadCommand()`. When the connection is closed or torn down, `ReadCommand()` returns an error and the goroutine exits cleanly without resource leaks.

Fixes #2057
Fixes #2234
Fixes #2470
Fixes #2472